### PR TITLE
Fix bug of view

### DIFF
--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
@@ -782,6 +782,14 @@ public class SpringJavaTest extends AbstractTest {
     }
 
     @Test
+    public void testFindMapByIds() {
+        List<UUID> list = new ArrayList<>();
+        list.add(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0"));
+        Map<UUID, BookStore> map = bookStoreRepository.findMapByIds(list);
+        Assertions.assertNotNull(map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
+    }
+
+    @Test
     public void testSpecification() {
         BookSpecification specification = new BookSpecification();
         specification.setMinPrice(new BigDecimal(46));

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
@@ -58,10 +58,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;
 
 import javax.sql.DataSource;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 @SpringBootTest(properties = {
         "jimmer.client.ts.path=/my-ts.zip",
@@ -774,6 +771,14 @@ public class SpringJavaTest extends AbstractTest {
                         ")",
                 views.get(0)
         );
+    }
+
+    @Test
+    public void testViewFindMapByIds() {
+        List<UUID> list = new ArrayList<>();
+        list.add(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0"));
+        Map<UUID, BookStoreView> map = bookStoreRepository.viewer(BookStoreView.class).findMapByIds(list);
+        Assertions.assertNotNull(map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
     }
 
     @Test

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
@@ -778,7 +778,45 @@ public class SpringJavaTest extends AbstractTest {
         List<UUID> list = new ArrayList<>();
         list.add(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0"));
         Map<UUID, BookStoreView> map = bookStoreRepository.viewer(BookStoreView.class).findMapByIds(list);
-        Assertions.assertNotNull(map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
+        assertContent("BookStoreView(id=d38c10da-6be8-4924-b9b9-5e81899612a0,\n" +
+                        " name=O'REILLY,\n" +
+                        " books=[BookStoreView.TargetOf_books(id=e110c564-23cc-4811-9e81-d587a13db634,\n" +
+                        " name=Learning GraphQL,\n" +
+                        " edition=1,\n" +
+                        " price=50.00),\n" +
+                        " BookStoreView.TargetOf_books(id=b649b11b-1161-4ad2-b261-af0112fdd7c8,\n" +
+                        " name=Learning GraphQL,\n" +
+                        " edition=2,\n" +
+                        " price=55.00),\n" +
+                        " BookStoreView.TargetOf_books(id=64873631-5d82-4bae-8eb8-72dd955bfc56,\n" +
+                        " name=Learning GraphQL,\n" +
+                        " edition=3,\n" +
+                        " price=51.00),\n" +
+                        " BookStoreView.TargetOf_books(id=8f30bc8a-49f9-481d-beca-5fe2d147c831,\n" +
+                        " name=Effective TypeScript,\n" +
+                        " edition=1,\n" +
+                        " price=73.00),\n" +
+                        " BookStoreView.TargetOf_books(id=8e169cfb-2373-4e44-8cce-1f1277f730d1,\n" +
+                        " name=Effective TypeScript,\n" +
+                        " edition=2,\n" +
+                        " price=69.00),\n" +
+                        " BookStoreView.TargetOf_books(id=9eded40f-6d2e-41de-b4e7-33a28b11c8b6,\n" +
+                        " name=Effective TypeScript,\n" +
+                        " edition=3,\n" +
+                        " price=88.00),\n" +
+                        " BookStoreView.TargetOf_books(id=914c8595-35cb-4f67-bbc7-8029e9e6245a,\n" +
+                        " name=Programming TypeScript,\n" +
+                        " edition=1,\n" +
+                        " price=47.50),\n" +
+                        " BookStoreView.TargetOf_books(id=058ecfd0-047b-4979-a7dc-46ee24d08f08,\n" +
+                        " name=Programming TypeScript,\n" +
+                        " edition=2,\n" +
+                        " price=45.00),\n" +
+                        " BookStoreView.TargetOf_books(id=782b9a9d-eac8-41c4-9f2d-74a5d047f45a,\n" +
+                        " name=Programming TypeScript,\n" +
+                        " edition=3,\n" +
+                        " price=48.00)])",
+                map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
     }
 
     @Test
@@ -786,7 +824,9 @@ public class SpringJavaTest extends AbstractTest {
         List<UUID> list = new ArrayList<>();
         list.add(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0"));
         Map<UUID, BookStore> map = bookStoreRepository.findMapByIds(list);
-        Assertions.assertNotNull(map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
+        assertContent("{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\",\n" +
+                "\"name\":\"O'REILLY\"}",
+                map.get(UUID.fromString("d38c10da-6be8-4924-b9b9-5e81899612a0")));
     }
 
     @Test

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
@@ -186,7 +186,11 @@ public class EntitiesImpl implements Entities {
         List<E> entities = findByIds(type, null, ids, con);
         Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
         for (E entity : entities) {
-            map.put((ID)((ImmutableSpi)(((View<?>) entity).toEntity())).__get(idPropId), entity);
+            if (View.class.isAssignableFrom(type)) {
+                map.put((ID)((ImmutableSpi)(((View<?>) entity).toEntity())).__get(idPropId), entity);
+            } else {
+                map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
+            }
         }
         return map;
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
@@ -186,7 +186,7 @@ public class EntitiesImpl implements Entities {
         List<E> entities = findByIds(type, null, ids, con);
         Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
         for (E entity : entities) {
-            map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
+            map.put((ID)((ImmutableSpi)(((View<?>) entity).toEntity())).__get(idPropId), entity);
         }
         return map;
     }


### PR DESCRIPTION
### Error function
`Map<UUID, BookStoreView> map = bookStoreRepository.viewer(BookStoreView.class).findMapByIds(list);`

### Error log spring
```
java.lang.ClassCastException: class org.babyfish.jimmer.spring.java.model.dto.BookStoreView cannot be cast to class org.babyfish.jimmer.runtime.ImmutableSpi (org.babyfish.jimmer.spring.java.model.dto.BookStoreView and org.babyfish.jimmer.runtime.ImmutableSpi are in unnamed module of loader 'app')
	at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.findMapByIds(EntitiesImpl.java:189)
	at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.lambda$findMapByIds$2(EntitiesImpl.java:135)
	at org.babyfish.jimmer.spring.cfg.support.SpringConnectionManager.execute(SpringConnectionManager.java:28)
	at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.findMapByIds(EntitiesImpl.java:134)
	at org.babyfish.jimmer.spring.repository.support.JRepositoryImpl$ViewerImpl.findMapByIds(JRepositoryImpl.java:403)
	at org.babyfish.jimmer.spring.java.SpringJavaTest.testViewFindMapByIds(SpringJavaTest.java:780)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

### Error log quarkus
```
java.lang.ClassCastException: class io.quarkiverse.jimmer.it.entity.dto.BookDetailView cannot be cast to class org.babyfish.jimmer.runtime.ImmutableSpi (io.quarkiverse.jimmer.it.entity.dto.BookDetailView is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @75d982d3; org.babyfish.jimmer.runtime.ImmutableSpi is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @8b96fde)
        at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.findMapByIds(EntitiesImpl.java:189)
        at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.lambda$findMapByIds$2(EntitiesImpl.java:135)
        at org.babyfish.jimmer.sql.runtime.ConnectionManager$1.execute(ConnectionManager.java:17)
        at org.babyfish.jimmer.sql.ast.impl.EntitiesImpl.findMapByIds(EntitiesImpl.java:134)
        at io.quarkiverse.jimmer.runtime.repository.JRepository$1.findMapByIds(JRepository.java:404)
        at io.quarkiverse.jimmer.it.resource.TestResources.testBookRepositoryFindMapByIdsView(TestResources.java:331)
        at io.quarkiverse.jimmer.it.resource.TestResources$quarkusrestinvoker$testBookRepositoryFindMapByIdsView_2b87fc9158cf12438ae0bc2781e457f38075b43e.invoke(Unknown Source)
        at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
        at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
        at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
        at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:582)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
        at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
        at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:1583)

```


### Error code
```
@SuppressWarnings("unchecked")
    private <ID, E> Map<ID, E> findMapByIds(Class<E> type, Collection<ID> ids, Connection con) {
        PropId idPropId = immutableTypeOf(type).getIdProp().getId();
        List<E> entities = findByIds(type, null, ids, con);
        Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
        for (E entity : entities) {
            map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
        }
        return map;
    }
```

### Fix
```
private <ID, E> Map<ID, E> findMapByIds(Class<E> type, Collection<ID> ids, Connection con) {
        PropId idPropId = immutableTypeOf(type).getIdProp().getId();
        List<E> entities = findByIds(type, null, ids, con);
        Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
        for (E entity : entities) {
            if (View.class.isAssignableFrom(type)) {
                map.put((ID)((ImmutableSpi)(((View<?>) entity).toEntity())).__get(idPropId), entity);
            } else {
                map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
            }
        }
        return map;
    }
```

### Cause
java.lang.ClassCastException