### PR TITLE
Fix bugs with cache and LiteralExpression

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -1146,7 +1146,7 @@ public class DtoGenerator {
             return metadata.getTargetTypeName();
         }
 
-        return toListType(getPropElementName(prop), baseProp.isList() && baseProp.getTargetType() != null);
+        return toListType(getPropElementName(prop), baseProp.isList() && !baseProp.isFormula());
     }
 
     private static TypeName toListType(TypeName typeName, boolean isList) {

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -1126,7 +1126,7 @@ class DtoGenerator private constructor(
         }
 
         return propElementName(prop)
-            .toList(baseProp.isList && baseProp.targetType !== null)
+            .toList(baseProp.isList && !baseProp.isFormula)
             .copy(nullable = prop.isNullable)
     }
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/expression/impl/TerminalExpressions.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/expression/impl/TerminalExpressions.kt
@@ -3,13 +3,11 @@ package org.babyfish.jimmer.sql.kt.ast.expression.impl
 import org.babyfish.jimmer.meta.ImmutableProp
 import org.babyfish.jimmer.sql.ast.PropExpression
 import org.babyfish.jimmer.sql.ast.impl.*
-import org.babyfish.jimmer.sql.ast.impl.render.BatchSqlBuilder
 import org.babyfish.jimmer.sql.ast.table.spi.PropExpressionImplementor
 import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KNullableExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KPropExpression
-import org.babyfish.jimmer.sql.runtime.DbLiteral
 import org.babyfish.jimmer.sql.runtime.ExecutionException
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor
 import org.babyfish.jimmer.sql.runtime.ScalarProvider
@@ -80,7 +78,7 @@ internal class LiteralExpression<T: Any>(
                 return
             }
         }
-        builder.variable(value)
+        builder.variable(Variables.process(value, type, sqlClient))
     }
 
     override fun determineHasVirtualPredicate(): Boolean = false

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/caffeine/CaffeineHashBinder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/caffeine/CaffeineHashBinder.java
@@ -66,7 +66,7 @@ public class CaffeineHashBinder<K, V> extends AbstractTrackingConsumerBinder<K> 
         Lock lock = rwl.writeLock();
         lock.lock();
         try {
-            Map<K, Map<SortedMap<String, Object>, V>> subMapMap = cache.getAllPresent(map.entrySet());
+            Map<K, Map<SortedMap<String, Object>, V>> subMapMap = cache.getAllPresent(map.keySet());
             Map<K, Map<SortedMap<String, Object>, V>> newSubMapMap = new HashMap<>((map.size() * 4 + 2) / 3);
             for (Map.Entry<K, V> e : map.entrySet()) {
                 Map<SortedMap<String, Object>, V> subMap = subMapMap.get(e.getKey());


### PR DESCRIPTION
1. Fix CaffeineHashBinder setAll method
2. Fix LiteralExpression renderTo method (previously it didn't correctly convert `Instant` values)
3. Fix broken `@IdView` properties