### PR TITLE
fix writeArrayTypeRef

### DIFF
--- a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/meta/impl/Context.java
+++ b/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/meta/impl/Context.java
@@ -214,7 +214,8 @@ class Context {
                 return enumType;
             }
             if (javaClass.isArray()) {
-                Class<?> componentClass = objectType(javaClass.getComponentType(), null).getJavaType();
+                final StaticObjectType componentType = objectType(javaClass.getComponentType(), null);
+                Class<?> componentClass = componentType.getJavaType();
 
                 if (componentClass.isArray()) {
                     throw new IllegalDocMetaException(
@@ -226,7 +227,13 @@ class Context {
                     );
                 }
 
-                return new ArrayTypeImpl(SimpleTypeImpl.get(componentClass));
+                final SimpleType simpleType = SimpleTypeImpl.get(componentClass);
+
+                if (simpleType != null) {
+                    return new ArrayTypeImpl(simpleType);
+                }
+
+                return new ArrayTypeImpl(componentType);
             }
             SimpleType simpleType = SimpleTypeImpl.get(javaClass);
             if (simpleType != null) {

--- a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/meta/impl/Context.java
+++ b/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/meta/impl/Context.java
@@ -1,12 +1,15 @@
 package org.babyfish.jimmer.client.meta.impl;
 
 import kotlin.jvm.JvmClassMappingKt;
-import kotlin.reflect.*;
+import kotlin.reflect.KClass;
+import kotlin.reflect.KType;
+import kotlin.reflect.KTypeParameter;
+import kotlin.reflect.KTypeProjection;
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError;
 import org.babyfish.jimmer.client.FetchBy;
 import org.babyfish.jimmer.client.IllegalDocMetaException;
-import org.babyfish.jimmer.client.meta.*;
 import org.babyfish.jimmer.client.meta.Type;
+import org.babyfish.jimmer.client.meta.*;
 import org.babyfish.jimmer.error.ErrorFamily;
 import org.babyfish.jimmer.error.ErrorField;
 import org.babyfish.jimmer.error.ErrorFields;
@@ -99,7 +102,7 @@ class Context {
         this.rawImmutableObjectTypeMap = base.rawImmutableObjectTypeMap;
         this.viewImmutableObjectTypeMap = base.viewImmutableObjectTypeMap;
         this.fetcherMap = base.fetcherMap;
-        TypeVariable<?>[] typeVariables = ((Class<?>)((ParameterizedType)parameterizedType.getType()).getRawType()).getTypeParameters();
+        TypeVariable<?>[] typeVariables = ((Class<?>) ((ParameterizedType) parameterizedType.getType()).getRawType()).getTypeParameters();
         AnnotatedType[] actualTypes = parameterizedType.getAnnotatedActualTypeArguments();
         Map<UnifiedTypeParameter, Object> map = new HashMap<>();
         for (int i = typeVariables.length - 1; i >= 0; --i) {
@@ -125,7 +128,7 @@ class Context {
         this.rawImmutableObjectTypeMap = base.rawImmutableObjectTypeMap;
         this.viewImmutableObjectTypeMap = base.viewImmutableObjectTypeMap;
         this.fetcherMap = base.fetcherMap;
-        List<KTypeParameter> typeParameters = ((KClass<?>)parameterizedType.getClassifier()).getTypeParameters();
+        List<KTypeParameter> typeParameters = ((KClass<?>) parameterizedType.getClassifier()).getTypeParameters();
         List<KTypeProjection> projections = parameterizedType.getArguments();
         Map<UnifiedTypeParameter, Object> map = new HashMap<>();
         for (int i = typeParameters.size() - 1; i >= 0; --i) {
@@ -211,8 +214,19 @@ class Context {
                 return enumType;
             }
             if (javaClass.isArray()) {
-                Type componentType = objectType(javaClass.getComponentType(), null);
-                return new ArrayTypeImpl(componentType);
+                Class<?> componentClass = objectType(javaClass.getComponentType(), null).getJavaType();
+
+                if (componentClass.isArray()) {
+                    throw new IllegalDocMetaException(
+                            "Illegal type \"" +
+                                    annotatedType +
+                                    "\" declared in " +
+                                    location +
+                                    ", multi-dimensional array is not supported"
+                    );
+                }
+
+                return new ArrayTypeImpl(SimpleTypeImpl.get(componentClass));
             }
             SimpleType simpleType = SimpleTypeImpl.get(javaClass);
             if (simpleType != null) {
@@ -240,14 +254,14 @@ class Context {
             return objectType(javaClass, null);
         }
         if (annotatedType instanceof AnnotatedWildcardType) {
-            return parseType(((AnnotatedWildcardType)annotatedType).getAnnotatedUpperBounds()[0]);
+            return parseType(((AnnotatedWildcardType) annotatedType).getAnnotatedUpperBounds()[0]);
         }
         if (annotatedType instanceof AnnotatedArrayType) {
             return new ArrayTypeImpl(parseType(((AnnotatedArrayType) annotatedType).getAnnotatedGenericComponentType()));
         }
         if (annotatedType instanceof AnnotatedTypeVariable) {
             if (ignoreTypeVariableResolving) {
-                return new UnresolvedTypeVariableImpl(((TypeVariable<?>)annotatedType.getType()).getName());
+                return new UnresolvedTypeVariableImpl(((TypeVariable<?>) annotatedType.getType()).getName());
             }
             TypeVariable<?> typeVariable = (TypeVariable<?>) annotatedType.getType();
             Object resolvedType = resolve(new UnifiedTypeParameter(typeVariable));
@@ -780,9 +794,10 @@ class Context {
 
         public static Object wrap(Object o) {
             if (o instanceof AnnotatedTypeVariable) {
-                TypeVariable<?> typeVariable = (TypeVariable<?>)((AnnotatedTypeVariable)o).getType();
+                TypeVariable<?> typeVariable = (TypeVariable<?>) ((AnnotatedTypeVariable) o).getType();
                 return new UnifiedTypeParameter(typeVariable);
-            } if (o instanceof TypeVariable<?>) {
+            }
+            if (o instanceof TypeVariable<?>) {
                 return new UnifiedTypeParameter((TypeVariable<?>) o);
             } else if (o instanceof KTypeParameter) {
                 return new UnifiedTypeParameter((KTypeParameter) o);

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/service/ArrayService.java
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/service/ArrayService.java
@@ -1,0 +1,11 @@
+package org.babyfish.jimmer.client.java.service;
+
+import org.babyfish.jimmer.client.meta.common.GetMapping;
+import org.babyfish.jimmer.client.meta.common.RequestParam;
+
+import java.util.UUID;
+
+public interface ArrayService {
+    @GetMapping("/insert/ids")
+    void saveIds(@RequestParam UUID[] ids);
+}

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/ts/JTypeScriptTest.java
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/ts/JTypeScriptTest.java
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.client.java.ts;
 
 import org.babyfish.jimmer.client.generator.ts.*;
 import org.babyfish.jimmer.client.java.model.*;
+import org.babyfish.jimmer.client.java.service.ArrayService;
 import org.babyfish.jimmer.client.java.service.AuthorService;
 import org.babyfish.jimmer.client.java.service.BookService;
 import org.babyfish.jimmer.client.meta.*;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Collections;
 
 public class JTypeScriptTest {
 
@@ -23,18 +23,20 @@ public class JTypeScriptTest {
         TsContext ctx = createContext(out);
         new ModuleWriter(ctx).flush();
         String code = out.toString();
-        Assertions.assertEquals(
-                "import type { Executor } from './';\n" +
+        Assertions.assertEquals("import type { Executor } from './';\n" +
                         "\n" +
-                        "import { AuthorService, BookService } from './services';\n" +
+                        "import { ArrayService, AuthorService, BookService } from './services';\n" +
                         "\n" +
                         "export class Api {\n" +
+                        "    \n" +
+                        "    readonly arrayService: ArrayService;\n" +
                         "    \n" +
                         "    readonly authorService: AuthorService;\n" +
                         "    \n" +
                         "    readonly bookService: BookService;\n" +
                         "    \n" +
                         "    constructor(executor: Executor) {\n" +
+                        "        this.arrayService = new ArrayService(executor);\n" +
                         "        this.authorService = new AuthorService(executor);\n" +
                         "        this.bookService = new BookService(executor);\n" +
                         "    }\n" +
@@ -49,231 +51,230 @@ public class JTypeScriptTest {
         TsContext ctx = createContext(out);
         new ModuleErrorsWriter(ctx).flush();
         String code = out.toString();
-        Assertions.assertEquals(
-                "import type { ExportedSavePath } from './model/static';\n" +
-                        "\n" +
-                        "export type AllErrors = \n" +
-                        "    {\n" +
-                        "        readonly family: \"BusinessError\",\n" +
-                        "        readonly code: \"GLOBAL_TENANT_REQUIRED\"\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"BusinessError\",\n" +
-                        "        readonly code: \"ILLEGAL_PATH_NODES\",\n" +
-                        "        readonly \"pathNodes\": string\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"BusinessError\",\n" +
-                        "        readonly code: \"OUT_OF_RANGE\",\n" +
-                        "        readonly \"min\": number,\n" +
-                        "        readonly \"max\": number\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"CANNOT_CREATE_TARGET\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"CANNOT_DISSOCIATE_TARGETS\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"FAILED_REMOTE_VALIDATION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"ILLEGAL_GENERATED_ID\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"ILLEGAL_ID_GENERATOR\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"ILLEGAL_TARGET_ID\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"ILLEGAL_VERSION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"KEY_NOT_UNIQUE\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"LONG_REMOTE_ASSOCIATION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NEITHER_ID_NOR_KEY\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NO_ID_GENERATOR\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NO_KEY_PROPS\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NO_NON_ID_PROPS\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NO_VERSION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"NULL_TARGET\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"REVERSED_REMOTE_ASSOCIATION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    } | \n" +
-                        "    {\n" +
-                        "        readonly family: \"SaveErrorCode\",\n" +
-                        "        readonly code: \"UNSTRUCTURED_ASSOCIATION\",\n" +
-                        "        readonly \"exportedPath\": ExportedSavePath\n" +
-                        "    }\n" +
-                        ";\n" +
-                        "\n" +
-                        "export type ApiErrors = {\n" +
-                        "    \"authorService\": {\n" +
-                        "        \"findComplexAuthor\": AllErrors & (\n" +
-                        "            {\n" +
-                        "                readonly family: 'BusinessError',\n" +
-                        "                readonly code: 'OUT_OF_RANGE',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'BusinessError',\n" +
-                        "                readonly code: 'ILLEGAL_PATH_NODES',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            }\n" +
-                        "        ),\n" +
-                        "        \"findSimpleAuthor\": AllErrors & (\n" +
-                        "            {\n" +
-                        "                readonly family: 'BusinessError',\n" +
-                        "                readonly code: 'GLOBAL_TENANT_REQUIRED',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'BusinessError',\n" +
-                        "                readonly code: 'OUT_OF_RANGE',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            }\n" +
-                        "        )\n" +
-                        "    },\n" +
-                        "    \"bookService\": {\n" +
-                        "        \"saveBooks\": AllErrors & (\n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NULL_TARGET',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'ILLEGAL_TARGET_ID',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'CANNOT_DISSOCIATE_TARGETS',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'CANNOT_CREATE_TARGET',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NO_ID_GENERATOR',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'ILLEGAL_ID_GENERATOR',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'ILLEGAL_GENERATED_ID',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NO_KEY_PROPS',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NO_NON_ID_PROPS',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NO_VERSION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'ILLEGAL_VERSION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'KEY_NOT_UNIQUE',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'NEITHER_ID_NOR_KEY',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'REVERSED_REMOTE_ASSOCIATION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'LONG_REMOTE_ASSOCIATION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'FAILED_REMOTE_VALIDATION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            } | \n" +
-                        "            {\n" +
-                        "                readonly family: 'SaveErrorCode',\n" +
-                        "                readonly code: 'UNSTRUCTURED_ASSOCIATION',\n" +
-                        "                readonly [key:string]: any\n" +
-                        "            }\n" +
-                        "        )\n" +
-                        "    }\n" +
-                        "};\n",
-                code
-        );
+        Assertions.assertEquals("import type { ExportedSavePath } from './model/static';\n" +
+                "\n" +
+                "export type AllErrors = \n" +
+                "    {\n" +
+                "        readonly family: \"BusinessError\",\n" +
+                "        readonly code: \"GLOBAL_TENANT_REQUIRED\"\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"BusinessError\",\n" +
+                "        readonly code: \"ILLEGAL_PATH_NODES\",\n" +
+                "        readonly \"pathNodes\": string\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"BusinessError\",\n" +
+                "        readonly code: \"OUT_OF_RANGE\",\n" +
+                "        readonly \"min\": number,\n" +
+                "        readonly \"max\": number\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"CANNOT_CREATE_TARGET\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"CANNOT_DISSOCIATE_TARGETS\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"FAILED_REMOTE_VALIDATION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"ILLEGAL_GENERATED_ID\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"ILLEGAL_ID_GENERATOR\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"ILLEGAL_TARGET_ID\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"ILLEGAL_VERSION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"KEY_NOT_UNIQUE\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"LONG_REMOTE_ASSOCIATION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NEITHER_ID_NOR_KEY\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NO_ID_GENERATOR\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NO_KEY_PROPS\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NO_NON_ID_PROPS\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NO_VERSION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"NULL_TARGET\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"REVERSED_REMOTE_ASSOCIATION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    } | \n" +
+                "    {\n" +
+                "        readonly family: \"SaveErrorCode\",\n" +
+                "        readonly code: \"UNSTRUCTURED_ASSOCIATION\",\n" +
+                "        readonly \"exportedPath\": ExportedSavePath\n" +
+                "    }\n" +
+                ";\n" +
+                "\n" +
+                "export type ApiErrors = {\n" +
+                "    \"arrayService\": {\n" +
+                "    },\n" +
+                "    \"authorService\": {\n" +
+                "        \"findComplexAuthor\": AllErrors & (\n" +
+                "            {\n" +
+                "                readonly family: 'BusinessError',\n" +
+                "                readonly code: 'OUT_OF_RANGE',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'BusinessError',\n" +
+                "                readonly code: 'ILLEGAL_PATH_NODES',\n" +
+                "                readonly [key:string]: any\n" +
+                "            }\n" +
+                "        ),\n" +
+                "        \"findSimpleAuthor\": AllErrors & (\n" +
+                "            {\n" +
+                "                readonly family: 'BusinessError',\n" +
+                "                readonly code: 'GLOBAL_TENANT_REQUIRED',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'BusinessError',\n" +
+                "                readonly code: 'OUT_OF_RANGE',\n" +
+                "                readonly [key:string]: any\n" +
+                "            }\n" +
+                "        )\n" +
+                "    },\n" +
+                "    \"bookService\": {\n" +
+                "        \"saveBooks\": AllErrors & (\n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NULL_TARGET',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'ILLEGAL_TARGET_ID',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'CANNOT_DISSOCIATE_TARGETS',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'CANNOT_CREATE_TARGET',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NO_ID_GENERATOR',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'ILLEGAL_ID_GENERATOR',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'ILLEGAL_GENERATED_ID',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NO_KEY_PROPS',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NO_NON_ID_PROPS',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NO_VERSION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'ILLEGAL_VERSION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'KEY_NOT_UNIQUE',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'NEITHER_ID_NOR_KEY',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'REVERSED_REMOTE_ASSOCIATION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'LONG_REMOTE_ASSOCIATION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'FAILED_REMOTE_VALIDATION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            } | \n" +
+                "            {\n" +
+                "                readonly family: 'SaveErrorCode',\n" +
+                "                readonly code: 'UNSTRUCTURED_ASSOCIATION',\n" +
+                "                readonly [key:string]: any\n" +
+                "            }\n" +
+                "        )\n" +
+                "    }\n" +
+                "};\n", code);
     }
 
     @Test
@@ -1168,7 +1169,40 @@ public class JTypeScriptTest {
                 code
         );
     }
-    
+
+    @Test
+    public void testArray() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        TsContext ctx = createContext(out);
+        Service service = Constants.JAVA_METADATA.getServices().get(ArrayService.class);
+        new ServiceWriter(ctx, service).flush();
+        String code = out.toString();
+        Assertions.assertEquals("import type { Executor } from '../';\n" +
+                "\n" +
+                "export class ArrayService {\n" +
+                "    \n" +
+                "    constructor(private executor: Executor) {}\n" +
+                "    \n" +
+                "    async saveIds(options: ArrayServiceOptions['saveIds']): Promise<void> {\n" +
+                "        let _uri = '/insert/ids';\n" +
+                "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
+                "        let _value: any = undefined;\n" +
+                "        _value = options.arg0.join(',');\n" +
+                "        if (_value !== undefined && _value !== null) {\n" +
+                "            _uri += _separator\n" +
+                "            _uri += 'arg0='\n" +
+                "            _uri += encodeURIComponent(_value);\n" +
+                "            _separator = '&';\n" +
+                "        }\n" +
+                "        return (await this.executor({uri: _uri, method: 'GET'})) as void\n" +
+                "    }\n" +
+                "}\n" +
+                "\n" +
+                "export type ArrayServiceOptions = {\n" +
+                "    'saveIds': {readonly arg0: ReadonlyArray<string>}\n" +
+                "}", code);
+    }
+
     private static TsContext createContext(OutputStream out, boolean anonymous) {
         return new TsContext(Constants.JAVA_METADATA, out, "Api", 4, anonymous);
     }

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/kotlin/service/KArrayService.kt
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/kotlin/service/KArrayService.kt
@@ -1,0 +1,10 @@
+package org.babyfish.jimmer.client.kotlin.service
+
+import org.babyfish.jimmer.client.meta.common.GetMapping
+import org.babyfish.jimmer.client.meta.common.RequestParam
+import java.util.*
+
+interface KArrayService {
+    @GetMapping("/insert/ids")
+    fun saveIds(@RequestParam ids: Array<UUID>)
+}

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/kotlin/ts/KTypeScriptTest.kt
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/kotlin/ts/KTypeScriptTest.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.client.kotlin.ts
 
 import org.babyfish.jimmer.client.generator.ts.*
 import org.babyfish.jimmer.client.kotlin.model.*
+import org.babyfish.jimmer.client.kotlin.service.KArrayService
 import org.babyfish.jimmer.client.kotlin.service.KBookService
 import org.babyfish.jimmer.client.meta.Constants
 import org.babyfish.jimmer.client.meta.StaticObjectType
@@ -21,20 +22,23 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { Executor } from './';\n" +
-                "\n" +
-                "import { KBookService, KBookStoreService } from './services';\n" +
-                "\n" +
-                "export class Api {\n" +
-                "    \n" +
-                "    readonly kbookService: KBookService;\n" +
-                "    \n" +
-                "    readonly kbookStoreService: KBookStoreService;\n" +
-                "    \n" +
-                "    constructor(executor: Executor) {\n" +
-                "        this.kbookService = new KBookService(executor);\n" +
-                "        this.kbookStoreService = new KBookStoreService(executor);\n" +
-                "    }\n" +
-                "}",
+                    "\n" +
+                    "import { KArrayService, KBookService, KBookStoreService } from './services';\n" +
+                    "\n" +
+                    "export class Api {\n" +
+                    "    \n" +
+                    "    readonly karrayService: KArrayService;\n" +
+                    "    \n" +
+                    "    readonly kbookService: KBookService;\n" +
+                    "    \n" +
+                    "    readonly kbookStoreService: KBookStoreService;\n" +
+                    "    \n" +
+                    "    constructor(executor: Executor) {\n" +
+                    "        this.karrayService = new KArrayService(executor);\n" +
+                    "        this.kbookService = new KBookService(executor);\n" +
+                    "        this.kbookStoreService = new KBookStoreService(executor);\n" +
+                    "    }\n" +
+                    "}",
             code
         )
     }
@@ -48,152 +52,152 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { Dynamic, Executor } from '../';\n" +
-                "import type { KAuthorDto, KBookDto } from '../model/dto';\n" +
-                "import type { KBook } from '../model/entities';\n" +
-                "import type { KBookInput, KPage, Tuple2 } from '../model/static';\n" +
-                "\n" +
-                "/**\n" +
-                " * BookService interface\n" +
-                " */\n" +
-                "export class KBookService {\n" +
-                "    \n" +
-                "    constructor(private executor: Executor) {}\n" +
-                "    \n" +
-                "    async deleteBook(options: KBookServiceOptions['deleteBook']): Promise<number> {\n" +
-                "        let _uri = '/book/';\n" +
-                "        _uri += encodeURIComponent(options.id);\n" +
-                "        return (await this.executor({uri: _uri, method: 'DELETE'})) as number\n" +
-                "    }\n" +
-                "    \n" +
-                "    /**\n" +
-                "     * Find book list\n" +
-                "     * \n" +
-                "     * Format of each element:\n" +
-                "     * -   id\n" +
-                "     * -   name\n" +
-                "     * -   edition\n" +
-                "     * -   price\n" +
-                "     * -   store\n" +
-                "     *     -   id\n" +
-                "     *     -   name\n" +
-                "     * -   authors\n" +
-                "     *     -   id\n" +
-                "     *     -   firstName\n" +
-                "     */\n" +
-                "    async findComplexBooks(options: KBookServiceOptions['findComplexBooks']): Promise<\n" +
-                "        ReadonlyArray<KBookDto['KBookService/COMPLEX_FETCHER']>\n" +
-                "    > {\n" +
-                "        let _uri = '/books/complex';\n" +
-                "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
-                "        let _value: any = undefined;\n" +
-                "        _value = options.name;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'name='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.storeName;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'storeName='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.authorName;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'authorName='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.minPrice;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'minPrice='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.maxPrice;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'maxPrice='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        return (await this.executor({uri: _uri, method: 'GET'})) as ReadonlyArray<KBookDto['KBookService/COMPLEX_FETCHER']>\n" +
-                "    }\n" +
-                "    \n" +
-                "    async findSimpleBooks(): Promise<\n" +
-                "        ReadonlyArray<KBookDto['KBookService/SIMPLE_FETCHER']>\n" +
-                "    > {\n" +
-                "        let _uri = '/books/simple';\n" +
-                "        return (await this.executor({uri: _uri, method: 'GET'})) as ReadonlyArray<KBookDto['KBookService/SIMPLE_FETCHER']>\n" +
-                "    }\n" +
-                "    \n" +
-                "    async findTuples(options: KBookServiceOptions['findTuples']): Promise<\n" +
-                "        KPage<Tuple2<KBookDto['KBookService/COMPLEX_FETCHER'], KAuthorDto['KBookService/AUTHOR_FETCHER']>>\n" +
-                "    > {\n" +
-                "        let _uri = '/tuples';\n" +
-                "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
-                "        let _value: any = undefined;\n" +
-                "        _value = options.name;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'name='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.pageIndex;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'pageIndex='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        _value = options.pageSize;\n" +
-                "        if (_value !== undefined && _value !== null) {\n" +
-                "            _uri += _separator\n" +
-                "            _uri += 'pageSize='\n" +
-                "            _uri += encodeURIComponent(_value);\n" +
-                "            _separator = '&';\n" +
-                "        }\n" +
-                "        return (await this.executor({uri: _uri, method: 'GET'})) as KPage<Tuple2<KBookDto['KBookService/COMPLEX_FETCHER'], KAuthorDto['KBookService/AUTHOR_FETCHER']>>\n" +
-                "    }\n" +
-                "    \n" +
-                "    async saveBooks(options: KBookServiceOptions['saveBooks']): Promise<\n" +
-                "        Dynamic<KBook> | undefined\n" +
-                "    > {\n" +
-                "        let _uri = '/book';\n" +
-                "        return (await this.executor({uri: _uri, method: 'PUT', body: options.body})) as Dynamic<KBook> | undefined\n" +
-                "    }\n" +
-                "}\n" +
-                "\n" +
-                "export type KBookServiceOptions = {\n" +
-                "    'deleteBook': {readonly id: number},\n" +
-                "    'findComplexBooks': {\n" +
-                "        readonly name: string, \n" +
-                "        readonly storeName?: string, \n" +
-                "        readonly authorName?: string, \n" +
-                "        readonly minPrice?: number, \n" +
-                "        readonly maxPrice?: number\n" +
-                "    },\n" +
-                "    'findSimpleBooks': {},\n" +
-                "    'findTuples': {\n" +
-                "        \n" +
-                "        /**\n" +
-                "         * Match the book name, optional\n" +
-                "         */\n" +
-                "        readonly name: string, \n" +
-                "        \n" +
-                "        /**\n" +
-                "         * Start from 0, not 1\n" +
-                "         */\n" +
-                "        readonly pageIndex?: number, \n" +
-                "        readonly pageSize: number\n" +
-                "    },\n" +
-                "    'saveBooks': {readonly body: KBookInput}\n" +
-                "}",
+                    "import type { KAuthorDto, KBookDto } from '../model/dto';\n" +
+                    "import type { KBook } from '../model/entities';\n" +
+                    "import type { KBookInput, KPage, Tuple2 } from '../model/static';\n" +
+                    "\n" +
+                    "/**\n" +
+                    " * BookService interface\n" +
+                    " */\n" +
+                    "export class KBookService {\n" +
+                    "    \n" +
+                    "    constructor(private executor: Executor) {}\n" +
+                    "    \n" +
+                    "    async deleteBook(options: KBookServiceOptions['deleteBook']): Promise<number> {\n" +
+                    "        let _uri = '/book/';\n" +
+                    "        _uri += encodeURIComponent(options.id);\n" +
+                    "        return (await this.executor({uri: _uri, method: 'DELETE'})) as number\n" +
+                    "    }\n" +
+                    "    \n" +
+                    "    /**\n" +
+                    "     * Find book list\n" +
+                    "     * \n" +
+                    "     * Format of each element:\n" +
+                    "     * -   id\n" +
+                    "     * -   name\n" +
+                    "     * -   edition\n" +
+                    "     * -   price\n" +
+                    "     * -   store\n" +
+                    "     *     -   id\n" +
+                    "     *     -   name\n" +
+                    "     * -   authors\n" +
+                    "     *     -   id\n" +
+                    "     *     -   firstName\n" +
+                    "     */\n" +
+                    "    async findComplexBooks(options: KBookServiceOptions['findComplexBooks']): Promise<\n" +
+                    "        ReadonlyArray<KBookDto['KBookService/COMPLEX_FETCHER']>\n" +
+                    "    > {\n" +
+                    "        let _uri = '/books/complex';\n" +
+                    "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
+                    "        let _value: any = undefined;\n" +
+                    "        _value = options.name;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'name='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.storeName;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'storeName='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.authorName;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'authorName='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.minPrice;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'minPrice='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.maxPrice;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'maxPrice='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        return (await this.executor({uri: _uri, method: 'GET'})) as ReadonlyArray<KBookDto['KBookService/COMPLEX_FETCHER']>\n" +
+                    "    }\n" +
+                    "    \n" +
+                    "    async findSimpleBooks(): Promise<\n" +
+                    "        ReadonlyArray<KBookDto['KBookService/SIMPLE_FETCHER']>\n" +
+                    "    > {\n" +
+                    "        let _uri = '/books/simple';\n" +
+                    "        return (await this.executor({uri: _uri, method: 'GET'})) as ReadonlyArray<KBookDto['KBookService/SIMPLE_FETCHER']>\n" +
+                    "    }\n" +
+                    "    \n" +
+                    "    async findTuples(options: KBookServiceOptions['findTuples']): Promise<\n" +
+                    "        KPage<Tuple2<KBookDto['KBookService/COMPLEX_FETCHER'], KAuthorDto['KBookService/AUTHOR_FETCHER']>>\n" +
+                    "    > {\n" +
+                    "        let _uri = '/tuples';\n" +
+                    "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
+                    "        let _value: any = undefined;\n" +
+                    "        _value = options.name;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'name='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.pageIndex;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'pageIndex='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        _value = options.pageSize;\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'pageSize='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        return (await this.executor({uri: _uri, method: 'GET'})) as KPage<Tuple2<KBookDto['KBookService/COMPLEX_FETCHER'], KAuthorDto['KBookService/AUTHOR_FETCHER']>>\n" +
+                    "    }\n" +
+                    "    \n" +
+                    "    async saveBooks(options: KBookServiceOptions['saveBooks']): Promise<\n" +
+                    "        Dynamic<KBook> | undefined\n" +
+                    "    > {\n" +
+                    "        let _uri = '/book';\n" +
+                    "        return (await this.executor({uri: _uri, method: 'PUT', body: options.body})) as Dynamic<KBook> | undefined\n" +
+                    "    }\n" +
+                    "}\n" +
+                    "\n" +
+                    "export type KBookServiceOptions = {\n" +
+                    "    'deleteBook': {readonly id: number},\n" +
+                    "    'findComplexBooks': {\n" +
+                    "        readonly name: string, \n" +
+                    "        readonly storeName?: string, \n" +
+                    "        readonly authorName?: string, \n" +
+                    "        readonly minPrice?: number, \n" +
+                    "        readonly maxPrice?: number\n" +
+                    "    },\n" +
+                    "    'findSimpleBooks': {},\n" +
+                    "    'findTuples': {\n" +
+                    "        \n" +
+                    "        /**\n" +
+                    "         * Match the book name, optional\n" +
+                    "         */\n" +
+                    "        readonly name: string, \n" +
+                    "        \n" +
+                    "        /**\n" +
+                    "         * Start from 0, not 1\n" +
+                    "         */\n" +
+                    "        readonly pageIndex?: number, \n" +
+                    "        readonly pageSize: number\n" +
+                    "    },\n" +
+                    "    'saveBooks': {readonly body: KBookInput}\n" +
+                    "}",
             code
         )
     }
@@ -207,17 +211,17 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KBook, KCoordinate } from './';\n" +
-                "\n" +
-                "export interface KBookStore {\n" +
-                "    \n" +
-                "    readonly id: number;\n" +
-                "    \n" +
-                "    readonly name?: string;\n" +
-                "    \n" +
-                "    readonly coordinate: KCoordinate;\n" +
-                "    \n" +
-                "    readonly books: ReadonlyArray<KBook>;\n" +
-                "}\n",
+                    "\n" +
+                    "export interface KBookStore {\n" +
+                    "    \n" +
+                    "    readonly id: number;\n" +
+                    "    \n" +
+                    "    readonly name?: string;\n" +
+                    "    \n" +
+                    "    readonly coordinate: KCoordinate;\n" +
+                    "    \n" +
+                    "    readonly books: ReadonlyArray<KBook>;\n" +
+                    "}\n",
             code
         )
     }
@@ -231,21 +235,21 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KAuthor, KBookStore } from './';\n" +
-                "\n" +
-                "export interface KBook {\n" +
-                "    \n" +
-                "    readonly id: number;\n" +
-                "    \n" +
-                "    readonly name?: string;\n" +
-                "    \n" +
-                "    readonly edition: number;\n" +
-                "    \n" +
-                "    readonly price?: number;\n" +
-                "    \n" +
-                "    readonly store?: KBookStore;\n" +
-                "    \n" +
-                "    readonly authors: ReadonlyArray<KAuthor>;\n" +
-                "}\n",
+                    "\n" +
+                    "export interface KBook {\n" +
+                    "    \n" +
+                    "    readonly id: number;\n" +
+                    "    \n" +
+                    "    readonly name?: string;\n" +
+                    "    \n" +
+                    "    readonly edition: number;\n" +
+                    "    \n" +
+                    "    readonly price?: number;\n" +
+                    "    \n" +
+                    "    readonly store?: KBookStore;\n" +
+                    "    \n" +
+                    "    readonly authors: ReadonlyArray<KAuthor>;\n" +
+                    "}\n",
             code
         )
     }
@@ -259,20 +263,20 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KGender } from '../enums';\n" +
-                "import type { KBook } from './';\n" +
-                "\n" +
-                "export interface KAuthor {\n" +
-                "    \n" +
-                "    readonly id: number;\n" +
-                "    \n" +
-                "    readonly firstName: string;\n" +
-                "    \n" +
-                "    readonly lastName: string;\n" +
-                "    \n" +
-                "    readonly gender?: KGender;\n" +
-                "    \n" +
-                "    readonly books: ReadonlyArray<KBook>;\n" +
-                "}\n",
+                    "import type { KBook } from './';\n" +
+                    "\n" +
+                    "export interface KAuthor {\n" +
+                    "    \n" +
+                    "    readonly id: number;\n" +
+                    "    \n" +
+                    "    readonly firstName: string;\n" +
+                    "    \n" +
+                    "    readonly lastName: string;\n" +
+                    "    \n" +
+                    "    readonly gender?: KGender;\n" +
+                    "    \n" +
+                    "    readonly books: ReadonlyArray<KBook>;\n" +
+                    "}\n",
             code
         )
     }
