### PR TITLE
Register manual connections to ConnectionManager

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/support/SpringConnectionManager.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/support/SpringConnectionManager.java
@@ -1,6 +1,7 @@
 package org.babyfish.jimmer.spring.cfg.support;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import javax.sql.DataSource;
@@ -22,12 +23,14 @@ public class SpringConnectionManager implements DataSourceAwareConnectionManager
     }
 
     @Override
-    public <R> R execute(Function<Connection, R> block) {
-        Connection con = DataSourceUtils.getConnection(dataSource);
+    public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
+        if (con != null) return block.apply(con);
+
+        Connection newConnection = DataSourceUtils.getConnection(dataSource);
         try {
-            return block.apply(con);
+            return block.apply(newConnection);
         } finally {
-            DataSourceUtils.releaseConnection(con, dataSource);
+            DataSourceUtils.releaseConnection(newConnection, dataSource);
         }
     }
 }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
@@ -382,7 +382,7 @@ class KSqlClientDsl constructor(
         private val dslBlock: ConnectionManagerDsl.() -> Unit
     ) : ConnectionManager {
 
-        override fun <R> execute(block: Function<Connection, R>): R =
+        override fun <R> execute(con: Connection?, block: Function<Connection, R>): R =
             ConnectionManagerDsl(block).let {
                 it.dslBlock()
                 it.get()

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/cache/FilterCacheEvictTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/cache/FilterCacheEvictTest.kt
@@ -30,18 +30,7 @@ class FilterCacheEvictTest : AbstractQueryTest() {
         deleteMessages.clear()
         _sqlClient = sqlClient {
             addFilters(CacheableFileFilter())
-            setConnectionManager(
-                object : ConnectionManager {
-                    @Suppress("UNCHECKED_CAST")
-                    override fun <R> execute(block: Function<Connection, R>): R {
-                        val resultBox = arrayOf<Any?>(null) as Array<R?>
-                        jdbc {
-                            resultBox[0] = block.apply(it)
-                        }
-                        return resultBox[0]!!
-                    }
-                }
-            )
+            setConnectionManager(TestConnectionManager())
             setCacheFactory(
                 object : KCacheFactory {
 

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/cache/FilterCacheTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/cache/FilterCacheTest.kt
@@ -5,17 +5,16 @@ import org.babyfish.jimmer.meta.ImmutableType
 import org.babyfish.jimmer.sql.cache.Cache
 import org.babyfish.jimmer.sql.kt.KSqlClient
 import org.babyfish.jimmer.sql.kt.ast.expression.isNull
-import org.babyfish.jimmer.sql.kt.ast.table.isNull
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.common.createCache
 import org.babyfish.jimmer.sql.kt.common.createParameterizedCache
 import org.babyfish.jimmer.sql.kt.filter.common.CacheableFileFilter
 import org.babyfish.jimmer.sql.kt.filter.common.FileFilter
-import org.babyfish.jimmer.sql.kt.model.filter.*
-import org.babyfish.jimmer.sql.runtime.ConnectionManager
-import java.sql.Connection
+import org.babyfish.jimmer.sql.kt.model.filter.File
+import org.babyfish.jimmer.sql.kt.model.filter.fetchBy
+import org.babyfish.jimmer.sql.kt.model.filter.id
+import org.babyfish.jimmer.sql.kt.model.filter.parentId
 import java.util.*
-import java.util.function.Function
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -30,18 +29,7 @@ class FilterCacheTest : AbstractQueryTest() {
         valueMap = mutableMapOf()
         _sqlClient = sqlClient {
             addFilters(CacheableFileFilter())
-            setConnectionManager(
-                object : ConnectionManager {
-                    @Suppress("UNCHECKED_CAST")
-                    override fun <R> execute(block: Function<Connection, R>): R {
-                        val resultBox = arrayOf<Any?>(null) as Array<R?>
-                        jdbc {
-                            resultBox[0] = block.apply(it)
-                        }
-                        return resultBox[0]!!
-                    }
-                }
-            )
+            setConnectionManager(TestConnectionManager())
             setCacheFactory(
                 object : KCacheFactory {
 

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/filter/QueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/filter/QueryTest.kt
@@ -4,27 +4,13 @@ import org.babyfish.jimmer.sql.kt.ast.expression.isNull
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.filter.common.FileFilter
 import org.babyfish.jimmer.sql.kt.model.filter.*
-import org.babyfish.jimmer.sql.runtime.ConnectionManager
-import java.sql.Connection
-import java.util.function.Function
 import kotlin.test.Test
 
 class QueryTest : AbstractQueryTest() {
 
     private val _sqlClient = sqlClient {
         addFilters(FileFilter())
-        setConnectionManager(
-            object : ConnectionManager {
-                @Suppress("UNCHECKED_CAST")
-                override fun <R> execute(block: Function<Connection, R>): R {
-                    val resultBox = arrayOf<Any?>(null) as Array<R?>
-                    jdbc {
-                        resultBox[0] = block.apply(it)
-                    }
-                    return resultBox[0]!!
-                }
-            }
-        )
+        setConnectionManager(TestConnectionManager())
     }
 
     @Test

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/microservice/MicroServiceExchangeImpl.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/microservice/MicroServiceExchangeImpl.kt
@@ -69,9 +69,11 @@ class MicroServiceExchangeImpl() : MicroServiceExchange {
 
         @Suppress("UNCHECKED_CAST")
         private val CONNECTION_MANAGER: ConnectionManager = object : ConnectionManager {
-            override fun <R> execute(block: Function<Connection, R>): R {
+            override fun <R> execute(con: Connection?, block: Function<Connection, R>): R {
                 val ref = arrayOfNulls<Any>(1) as Array<R>
-                AbstractTest.jdbc { con: Connection ->
+                if (con == null) {
+                    AbstractTest.jdbc { ref[0] = block.apply(it) }
+                } else {
                     ref[0] = block.apply(con)
                 }
                 return ref[0]

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
@@ -168,7 +168,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
         this.connectionManager =
                 connectionManager != null ?
                         connectionManager :
-                        ConnectionManager.ILLEGAL;
+                        ConnectionManager.EXTERNAL_ONLY;
         this.slaveConnectionManager = slaveConnectionManager;
         this.dialect = dialect;
         this.executor =

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
@@ -19,7 +19,9 @@ import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.Queries;
 import org.babyfish.jimmer.sql.ast.impl.table.FetcherSelectionImpl;
-import org.babyfish.jimmer.sql.ast.mutation.*;
+import org.babyfish.jimmer.sql.ast.mutation.BatchEntitySaveCommand;
+import org.babyfish.jimmer.sql.ast.mutation.DeleteCommand;
+import org.babyfish.jimmer.sql.ast.mutation.SimpleEntitySaveCommand;
 import org.babyfish.jimmer.sql.ast.query.ConfigurableRootQuery;
 import org.babyfish.jimmer.sql.ast.query.Example;
 import org.babyfish.jimmer.sql.ast.query.Order;
@@ -60,6 +62,14 @@ public class EntitiesImpl implements Entities {
         this.forUpdate = forUpdate;
         this.con = con;
         this.purpose = purpose;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ImmutableType immutableTypeOf(Class<?> type) {
+        if (View.class.isAssignableFrom(type)) {
+            return DtoMetadata.of((Class<? extends View>) type).getFetcher().getImmutableType();
+        }
+        return ImmutableType.get(type);
     }
 
     public JSqlClientImplementor getSqlClient() {
@@ -109,62 +119,32 @@ public class EntitiesImpl implements Entities {
 
     @Override
     public <E> E findById(Class<E> type, Object id) {
-        if (con != null) {
-            return findById(type, id, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findById(type, id, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findById(type, id, con));
     }
 
     @Override
     public <E> List<E> findByIds(Class<E> type, Collection<?> ids) {
-        if (con != null) {
-            return findByIds(type, ids, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findByIds(type, ids, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findByIds(type, ids, con));
     }
 
     @Override
     public <ID, E> Map<ID, E> findMapByIds(Class<E> type, Collection<ID> ids) {
-        if (con != null) {
-            return findMapByIds(type, ids, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findMapByIds(type, ids, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findMapByIds(type, ids, con));
     }
 
     @Override
     public <E> E findById(Fetcher<E> fetcher, Object id) {
-        if (con != null) {
-            return findById(fetcher, id, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findById(fetcher, id, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findById(fetcher, id, con));
     }
 
     @Override
     public <E> List<E> findByIds(Fetcher<E> fetcher, Collection<?> ids) {
-        if (con != null) {
-            return findByIds(fetcher, ids, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findByIds(fetcher, ids, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findByIds(fetcher, ids, con));
     }
 
     @Override
     public <ID, E> Map<ID, E> findMapByIds(Fetcher<E> fetcher, Collection<ID> ids) {
-        if (con != null) {
-            return findMapByIds(fetcher, ids, con);
-        }
-        return sqlClient.getConnectionManager().execute(con ->
-                findMapByIds(fetcher, ids, con)
-        );
+        return sqlClient.getConnectionManager().execute(con, con -> findMapByIds(fetcher, ids, con));
     }
 
     private <E> E findById(Class<E> type, Object id, Connection con) {
@@ -188,9 +168,9 @@ public class EntitiesImpl implements Entities {
         Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
         for (E entity : entities) {
             if (View.class.isAssignableFrom(type)) {
-                map.put((ID)((ImmutableSpi)(((View<?>) entity).toEntity())).__get(idPropId), entity);
+                map.put((ID) ((ImmutableSpi) (((View<?>) entity).toEntity())).__get(idPropId), entity);
             } else {
-                map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
+                map.put((ID) ((ImmutableSpi) entity).__get(idPropId), entity);
             }
         }
         return map;
@@ -214,10 +194,10 @@ public class EntitiesImpl implements Entities {
     private <ID, E> Map<ID, E> findMapByIds(Fetcher<E> fetcher, Collection<ID> ids, Connection con) {
         ImmutableType type = fetcher.getImmutableType();
         PropId idPropId = type.getIdProp().getId();
-        List<E> entities = findByIds((Class<E>)type.getJavaClass(), fetcher, ids, con);
+        List<E> entities = findByIds((Class<E>) type.getJavaClass(), fetcher, ids, con);
         Map<ID, E> map = new LinkedHashMap<>((entities.size() * 4 + 2) / 3);
         for (E entity : entities) {
-            map.put((ID)((ImmutableSpi) entity).__get(idPropId), entity);
+            map.put((ID) ((ImmutableSpi) entity).__get(idPropId), entity);
         }
         return map;
     }
@@ -250,10 +230,10 @@ public class EntitiesImpl implements Entities {
             if (Converters.tryConvert(id, idClass) == null) {
                 throw new IllegalArgumentException(
                         "The type of \"" +
-                                immutableType.getIdProp() +
-                                "\" must be \"" +
-                                idClass.getName() +
-                                "\""
+                        immutableType.getIdProp() +
+                        "\" must be \"" +
+                        idClass.getName() +
+                        "\""
                 );
             }
         }
@@ -296,8 +276,8 @@ public class EntitiesImpl implements Entities {
                                 (ImmutableSpi) Internal.produce(immutableType, spi, draft -> {
                                     for (ImmutableProp prop : immutableType.getProps().values()) {
                                         if (!prop.isView() &&
-                                                spi.__isLoaded(prop.getId()) &&
-                                                !fetcher.getFieldMap().containsKey(prop.getName())) {
+                                            spi.__isLoaded(prop.getId()) &&
+                                            !fetcher.getFieldMap().containsKey(prop.getName())) {
                                             ((DraftSpi) draft).__unload(prop.getId());
                                         }
                                     }
@@ -375,10 +355,10 @@ public class EntitiesImpl implements Entities {
             if (Converters.tryConvert(id, idClass) == null) {
                 throw new IllegalArgumentException(
                         "The type of \"" +
-                                immutableType.getIdProp() +
-                                "\" must be \"" +
-                                idClass.getName() +
-                                "\""
+                        immutableType.getIdProp() +
+                        "\" must be \"" +
+                        idClass.getName() +
+                        "\""
                 );
             }
         }
@@ -421,8 +401,8 @@ public class EntitiesImpl implements Entities {
                                 (ImmutableSpi) Internal.produce(immutableType, spi, draft -> {
                                     for (ImmutableProp prop : immutableType.getProps().values()) {
                                         if (!prop.isView() &&
-                                                spi.__isLoaded(prop.getId()) &&
-                                                !fetcher.getFieldMap().containsKey(prop.getName())) {
+                                            spi.__isLoaded(prop.getId()) &&
+                                            !fetcher.getFieldMap().containsKey(prop.getName())) {
                                             ((DraftSpi) draft).__unload(prop.getId());
                                         }
                                     }
@@ -524,24 +504,24 @@ public class EntitiesImpl implements Entities {
             ImmutableType type,
             Fetcher<E> fetcher,
             ExampleImpl<E> example,
-            TypedProp.Scalar<?, ?> ... sortedProps
+            TypedProp.Scalar<?, ?>... sortedProps
     ) {
         if (fetcher != null && fetcher.getImmutableType() != type) {
             throw new IllegalArgumentException(
                     "The type of fetcher is \"" +
-                            fetcher.getImmutableType() +
-                            "\", it does not match the query root type \"" +
-                            type +
-                            "\""
+                    fetcher.getImmutableType() +
+                    "\", it does not match the query root type \"" +
+                    type +
+                    "\""
             );
         }
         if (example != null && example.type() != type) {
             throw new IllegalArgumentException(
                     "The type of example is \"" +
-                            example.type() +
-                            "\", it does not match the query root type \"" +
-                            type +
-                            "\""
+                    example.type() +
+                    "\", it does not match the query root type \"" +
+                    type +
+                    "\""
             );
         }
         MutableRootQueryImpl<Table<E>> query =
@@ -554,10 +534,10 @@ public class EntitiesImpl implements Entities {
             if (!sortedProp.unwrap().getDeclaringType().isAssignableFrom(type)) {
                 throw new IllegalArgumentException(
                         "The sorted field \"" +
-                                sortedProp +
-                                "\" does not belong to the type \"" +
-                                type +
-                                "\" or its super types"
+                        sortedProp +
+                        "\" does not belong to the type \"" +
+                        type +
+                        "\" or its super types"
                 );
             }
             Expression<?> expr = table.get(sortedProp.unwrap().getName());
@@ -584,7 +564,7 @@ public class EntitiesImpl implements Entities {
     private <V> List<V> find(
             DtoMetadata<?, ?> metadata,
             ExampleImpl<?> example,
-            TypedProp.Scalar<?, ?> ... sortedProps
+            TypedProp.Scalar<?, ?>... sortedProps
     ) {
         Fetcher<?> fetcher = metadata.getFetcher();
         Function<?, V> converter = (Function<?, V>) metadata.getConverter();
@@ -599,10 +579,10 @@ public class EntitiesImpl implements Entities {
             if (!sortedProp.unwrap().getDeclaringType().isAssignableFrom(type)) {
                 throw new IllegalArgumentException(
                         "The sorted field \"" +
-                                sortedProp +
-                                "\" does not belong to the type \"" +
-                                type +
-                                "\" or its super types"
+                        sortedProp +
+                        "\" does not belong to the type \"" +
+                        type +
+                        "\" or its super types"
                 );
             }
             Expression<?> expr = table.get(sortedProp.unwrap().getName());
@@ -633,7 +613,7 @@ public class EntitiesImpl implements Entities {
         if (entity instanceof Input<?>) {
             throw new IllegalArgumentException(
                     "entity cannot be input, " +
-                            "please call another overloaded function whose parameter is input"
+                    "please call another overloaded function whose parameter is input"
             );
         }
         return new SimpleEntitySaveCommandImpl<>(sqlClient, con, entity);
@@ -645,7 +625,7 @@ public class EntitiesImpl implements Entities {
             if (e instanceof Input<?>) {
                 throw new IllegalArgumentException(
                         "the collection cannot contains input, " +
-                                "please call another overloaded function whose parameter is input collection"
+                        "please call another overloaded function whose parameter is input collection"
                 );
             }
         }
@@ -660,7 +640,7 @@ public class EntitiesImpl implements Entities {
         if (id instanceof Collection<?>) {
             throw new IllegalArgumentException("`id` cannot be collection, do you want to call `deleteAll/deleteAllCommand`?");
         }
-        if ((id instanceof ImmutableSpi && ((ImmutableSpi)id).__type().isEntity()) || id instanceof Input<?>) {
+        if ((id instanceof ImmutableSpi && ((ImmutableSpi) id).__type().isEntity()) || id instanceof Input<?>) {
             throw new IllegalArgumentException("`id` must be simple type");
         }
         return batchDeleteCommand(type, Collections.singleton(id));
@@ -673,20 +653,12 @@ public class EntitiesImpl implements Entities {
             Collection<?> ids
     ) {
         for (Object id : ids) {
-            if ((id instanceof ImmutableSpi && ((ImmutableSpi)id).__type().isEntity()) || id instanceof Input<?>) {
+            if ((id instanceof ImmutableSpi && ((ImmutableSpi) id).__type().isEntity()) || id instanceof Input<?>) {
                 throw new IllegalArgumentException("All the elements of `ids` must be simple type");
             }
         }
         ImmutableType immutableType = immutableTypeOf(type);
         return new DeleteCommandImpl(sqlClient, con, immutableType, ids);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static ImmutableType immutableTypeOf(Class<?> type) {
-        if (View.class.isAssignableFrom(type)) {
-            return DtoMetadata.of((Class<? extends View>)type).getFetcher().getImmutableType();
-        }
-        return ImmutableType.get(type);
     }
 }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationExecutable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationExecutable.java
@@ -67,7 +67,7 @@ class AssociationExecutable implements Executable<Integer> {
         this.defaultCheckExistence = defaultCheckExistence;
         this.nullOrCheckedExistence = nullOrCheckedExistence;
         this.idTuples = idTuples instanceof Set<?> ?
-                (Set<Tuple2<?, ?>>)idTuples :
+                (Set<Tuple2<?, ?>>) idTuples :
                 new LinkedHashSet<>(idTuples);
     }
 
@@ -89,26 +89,10 @@ class AssociationExecutable implements Executable<Integer> {
     }
 
     @Override
-    public Integer execute() {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        return sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public Integer execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        if (this.con != null) {
-            return executeImpl(this.con);
-        }
         return sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con == null ? this.con : con, this::executeImpl);
     }
 
     private Integer executeImpl(Connection con) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationSaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationSaveCommandImpl.java
@@ -14,22 +14,11 @@ class AssociationSaveCommandImpl implements AssociationSaveCommand {
     }
 
     @Override
-    public Integer execute() {
-        return executable
-                .sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public Integer execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
         return executable
                 .sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con, this::executeImpl);
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/DeleteCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/DeleteCommandImpl.java
@@ -38,10 +38,10 @@ public class DeleteCommandImpl implements DeleteCommand {
             if (Converters.tryConvert(id, idClass) == null) {
                 throw new IllegalArgumentException(
                         "The type of \"" +
-                                immutableType.getIdProp() +
-                                "\" must be \"" +
-                                idClass.getName() +
-                                "\""
+                        immutableType.getIdProp() +
+                        "\" must be \"" +
+                        idClass.getName() +
+                        "\""
                 );
             }
         }
@@ -74,26 +74,10 @@ public class DeleteCommandImpl implements DeleteCommand {
     }
 
     @Override
-    public DeleteResult execute() {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        return sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public DeleteResult execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        if (this.con != null) {
-            return executeImpl(this.con);
-        }
         return sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con == null ? this.con : con, this::executeImpl);
     }
 
     private DeleteResult executeImpl(Connection con) {
@@ -215,11 +199,11 @@ public class DeleteCommandImpl implements DeleteCommand {
         @Override
         public String toString() {
             return "Data{" +
-                    "sqlClient=" + sqlClient +
-                    ", mode=" + mode +
-                    ", dissociateActionMap=" + dissociateActionMap +
-                    ", frozen=" + frozen +
-                    '}';
+                   "sqlClient=" + sqlClient +
+                   ", mode=" + mode +
+                   ", dissociateActionMap=" + dissociateActionMap +
+                   ", frozen=" + frozen +
+                   '}';
         }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
@@ -1,6 +1,5 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
-import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.PropId;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
@@ -92,20 +91,10 @@ public class MutableDeleteImpl
     }
 
     @Override
-    public Integer execute() {
-        return getSqlClient()
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public Integer execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
         return getSqlClient()
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con, this::executeImpl);
     }
 
     @Override
@@ -137,8 +126,8 @@ public class MutableDeleteImpl
         boolean binLogOnly = sqlClient.getTriggerType() == TriggerType.BINLOG_ONLY;
         DissociationInfo info = sqlClient.getEntityManager().getDissociationInfo(table.getImmutableType());
         boolean directly = table.isEmpty(it -> astContext.getTableUsedState(it) == TableUsedState.USED) &&
-                binLogOnly &&
-                (isDissociationDisabled || info == null || info.isDirectlyDeletable(sqlClient.getMetadataStrategy()));
+                           binLogOnly &&
+                           (isDissociationDisabled || info == null || info.isDirectlyDeletable(sqlClient.getMetadataStrategy()));
 
         if (directly) {
             SqlBuilder builder = new SqlBuilder(astContext);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SimpleEntitySaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SimpleEntitySaveCommandImpl.java
@@ -39,31 +39,15 @@ public class SimpleEntitySaveCommandImpl<E>
     }
 
     @Override
-    public SimpleSaveResult<E> execute() {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        return sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public SimpleSaveResult<E> execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        if (this.con != null) {
-            return executeImpl(this.con);
-        }
         return sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con == null ? this.con : con, this::executeImpl);
     }
 
     private SimpleSaveResult<E> executeImpl(Connection con) {
         data.freeze();
-        Saver saver = new Saver(data, con, ((ImmutableSpi)entity).__type());
+        Saver saver = new Saver(data, con, ((ImmutableSpi) entity).__type());
         return saver.save(entity);
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/filter/impl/FilterManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/filter/impl/FilterManager.java
@@ -309,7 +309,7 @@ public class FilterManager implements Filters {
         if (this.sqlClient != null) {
             throw new IllegalStateException("The filter manager has been initialized");
         }
-        if (sqlClient.getConnectionManager() == ConnectionManager.ILLEGAL) {
+        if (sqlClient.getConnectionManager() == ConnectionManager.EXTERNAL_ONLY) {
             for (Filter<?> filter : allFilters) {
                 if (filter instanceof CacheableFilter<?>) {
                     throw new IllegalStateException(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/graphql/impl/BatchCommand.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/graphql/impl/BatchCommand.java
@@ -44,26 +44,10 @@ class BatchCommand<S, T> implements Executable<Map<S, T>> {
     }
 
     @Override
-    public Map<S, T> execute() {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        return sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public Map<S, T> execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        if (this.con != null) {
-            return executeImpl(this.con);
-        }
         return sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con == null ? this.con : con, this::executeImpl);
     }
 
     @SuppressWarnings("unchecked")

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/graphql/impl/SingleCommand.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/graphql/impl/SingleCommand.java
@@ -49,26 +49,10 @@ class SingleCommand<T> implements Executable<T> {
     }
 
     @Override
-    public T execute() {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        return sqlClient
-                .getConnectionManager()
-                .execute(this::executeImpl);
-    }
-
-    @Override
     public T execute(Connection con) {
-        if (con != null) {
-            return executeImpl(con);
-        }
-        if (this.con != null) {
-            return executeImpl(this.con);
-        }
         return sqlClient
                 .getConnectionManager()
-                .execute(this::executeImpl);
+                .execute(con == null ? this.con : con, this::executeImpl);
     }
 
     @SuppressWarnings("unchecked")

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ConnectionManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ConnectionManager.java
@@ -1,16 +1,45 @@
 package org.babyfish.jimmer.sql.runtime;
 
+import org.jetbrains.annotations.Nullable;
+
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.Objects;
 import java.util.function.Function;
 
 @FunctionalInterface
 public interface ConnectionManager {
 
-    <R> R execute(Function<Connection, R> block);
+    ConnectionManager EXTERNAL_ONLY = new ConnectionManager() {
+        @Override
+        public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
+            Objects.requireNonNull(con, "External connection cannot be null");
+            return block.apply(con);
+        }
+    };
+
+    static ConnectionManager singleConnectionManager(Connection connection) {
+        return new ConnectionManager() {
+            @Override
+            public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
+                return block.apply(con == null ? connection : con);
+            }
+        };
+    }
 
     static ConnectionManager simpleConnectionManager(DataSource dataSource) {
         return new ConnectionManager() {
+            @Override
+            public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
+                try {
+                    return block.apply(con);
+                } catch (RuntimeException | Error ex) {
+                    throw ex;
+                } catch (Throwable ex) {
+                    throw new ExecutionException(ex.getMessage(), ex);
+                }
+            }
+
             @Override
             public <R> R execute(Function<Connection, R> block) {
                 try (Connection con = dataSource.getConnection()) {
@@ -24,10 +53,9 @@ public interface ConnectionManager {
         };
     }
 
-    ConnectionManager ILLEGAL = new ConnectionManager() {
-        @Override
-        public <R> R execute(Function<Connection, R> block) {
-            throw new ExecutionException("ConnectionManager of SqlClient is not configured");
-        }
-    };
+    <R> R execute(@Nullable Connection con, Function<Connection, R> block);
+
+    default <R> R execute(Function<Connection, R> block) {
+        return execute(null, block);
+    }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/CalculationEvictTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/CalculationEvictTest.java
@@ -57,19 +57,7 @@ public class CalculationEvictTest extends AbstractQueryTest {
                         }
                 );
             });
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
         });
     }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/FilterCacheEvictTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/FilterCacheEvictTest.java
@@ -9,17 +9,14 @@ import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.common.ParameterizedCaches;
 import org.babyfish.jimmer.sql.filter.common.CacheableFileFilter;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 
 public class FilterCacheEvictTest extends AbstractQueryTest {
 
@@ -60,19 +57,7 @@ public class FilterCacheEvictTest extends AbstractQueryTest {
                         }
                 );
             });
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
         });
     }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/FilterCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/FilterCacheTest.java
@@ -6,24 +6,20 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.common.ParameterizedCaches;
-import org.babyfish.jimmer.sql.fetcher.RecursiveListFieldConfig;
 import org.babyfish.jimmer.sql.filter.common.CacheableFileFilter;
 import org.babyfish.jimmer.sql.filter.common.FileFilter;
 import org.babyfish.jimmer.sql.model.filter.File;
 import org.babyfish.jimmer.sql.model.filter.FileFetcher;
 import org.babyfish.jimmer.sql.model.filter.FileTable;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class FilterCacheTest extends AbstractQueryTest {
@@ -37,19 +33,7 @@ public class FilterCacheTest extends AbstractQueryTest {
         valueMap = new HashMap<>();
         sqlClient = getSqlClient(it -> {
             it.addFilters(new CacheableFileFilter());
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
             it.setCacheFactory(
                     new CacheFactory() {
                         @Override

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/LogicalDeletedCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/LogicalDeletedCacheTest.java
@@ -5,23 +5,14 @@ import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
-import org.babyfish.jimmer.sql.common.ParameterizedCaches;
-import org.babyfish.jimmer.sql.event.EntityEvent;
-import org.babyfish.jimmer.sql.filter.CacheableFilter;
-import org.babyfish.jimmer.sql.filter.FilterArgs;
 import org.babyfish.jimmer.sql.model.inheritance.*;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.babyfish.jimmer.sql.runtime.LogicalDeletedBehavior;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.function.Function;
 
 public class LogicalDeletedCacheTest extends AbstractQueryTest {
 
@@ -59,19 +50,7 @@ public class LogicalDeletedCacheTest extends AbstractQueryTest {
                         }
                 );
             });
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
         });
         sqlClientForAllData = sqlClient
                 .filters(cfg -> cfg.setBehavior(LogicalDeletedBehavior.IGNORED));

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/LogicalDeletedEvictTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/LogicalDeletedEvictTest.java
@@ -7,21 +7,16 @@ import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
-import org.babyfish.jimmer.sql.common.ParameterizedCaches;
-import org.babyfish.jimmer.sql.event.EntityEvent;
-import org.babyfish.jimmer.sql.filter.CacheableFilter;
-import org.babyfish.jimmer.sql.filter.FilterArgs;
-import org.babyfish.jimmer.sql.model.inheritance.*;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.util.*;
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 public class LogicalDeletedEvictTest extends AbstractQueryTest {
 
@@ -61,19 +56,7 @@ public class LogicalDeletedEvictTest extends AbstractQueryTest {
                         }
                 );
             });
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
         });
     }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/OrganizationEvictTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/OrganizationEvictTest.java
@@ -8,19 +8,15 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.common.ParameterizedCaches;
-import org.babyfish.jimmer.sql.filter.common.CacheableFileFilter;
 import org.babyfish.jimmer.sql.filter.common.OrganizationFilter;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 
 public class OrganizationEvictTest extends AbstractQueryTest {
 
@@ -61,19 +57,7 @@ public class OrganizationEvictTest extends AbstractQueryTest {
                         }
                 );
             });
-            it.setConnectionManager(
-                    new ConnectionManager() {
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public <R> R execute(Function<Connection, R> block) {
-                            R[] resultBox = (R[])new Object[1];
-                            jdbc(con -> {
-                                resultBox[0] = block.apply(con);
-                            });
-                            return resultBox[0];
-                        }
-                    }
-            );
+            it.setConnectionManager(testConnectionManager());
         });
     }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
@@ -205,6 +205,10 @@ public class AbstractTest extends Tests {
         }
     }
 
+    public static ConnectionManager testConnectionManager() {
+        return new TestConnectionManager();
+    }
+
     public static void jdbc(SqlConsumer<Connection> block) {
         jdbc(null, false, block);
     }
@@ -367,6 +371,20 @@ public class AbstractTest extends Tests {
                 BiConsumer<MutableSubQuery, AssociationTable<SE, ST, TE, TT>> block
         ) {
             return Queries.createAssociationWildSubQuery(parent, sourceTableType, targetTableGetter, block);
+        }
+    }
+
+    public static class TestConnectionManager implements ConnectionManager {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
+            R[] resultBox = (R[]) new Object[1];
+            if (con == null) {
+                jdbc(c -> resultBox[0] = block.apply(c));
+            } else {
+                resultBox[0] = block.apply(con);
+            }
+            return resultBox[0];
         }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/filter/QueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/filter/QueryTest.java
@@ -3,38 +3,22 @@ package org.babyfish.jimmer.sql.filter;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.ast.table.AssociationTable;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
-import org.babyfish.jimmer.sql.fetcher.RecursiveListFieldConfig;
 import org.babyfish.jimmer.sql.filter.common.FileFilter;
 import org.babyfish.jimmer.sql.model.filter.*;
 import org.babyfish.jimmer.sql.model.inheritance.Permission;
 import org.babyfish.jimmer.sql.model.inheritance.RoleFetcher;
 import org.babyfish.jimmer.sql.model.inheritance.RoleTable;
-import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.babyfish.jimmer.sql.runtime.LogicalDeletedBehavior;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 public class QueryTest extends AbstractQueryTest {
 
     private JSqlClient sqlClient = getSqlClient(it -> {
         it.addFilters(new FileFilter());
-        it.setConnectionManager(
-                new ConnectionManager() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public <R> R execute(Function<Connection, R> block) {
-                        R[] resultBox = (R[])new Object[1];
-                        jdbc(con -> {
-                            resultBox[0] = block.apply(con);
-                        });
-                        return resultBox[0];
-                    }
-                }
-        );
+        it.setConnectionManager(testConnectionManager());
     });
 
     @SuppressWarnings("unchecked")

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/formatter/AbstractFormatterTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/formatter/AbstractFormatterTest.java
@@ -32,14 +32,7 @@ public abstract class AbstractFormatterTest extends AbstractTest {
         con.setAutoCommit(false);
         sqlClient = JSqlClient
                 .newBuilder()
-                .setConnectionManager(
-                        new ConnectionManager() {
-                            @Override
-                            public <R> R execute(Function<Connection, R> block) {
-                                return block.apply(con);
-                            }
-                        }
-                )
+                .setConnectionManager(ConnectionManager.singleConnectionManager(con))
                 .setExecutor(
                         new Executor() {
                             @Override

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/json/AbstractJsonTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/json/AbstractJsonTest.java
@@ -38,14 +38,7 @@ public abstract class AbstractJsonTest {
         con.setAutoCommit(false);
         sqlClient = JSqlClient
                 .newBuilder()
-                .setConnectionManager(
-                        new ConnectionManager() {
-                            @Override
-                            public <R> R execute(Function<Connection, R> block) {
-                                return block.apply(con);
-                            }
-                        }
-                )
+                .setConnectionManager(ConnectionManager.singleConnectionManager(con))
                 .setExecutor(
                         new Executor() {
                             @Override

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/microservice/MicroServiceExchangeImpl.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/microservice/MicroServiceExchangeImpl.java
@@ -4,31 +4,19 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
-import org.babyfish.jimmer.sql.common.AbstractTest;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
 import org.babyfish.jimmer.sql.runtime.ConnectionManager;
 import org.babyfish.jimmer.sql.runtime.MicroServiceExchange;
 import org.babyfish.jimmer.sql.runtime.MicroServiceExporter;
 
-import java.sql.Connection;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
+
+import static org.babyfish.jimmer.sql.common.AbstractTest.testConnectionManager;
 
 public class MicroServiceExchangeImpl implements MicroServiceExchange {
 
-    private static final ConnectionManager CONNECTION_MANAGER =
-            new ConnectionManager() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public <R> R execute(Function<Connection, R> block) {
-                    R[] ref = (R[])new Object[1];
-                    AbstractTest.jdbc(con -> {
-                        ref[0] = block.apply(con);
-                    });
-                    return ref[0];
-                }
-            };
+    private static final ConnectionManager CONNECTION_MANAGER = testConnectionManager();
 
     private final JSqlClient orderClient =
             JSqlClient

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/EntityTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/EntityTest.java
@@ -4,8 +4,6 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.model.AuthorFetcher;
 import org.babyfish.jimmer.sql.model.Book;
-import static org.babyfish.jimmer.sql.common.Constants.*;
-
 import org.babyfish.jimmer.sql.model.BookFetcher;
 import org.babyfish.jimmer.sql.model.BookStoreFetcher;
 import org.babyfish.jimmer.sql.runtime.ConnectionManager;
@@ -13,7 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.util.Arrays;
-import java.util.function.Function;
+
+import static org.babyfish.jimmer.sql.common.Constants.*;
 
 public class EntityTest extends AbstractQueryTest {
 
@@ -335,13 +334,6 @@ public class EntityTest extends AbstractQueryTest {
     }
 
     private JSqlClient getSqlClient(Connection con) {
-        return getSqlClient(builder -> {
-            builder.setConnectionManager(new ConnectionManager() {
-                @Override
-                public <R> R execute(Function<Connection, R> block) {
-                    return block.apply(con);
-                }
-            });
-        });
+        return getSqlClient(builder -> builder.setConnectionManager(ConnectionManager.singleConnectionManager(con)));
     }
 }


### PR DESCRIPTION
All queries goes through ConnectionManager including queries with external connection.
I tried to make as little breaking changes as possible, but it looks like ConnectionManager is not the best name for the new abstraction anymore.
I think `JdbcExecutor` will be better.