### PR TITLE
Use task_configuration_avoidance whenever possible

### DIFF
--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/dokka-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/dokka-convention.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 tasks {
-    withType<Jar> {
+    withType<Jar>().configureEach {
         if (archiveClassifier.get() == "javadoc") {
             from(dokkaHtml.flatMap { it.outputDirectory })
         }

--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/java-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/java-convention.gradle.kts
@@ -12,9 +12,9 @@ extensions.configure<JavaPluginExtension> {
 tasks.test {
     useJUnitPlatform()
 }
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-parameters")
 }
-tasks.withType<Javadoc>{
+tasks.withType<Javadoc>().configureEach {
     options.encoding = "UTF-8"
 }

--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/kotlin-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/kotlin-convention.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 val javaVersion = extensions.getByName<JavaPluginExtension>("java").targetCompatibility.toString()
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all")
         jvmTarget = javaVersion

--- a/project/jimmer-client/build.gradle.kts
+++ b/project/jimmer-client/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     testImplementation(libs.spring.web)
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Ajimmer.source.includes=org.babyfish.jimmer.client.java.")
     options.compilerArgs.add("-Ajimmer.client.checkedException=true")
 }

--- a/project/jimmer-core/build.gradle.kts
+++ b/project/jimmer-core/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     testAnnotationProcessor(libs.mapstruct.processor)
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Ajimmer.source.excludes=org.babyfish.jimmer.invalid")
     options.compilerArgs.add("-Ajimmer.generate.dynamic.pojo=true")
 }

--- a/project/jimmer-dto-compiler/build.gradle.kts
+++ b/project/jimmer-dto-compiler/build.gradle.kts
@@ -12,10 +12,10 @@ dependencies {
     antlr(libs.antlr)
 }
 
-tasks.withType<Jar> {
+tasks.withType<Jar>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
 }

--- a/project/jimmer-sql/build.gradle.kts
+++ b/project/jimmer-sql/build.gradle.kts
@@ -36,15 +36,15 @@ dependencies {
     // testImplementation(files("/Users/chentao/Downloads/ojdbc8-21.9.0.0.jar"))
 }
 
-tasks.withType<Jar> {
+tasks.withType<Jar>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xmaxerrs")
     options.compilerArgs.add("2000")
 }


### PR DESCRIPTION
Skip task configuration if possible:
https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview