### PR TITLE
Add GeneratedBy to all top level entities

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/internal/GeneratedBy.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/internal/GeneratedBy.java
@@ -12,9 +12,9 @@ import java.lang.annotation.*;
  * simply customize one.</p>
  */
 @Documented
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
-@kotlin.annotation.Target(allowedTargets = { AnnotationTarget.CLASS, AnnotationTarget.FILE })
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@kotlin.annotation.Target(allowedTargets = { AnnotationTarget.CLASS, AnnotationTarget.FILE, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION })
 public @interface GeneratedBy {
 
     Class<?> type() default void.class;

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -18,6 +18,7 @@ import org.babyfish.jimmer.ksp.immutable.generator.*
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import org.babyfish.jimmer.ksp.util.ConverterMetadata
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import java.io.OutputStreamWriter
 import java.util.*
 import kotlin.math.min
@@ -143,6 +144,7 @@ class DtoGenerator private constructor(
             val builder = TypeSpec
                 .classBuilder(innerClassName)
                 .addModifiers(KModifier.OPEN)
+                .addGeneratedAnnotation()
             builder.addTypeAnnotations()
             _typeBuilder = builder
             try {
@@ -261,6 +263,7 @@ class DtoGenerator private constructor(
             typeBuilder.addType(
                 TypeSpec
                     .companionObjectBuilder()
+                    .addGeneratedAnnotation()
                     .apply {
                         addMetadata()
                         for (prop in dtoType.dtoProps) {

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/BuilderGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/BuilderGenerator.kt
@@ -1,7 +1,7 @@
 package org.babyfish.jimmer.ksp.immutable.generator
 
 import com.squareup.kotlinpoet.*
-import org.babyfish.jimmer.impl.util.StringUtil
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 
@@ -13,6 +13,7 @@ class BuilderGenerator(
         parent.addType(
             TypeSpec
                 .classBuilder("Builder")
+                .addGeneratedAnnotation(type)
                 .apply {
                     addMembers()
                 }

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftGenerator.kt
@@ -7,6 +7,7 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.babyfish.jimmer.ksp.Context
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import java.io.OutputStreamWriter
@@ -70,12 +71,7 @@ class DraftGenerator(
                 .interfaceBuilder("${type.simpleName}$DRAFT")
                 .addAnnotation(DSL_SCOPE_CLASS_NAME)
                 .addSuperinterface(type.className)
-                .addAnnotation(
-                    AnnotationSpec
-                        .builder(GENERATED_BY_CLASS_NAME)
-                        .addMember("type = %T::class", type.className)
-                        .build()
-                )
+                .addGeneratedAnnotation(type)
                 .apply {
                     if (type.superTypes.isEmpty()) {
                         addSuperinterface(DRAFT_CLASS_NAME)
@@ -165,6 +161,7 @@ class DraftGenerator(
         addFunction(
             FunSpec
                 .builder("addBy")
+                .addGeneratedAnnotation(type)
                 .receiver(receiverTypeName)
                 .addParameter(
                     ParameterSpec
@@ -209,6 +206,7 @@ class DraftGenerator(
                         "by"
                     }
                 )
+                .addGeneratedAnnotation(type)
                 .apply {
                     if (companion) {
                         addModifiers(KModifier.OPERATOR)
@@ -257,6 +255,7 @@ class DraftGenerator(
         addFunction(
             FunSpec
                 .builder("copy")
+                .addGeneratedAnnotation(type)
                 .receiver(type.className)
                 .addParameter(
                     "block",

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftImplGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftImplGenerator.kt
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.ksp.immutable.generator
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.get
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
@@ -17,6 +18,7 @@ class DraftImplGenerator(
         parent.addType(
             TypeSpec
                 .classBuilder(DRAFT_IMPL)
+                .addGeneratedAnnotation(type)
                 .addSuperinterface(type.draftClassName(PRODUCER, IMPLEMENTOR))
                 .addSuperinterface(type.draftClassName)
                 .addSuperinterface(DRAFT_SPI_CLASS_NAME)

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/FetcherDslGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/FetcherDslGenerator.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.ksp.immutable.generator
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import org.babyfish.jimmer.sql.JoinTable
@@ -17,6 +18,7 @@ class FetcherDslGenerator(
             TypeSpec
                 .classBuilder("${type.simpleName}$FETCHER_DSL")
                 .addAnnotation(DSL_SCOPE_CLASS_NAME)
+                .addGeneratedAnnotation(type)
                 .apply {
                     addField()
                     addConstructor()

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/FetcherGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/FetcherGenerator.kt
@@ -7,6 +7,7 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.babyfish.jimmer.ksp.Context
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import java.io.OutputStreamWriter
 
@@ -75,6 +76,7 @@ class FetcherGenerator(
         addFunction(
             FunSpec
                 .builder("by")
+                .addGeneratedAnnotation(type)
                 .receiver(
                     FETCHER_CREATOR_CLASS_NAME.parameterizedBy(
                         type.className

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ImplGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ImplGenerator.kt
@@ -2,10 +2,10 @@ package org.babyfish.jimmer.ksp.immutable.generator
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import org.babyfish.jimmer.meta.PropId
-import java.io.Serializable
 import kotlin.reflect.KClass
 
 class ImplGenerator(
@@ -17,6 +17,7 @@ class ImplGenerator(
             TypeSpec
                 .classBuilder(IMPL)
                 .addModifiers(KModifier.PRIVATE)
+                .addGeneratedAnnotation(type)
                 .addSuperinterface(type.draftClassName(PRODUCER, IMPLEMENTOR))
                 .addSuperinterface(CLONEABLE_CLASS_NAME)
                 .addSuperinterface(SERIALIZABLE_CLASS_NAME)

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ImplementorGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ImplementorGenerator.kt
@@ -2,7 +2,7 @@ package org.babyfish.jimmer.ksp.immutable.generator
 
 import com.squareup.kotlinpoet.*
 import org.babyfish.jimmer.jackson.ImmutableModuleRequiredException
-import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import org.babyfish.jimmer.meta.PropId
 import kotlin.reflect.KClass
@@ -16,6 +16,7 @@ class ImplementorGenerator(
         parent.addType(
             TypeSpec
                 .interfaceBuilder(IMPLEMENTOR)
+                .addGeneratedAnnotation(type)
                 .addModifiers(KModifier.PRIVATE, KModifier.ABSTRACT)
                 .addSuperinterface(type.className)
                 .addSuperinterface(IMMUTABLE_SPI_CLASS_NAME)

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/JimmerModuleGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/JimmerModuleGenerator.kt
@@ -5,8 +5,8 @@ import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.*
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import java.io.OutputStreamWriter
-import java.lang.IllegalArgumentException
 
 class JimmerModuleGenerator(
     private val codeGenerator: CodeGenerator,
@@ -51,6 +51,7 @@ class JimmerModuleGenerator(
                     addType(
                         TypeSpec
                             .classBuilder("JimmerModule")
+                            .addGeneratedAnnotation()
                             .addModifiers(KModifier.PRIVATE)
                             .build()
                     )
@@ -61,6 +62,7 @@ class JimmerModuleGenerator(
                                 "Under normal circumstances, users do not need to use this code. \n" +
                                     "This code is for compatibility with version 0.7.47 and earlier."
                             )
+                            .addGeneratedAnnotation()
                             .initializer(
                                 CodeBlock
                                     .builder()

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ProducerGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/ProducerGenerator.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.babyfish.jimmer.Formula
 import org.babyfish.jimmer.currentVersion
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
 import org.babyfish.jimmer.sql.*
@@ -16,6 +17,7 @@ class ProducerGenerator(
         parent.addType(
             TypeSpec
                 .objectBuilder(PRODUCER)
+                .addGeneratedAnnotation(type)
                 .apply {
                     if (!type.isMappedSuperclass) {
                         addSlots()

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/PropsGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/PropsGenerator.kt
@@ -13,6 +13,7 @@ import org.babyfish.jimmer.ksp.className
 import org.babyfish.jimmer.ksp.Context
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableProp
 import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
+import org.babyfish.jimmer.ksp.util.addGeneratedAnnotation
 import org.babyfish.jimmer.sql.Embeddable
 import java.io.OutputStreamWriter
 
@@ -173,6 +174,7 @@ class PropsGenerator(
         addProperty(
             PropertySpec
                 .builder(propName, returnTypeName)
+                .addGeneratedAnnotation(type)
                 .receiver(receiverClassName)
                 .getter(
                     FunSpec
@@ -267,6 +269,7 @@ class PropsGenerator(
         addProperty(
             PropertySpec
                 .builder(idPropName, returnClassName)
+                .addGeneratedAnnotation(type)
                 .receiver(receiverClassName)
                 .getter(
                     FunSpec
@@ -312,6 +315,7 @@ class PropsGenerator(
         addProperty(
             PropertySpec
                 .builder(prop.name, returnTypeName)
+                .addGeneratedAnnotation(type)
                 .apply {
                     if (!prop.isNullable) {
                         addAnnotation(
@@ -356,6 +360,7 @@ class PropsGenerator(
         addProperty(
             PropertySpec
                 .builder(type.idProp!!.name, returnTypeName)
+                .addGeneratedAnnotation(type)
                 .receiver(
                     if (nullable) {
                         K_NULLABLE_REMOTE_REF
@@ -384,6 +389,7 @@ class PropsGenerator(
         addFunction(
             FunSpec
                 .builder("fetchBy")
+                .addGeneratedAnnotation(type)
                 .receiver(
                     if (nullable) {
                         K_NULLABLE_TABLE_CLASS_NAME
@@ -419,6 +425,7 @@ class PropsGenerator(
         addType(
             TypeSpec
                 .objectBuilder(type.propsClassName)
+                .addGeneratedAnnotation(type)
                 .apply {
                     for (prop in type.properties.values) {
                         addPropMeta(type, prop)

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/util/GeneratedAnnotation.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/util/GeneratedAnnotation.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.ksp.util
+
+import com.squareup.kotlinpoet.Annotatable
+import com.squareup.kotlinpoet.AnnotationSpec
+import org.babyfish.jimmer.ksp.immutable.generator.GENERATED_BY_CLASS_NAME
+import org.babyfish.jimmer.ksp.immutable.meta.ImmutableType
+
+internal fun <T: Annotatable.Builder<T>> T.addGeneratedAnnotation(): T = addAnnotation(
+    AnnotationSpec.builder(GENERATED_BY_CLASS_NAME)
+        .build()
+)
+
+internal fun <T: Annotatable.Builder<T>> T.addGeneratedAnnotation(type: ImmutableType): T = addAnnotation(
+    AnnotationSpec.builder(GENERATED_BY_CLASS_NAME)
+        .addMember("type = %T::class", type.className)
+        .build()
+)


### PR DESCRIPTION
#543 

Exclude all generated code from a jacoco coverage report.
I added annotations for kotlin only.
If this looks good for you, I can do the same thing for java.