### PR TITLE
fix: incompatibility with Spring Native

### DIFF
--- a/project/jimmer-spring-boot-starter/build.gradle.kts
+++ b/project/jimmer-spring-boot-starter/build.gradle.kts
@@ -47,6 +47,14 @@ tasks.getByName<Test>("test") {
     useJUnitPlatform()
 }
 
+tasks.withType<JavaCompile> {
+    /*
+     * it must be compiled with parameters
+     * when using @ConstructorBinding in Spring Native Image
+     */
+    options.compilerArgs.add("-parameters")
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")


### PR DESCRIPTION
当 spring-boot 项目引用 `org.graalvm.buildtools.native` Gradle 插件时（即使用 Spring Native 时），在 aot 编译时报错：
```
Exception in thread "main" org.springframework.boot.context.properties.bind.MissingParametersCompilerArgumentException: Constructor binding in a native image requires compilation with -parameters but the following classes were compiled without it:
 org.babyfish.jimmer.spring.cfg.JimmerProperties
 org.babyfish.jimmer.spring.cfg.JimmerProperties$Client$TypeScript
 org.babyfish.jimmer.spring.cfg.JimmerProperties$Client
 org.babyfish.jimmer.spring.cfg.JimmerProperties$Client$JavaFeign
```
所以我在 `jimmer-spring-boot-starter` 的构建文件中为 `javac` 添加了 `-parameters` 编译参数，经我个人测试可以运行。