@@ -285,31 +289,31 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KCoordinate } from '../entities';\n" +
-                "import type { KGender } from '../enums';\n" +
-                "\n" +
-                "export type KBookDto = {\n" +
-                "    'KBookService/SIMPLE_FETCHER': {\n" +
-                "        readonly id: number, \n" +
-                "        readonly name?: string\n" +
-                "    }, \n" +
-                "    'KBookService/COMPLEX_FETCHER': {\n" +
-                "        readonly id: number, \n" +
-                "        readonly name?: string, \n" +
-                "        readonly edition: number, \n" +
-                "        readonly price?: number, \n" +
-                "        readonly store?: {\n" +
-                "            readonly id: number, \n" +
-                "            readonly name?: string, \n" +
-                "            readonly coordinate: KCoordinate\n" +
-                "        }, \n" +
-                "        readonly authors: ReadonlyArray<{\n" +
-                "            readonly id: number, \n" +
-                "            readonly firstName: string, \n" +
-                "            readonly lastName: string, \n" +
-                "            readonly gender?: KGender\n" +
-                "        }>\n" +
-                "    }\n" +
-                "}",
+                    "import type { KGender } from '../enums';\n" +
+                    "\n" +
+                    "export type KBookDto = {\n" +
+                    "    'KBookService/SIMPLE_FETCHER': {\n" +
+                    "        readonly id: number, \n" +
+                    "        readonly name?: string\n" +
+                    "    }, \n" +
+                    "    'KBookService/COMPLEX_FETCHER': {\n" +
+                    "        readonly id: number, \n" +
+                    "        readonly name?: string, \n" +
+                    "        readonly edition: number, \n" +
+                    "        readonly price?: number, \n" +
+                    "        readonly store?: {\n" +
+                    "            readonly id: number, \n" +
+                    "            readonly name?: string, \n" +
+                    "            readonly coordinate: KCoordinate\n" +
+                    "        }, \n" +
+                    "        readonly authors: ReadonlyArray<{\n" +
+                    "            readonly id: number, \n" +
+                    "            readonly firstName: string, \n" +
+                    "            readonly lastName: string, \n" +
+                    "            readonly gender?: KGender\n" +
+                    "        }>\n" +
+                    "    }\n" +
+                    "}",
             code
         )
     }
