### PR TITLE
Refactor publishing

### DIFF
--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/dokka-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/dokka-convention.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.dokka.DokkaVersion
+
 plugins {
     id("org.jetbrains.dokka")
 }
@@ -8,4 +10,8 @@ tasks {
             from(dokkaHtml.flatMap { it.outputDirectory })
         }
     }
+}
+
+dependencies {
+    dokkaHtmlPlugin("org.jetbrains.dokka", "dokka-base", DokkaVersion.version)
 }

--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/java-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/java-convention.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("publish-convention")
 }
 
 extensions.configure<JavaPluginExtension> {

--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/publish-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/publish-convention.gradle.kts
@@ -1,0 +1,58 @@
+plugins {
+    `maven-publish`
+    signing
+}
+
+publishing {
+    repositories {
+        maven {
+            credentials {
+                username = findProperty("NEXUS_USERNAME") as String?
+                password = findProperty("NEXUS_PASSWORD") as String?
+            }
+            name = "MavenCentral"
+            url = if (project.version.toString().endsWith("-SNAPSHOT")) {
+                uri("https://oss.sonatype.org/content/repositories/snapshots")
+            } else {
+                uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            }
+        }
+    }
+    publications {
+        create<MavenPublication>("mavenJava") {
+            plugins.withType<JavaPlugin> {
+                from(components["java"])
+            }
+            plugins.withType<JavaPlatformPlugin> {
+                from(components["javaPlatform"])
+            }
+            pom {
+                name.set("jimmer")
+                description.set("A revolutionary ORM framework for both java and kotlin")
+                url.set("https://github.com/babyfish-ct/jimmer")
+                licenses {
+                    license {
+                        name.set("Apache-2.0")
+                        url.set("https://github.com/babyfish-ct/jimmer/blob/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("babyfish-ct")
+                        name.set("陈涛")
+                        email.set("babyfish.ct@gmail.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/babyfish-ct/jimmer.git")
+                    developerConnection.set("scm:git:ssh://github.com/babyfish-ct/jimmer.git")
+                    url.set("https://github.com//babyfish-ct/jimmer")
+                }
+            }
+        }
+    }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
+}

--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ antlr = "4.13.0"
 apacheCommonsLang3 = "3.12.0"
 buildconfig = "5.3.5"
 caffeine = "2.9.1"
-dokka = "1.6.10"
 h2 = "2.1.212"
 intellijAnnotations = "12.0"
 jackson = "2.15.2"
@@ -31,8 +30,6 @@ antlr = { group = "org.antlr", name = "antlr4", version.ref = "antlr" }
 apache-commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "apacheCommonsLang3" }
 
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
-
-dokka-base = { group = "org.jetbrains.dokka", name = "dokka-base", version.ref = "dokka" }
 
 h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 

--- a/project/jimmer-bom/build.gradle.kts
+++ b/project/jimmer-bom/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-platform`
+    `publish-convention`
 }
 
 dependencies {

--- a/project/jimmer-core-kotlin/build.gradle.kts
+++ b/project/jimmer-core-kotlin/build.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
     testImplementation(libs.mapstruct)
     testImplementation(libs.javax.validation.api)
     kspTest(projects.jimmerKsp)
-
-    dokkaHtmlPlugin(libs.dokka.base)
 }
 
 kotlin {

--- a/project/jimmer-ksp/build.gradle.kts
+++ b/project/jimmer-ksp/build.gradle.kts
@@ -13,6 +13,4 @@ dependencies {
     implementation(libs.kotlinpoet.ksp)
     implementation(libs.javax.validation.api)
     implementation(libs.jakarta.validation.api)
-
-    dokkaHtmlPlugin(libs.dokka.base)
 }

--- a/project/jimmer-sql-kotlin/build.gradle.kts
+++ b/project/jimmer-sql-kotlin/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 
     testImplementation(libs.h2)
     testImplementation(libs.javax.validation.api)
-    dokkaHtmlPlugin(libs.dokka.base)
     testImplementation(libs.jackson.datatype.jsr310)
     testImplementation(libs.postgresql)
     testImplementation(libs.spring.jdbc)


### PR DESCRIPTION
`publish-convention` plugin is applied inside `java-convention` because we want always publish all java projects.
If you will ever need to add unpublishable java project you will need to apply `publish-convention` manually to all required projects.