### PR TITLE
Fix `JsonConverter` annotation target

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/JsonConverter.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/JsonConverter.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
-@kotlin.annotation.Target(allowedTargets = AnnotationTarget.PROPERTY)
+@kotlin.annotation.Target(AnnotationTarget.PROPERTY, AnnotationTarget.ANNOTATION_CLASS)
 public @interface JsonConverter {
 
     Class<? extends Converter<?, ?>> value();


### PR DESCRIPTION
This PR fix the `JsonConverter` annotation cannot annotate other annotation class in `kotlin`.
```kotlin
@JsonConverter(ObfuscationConverter::class)
annotation class Obfuscated
```