@@ -322,27 +326,27 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KCoordinate } from '../entities';\n" +
-                "import type { KGender } from '../enums';\n" +
-                "\n" +
-                "export type KAuthorDto = {\n" +
-                "    'KBookService/AUTHOR_FETCHER': {\n" +
-                "        readonly id: number, \n" +
-                "        readonly firstName: string, \n" +
-                "        readonly lastName: string, \n" +
-                "        readonly gender?: KGender, \n" +
-                "        readonly books: ReadonlyArray<{\n" +
-                "            readonly id: number, \n" +
-                "            readonly name?: string, \n" +
-                "            readonly edition: number, \n" +
-                "            readonly price?: number, \n" +
-                "            readonly store?: {\n" +
-                "                readonly id: number, \n" +
-                "                readonly name?: string, \n" +
-                "                readonly coordinate: KCoordinate\n" +
-                "            }\n" +
-                "        }>\n" +
-                "    }\n" +
-                "}",
+                    "import type { KGender } from '../enums';\n" +
+                    "\n" +
+                    "export type KAuthorDto = {\n" +
+                    "    'KBookService/AUTHOR_FETCHER': {\n" +
+                    "        readonly id: number, \n" +
+                    "        readonly firstName: string, \n" +
+                    "        readonly lastName: string, \n" +
+                    "        readonly gender?: KGender, \n" +
+                    "        readonly books: ReadonlyArray<{\n" +
+                    "            readonly id: number, \n" +
+                    "            readonly name?: string, \n" +
+                    "            readonly edition: number, \n" +
+                    "            readonly price?: number, \n" +
+                    "            readonly store?: {\n" +
+                    "                readonly id: number, \n" +
+                    "                readonly name?: string, \n" +
+                    "                readonly coordinate: KCoordinate\n" +
+                    "            }\n" +
+                    "        }>\n" +
+                    "    }\n" +
+                    "}",
             code
         )
     }
