### PR TITLE
fix(doc): use the proper TreeNodeDraft type for Kotlin `childNodes()` function

### DIFF
--- a/doc/docs/jimmer-core/draft.mdx
+++ b/doc/docs/jimmer-core/draft.mdx
@@ -693,7 +693,7 @@ public interface TreeNodeDraft : TreeNode, Draft {
 
     override var childNodes: List<TreeNode>
     
-    fun childNodes(): MutableList<TreeNode>
+    fun childNodes(): MutableList<TreeNodeDraft>
 
     ...omit other code...
 }


### PR DESCRIPTION
I think there is a little mistake in the Kotlin example in the documentation.

As I'm discovering everything 30min ago, I might be wrong but this seems consistent with what I understood (and with the related Java version example) :)