### PR TITLE
Create h2 database files inside build directory

### DIFF
--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/datasource/DataSources.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/datasource/DataSources.java
@@ -12,7 +12,7 @@ public class DataSources {
     public static DataSource create(TxCallback callback) {
         SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
         dataSource.setDriver(new Driver());
-        dataSource.setUrl("jdbc:h2:~/jimmer_spring_test_db;database_to_upper=true");
+        dataSource.setUrl("jdbc:h2:./build/h2/jimmer_spring_test_db;database_to_upper=true");
         return callback == null ? dataSource : new DataSourceProxy(dataSource, callback);
     }
 }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
@@ -57,7 +57,7 @@ abstract class AbstractTest {
 
     companion object {
 
-        private val JDBC_URL = "jdbc:h2:~/jimmer_kt_test_db;database_to_upper=true"
+        private val JDBC_URL = "jdbc:h2:./build/h2/jimmer_kt_test_db;database_to_upper=true"
 
         @JvmStatic
         fun jdbc(dataSource: DataSource? = null, rollback: Boolean = false, block: (Connection) -> Unit) {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
 
 public class AbstractTest extends Tests {
 
-    protected static final String JDBC_URL = "jdbc:h2:~/jimmer_test_db;database_to_upper=true";
+    protected static final String JDBC_URL = "jdbc:h2:./build/h2/jimmer_test_db;database_to_upper=true";
 
     private Map<Class<?>, AutoIds> autoIdMap = new HashMap<>();
 


### PR DESCRIPTION
I moved all h2 files to build directories.
Now we can guaranteed delete them with `gradle clean`.