@@ -355,14 +359,14 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "import type { KCoordinate } from '../entities';\n" +
-                "\n" +
-                "export type KBookStoreDto = {\n" +
-                "    'DEFAULT': {\n" +
-                "        readonly id: number, \n" +
-                "        readonly name?: string, \n" +
-                "        readonly coordinate: KCoordinate\n" +
-                "    }\n" +
-                "}",
+                    "\n" +
+                    "export type KBookStoreDto = {\n" +
+                    "    'DEFAULT': {\n" +
+                    "        readonly id: number, \n" +
+                    "        readonly name?: string, \n" +
+                    "        readonly coordinate: KCoordinate\n" +
+                    "    }\n" +
+                    "}",
             code
         )
     }
@@ -376,17 +380,17 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "export interface KBookInput {\n" +
-                "    \n" +
-                "    readonly authorIds: ReadonlyArray<number>;\n" +
-                "    \n" +
-                "    readonly edition: number;\n" +
-                "    \n" +
-                "    readonly name: string;\n" +
-                "    \n" +
-                "    readonly price: number;\n" +
-                "    \n" +
-                "    readonly storeId?: number;\n" +
-                "}\n",
+                    "    \n" +
+                    "    readonly authorIds: ReadonlyArray<number>;\n" +
+                    "    \n" +
+                    "    readonly edition: number;\n" +
+                    "    \n" +
+                    "    readonly name: string;\n" +
+                    "    \n" +
+                    "    readonly price: number;\n" +
+                    "    \n" +
+                    "    readonly storeId?: number;\n" +
+                    "}\n",
             code
         )
     }
@@ -400,13 +404,13 @@ class KTypeScriptTest {
         val code = out.toString()
         Assertions.assertEquals(
             "export interface KPage<E> {\n" +
-                "    \n" +
-                "    readonly entities: ReadonlyArray<E>;\n" +
-                "    \n" +
-                "    readonly totalPageCount: number;\n" +
-                "    \n" +
-                "    readonly totalRowCount: number;\n" +
-                "}\n",
+                    "    \n" +
+                    "    readonly entities: ReadonlyArray<E>;\n" +
+                    "    \n" +
+                    "    readonly totalPageCount: number;\n" +
+                    "    \n" +
+                    "    readonly totalRowCount: number;\n" +
+                    "}\n",
             code
         )
     }
@@ -421,6 +425,44 @@ class KTypeScriptTest {
         Assertions.assertEquals(
             "export type KGender = 'MALE' | 'FEMALE';\n",
             code
+        )
+    }
+
+    @Test
+    fun testArray() {
+        val out = ByteArrayOutputStream()
+        val ctx = createContext(out)
+        val service = Constants.KOTLIN_METADATA.services[KArrayService::class.java]
+        ServiceWriter(ctx, service).flush()
+        val code = out.toString()
+        Assertions.assertEquals(
+            "import type { Executor } from '../';\n" +
+                    "import type { Unit } from '../model/static';\n" +
+                    "\n" +
+                    "export class KArrayService {\n" +
+                    "    \n" +
+                    "    constructor(private executor: Executor) {}\n" +
+                    "    \n" +
+                    "    async saveIds(options: KArrayServiceOptions['saveIds']): Promise<\n" +
+                    "        Unit\n" +
+                    "    > {\n" +
+                    "        let _uri = '/insert/ids';\n" +
+                    "        let _separator = _uri.indexOf('?') === -1 ? '?' : '&';\n" +
+                    "        let _value: any = undefined;\n" +
+                    "        _value = options.arg0.join(',');\n" +
+                    "        if (_value !== undefined && _value !== null) {\n" +
+                    "            _uri += _separator\n" +
+                    "            _uri += 'arg0='\n" +
+                    "            _uri += encodeURIComponent(_value);\n" +
+                    "            _separator = '&';\n" +
+                    "        }\n" +
+                    "        return (await this.executor({uri: _uri, method: 'GET'})) as Unit\n" +
+                    "    }\n" +
+                    "}\n" +
+                    "\n" +
+                    "export type KArrayServiceOptions = {\n" +
+                    "    'saveIds': {readonly arg0: ReadonlyArray<string>}\n" +
+                    "}", code
         )
     }
 

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/meta/Constants.java
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/meta/Constants.java
@@ -3,9 +3,11 @@ package org.babyfish.jimmer.client.meta;
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KFunction;
 import kotlin.reflect.KType;
+import org.babyfish.jimmer.client.java.service.ArrayService;
 import org.babyfish.jimmer.client.java.service.AuthorService;
 import org.babyfish.jimmer.client.java.service.BookService;
 import org.babyfish.jimmer.client.java.service.FindBookArguments;
+import org.babyfish.jimmer.client.kotlin.service.KArrayService;
 import org.babyfish.jimmer.client.kotlin.service.KBookService;
 import org.babyfish.jimmer.client.kotlin.service.KBookStoreService;
 import org.babyfish.jimmer.client.meta.common.*;
@@ -96,6 +98,7 @@ public class Constants {
     public final static Metadata JAVA_METADATA = Metadata.newBuilder()
             .addServiceType(BookService.class)
             .addServiceType(AuthorService.class)
+            .addServiceType(ArrayService.class)
             .setOperationParser(
                     OPERATION_PARSER
             )
@@ -107,6 +110,7 @@ public class Constants {
     public final static Metadata KOTLIN_METADATA = Metadata.newBuilder()
             .addServiceType(KBookService.class)
             .addServiceType(KBookStoreService.class)
+            .addServiceType(KArrayService.class)
             .setOperationParser(
                     OPERATION_PARSER
             )


### PR DESCRIPTION
Fixed an issue in `writeArrayTypeRef` where `SIMPLE_TYPE_NAMES` mapping wasn't used for conversion. Previously, `Array<UUID>` or `UUID[]` was converted to `ReadonlyArray<UUID>`. With the fix, `Array<UUID>` or `UUID[]` is now correctly converted to `ReadonlyArray<string>`. Additionally, type restriction was added to disallow multi-dimensional arrays.