### PR TITLE
Add a switch for investigating constraint violation and improve relative tip logs

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
@@ -171,6 +171,9 @@ class JSpringSqlClient extends JLazyInitializationSqlClient {
         builder.addDraftPreProcessors(processors);
         builder.addDraftInterceptors(interceptors);
         builder.addExceptionTranslators(exceptionTranslators);
+        if (properties.getInvestigateConstraintViolationEnabled() != null) {
+            builder.setInvestigateConstraintViolationEnabled(properties.getInvestigateConstraintViolationEnabled());
+        }
         initializeByLanguage(builder);
         builder.addInitializers(new SpringEventInitializer(ctx));
 

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
@@ -76,6 +76,8 @@ public class JimmerProperties {
     @NotNull
     private final ErrorTranslator errorTranslator;
 
+    private final Boolean investigateConstraintViolationEnabled;
+
     @NotNull
     private final Client client;
 
@@ -104,6 +106,7 @@ public class JimmerProperties {
             @Nullable Collection<String> executorContextPrefixes,
             @Nullable String microServiceName,
             @Nullable ErrorTranslator errorTranslator,
+            @Nullable Boolean investigateConstraintViolationEnabled,
             @Nullable Client client) {
         if (language == null) {
             this.language = "java";
@@ -233,6 +236,7 @@ public class JimmerProperties {
         } else {
             this.errorTranslator = errorTranslator;
         }
+        this.investigateConstraintViolationEnabled = investigateConstraintViolationEnabled;
         if (client == null) {
             this.client = new Client(null, false, null, null);
         } else {
@@ -392,6 +396,14 @@ public class JimmerProperties {
         return errorTranslator;
     }
 
+    /**
+     * This property is nullable, to distinguish whether it is set explicitly or not.
+     */
+    @Nullable
+    public Boolean getInvestigateConstraintViolationEnabled() {
+        return investigateConstraintViolationEnabled;
+    }
+
     @NotNull
     public Client getClient() {
         return client;
@@ -423,6 +435,7 @@ public class JimmerProperties {
                 ", executorContextPrefixes=" + executorContextPrefixes +
                 ", microServiceName='" + microServiceName + '\'' +
                 ", errorTranslator=" + errorTranslator +
+                ", investigateConstraintViolationEnabled=" + investigateConstraintViolationEnabled +
                 ", client=" + client +
                 '}';
     }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
@@ -83,6 +83,10 @@ class KSqlClientDsl constructor(
         javaBuilder.addExceptionTranslators(translators)
     }
 
+    fun setInvestigateConstraintViolationEnabled(enabled: Boolean) {
+        javaBuilder.setInvestigateConstraintViolationEnabled(enabled)
+    }
+
     fun setConnectionManager(block: ConnectionManagerDsl.() -> Unit) {
         javaBuilder.setConnectionManager(ConnectionManagerImpl(block))
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
@@ -495,6 +495,9 @@ public interface JSqlClient extends SubQueryProvider {
         Builder addExceptionTranslators(Collection<ExceptionTranslator<?>> translators);
 
         @OldChain
+        Builder setInvestigateConstraintViolationEnabled(boolean enabled);
+
+        @OldChain
         Builder addCustomizers(Customizer ... customizers);
 
         @OldChain

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
@@ -93,6 +93,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
 
     private final ExceptionTranslator<Exception> exceptionTranslator;
 
+    private final Boolean investigateConstraintViolationEnabled;
+
     private final EntitiesImpl entities;
 
     private final EntityManager entityManager;
@@ -152,6 +154,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
             int maxCommandJoinCount,
             boolean targetTransferable,
             ExceptionTranslator<Exception> exceptionTranslator,
+            Boolean investigateConstraintViolationEnabled,
             EntitiesImpl entities,
             EntityManager entityManager,
             Caches caches,
@@ -198,6 +201,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
         this.maxCommandJoinCount = maxCommandJoinCount;
         this.targetTransferable = targetTransferable;
         this.exceptionTranslator = exceptionTranslator;
+        this.investigateConstraintViolationEnabled = investigateConstraintViolationEnabled;
         this.entities =
                 entities != null ?
                         entities.forSqlClient(this) :
@@ -369,6 +373,11 @@ class JSqlClientImpl implements JSqlClientImplementor {
     }
 
     @Override
+    public Boolean getInvestigateConstraintViolationEnabled() {
+        return investigateConstraintViolationEnabled;
+    }
+
+    @Override
     public <T extends TableProxy<?>> MutableRootQuery<T> createQuery(T table) {
         if (table instanceof TableEx<?>) {
             throw new IllegalArgumentException("Top-level query does not support TableEx");
@@ -529,6 +538,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 maxCommandJoinCount,
                 targetTransferable,
                 exceptionTranslator,
+                investigateConstraintViolationEnabled,
                 entities,
                 entityManager,
                 new CachesImpl((CachesImpl) caches, cfg),
@@ -579,6 +589,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 maxCommandJoinCount,
                 targetTransferable,
                 exceptionTranslator,
+                investigateConstraintViolationEnabled,
                 entities,
                 entityManager,
                 caches,
@@ -624,6 +635,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 maxCommandJoinCount,
                 targetTransferable,
                 exceptionTranslator,
+                investigateConstraintViolationEnabled,
                 entities,
                 entityManager,
                 caches,
@@ -672,6 +684,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 maxCommandJoinCount,
                 targetTransferable,
                 exceptionTranslator,
+                investigateConstraintViolationEnabled,
                 entities,
                 entityManager,
                 caches,
@@ -860,6 +873,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
         private boolean targetTransferable;
 
         private final Set<ExceptionTranslator<?>> exceptionTranslators = new LinkedHashSet<>();
+
+        private Boolean investigateConstraintViolationEnabled = null;
 
         private final Set<Customizer> customizers = new LinkedHashSet<>();
 
@@ -1428,6 +1443,12 @@ class JSqlClientImpl implements JSqlClientImplementor {
         }
 
         @Override
+        public JSqlClient.Builder setInvestigateConstraintViolationEnabled(boolean enabled) {
+            this.investigateConstraintViolationEnabled = enabled;
+            return this;
+        }
+
+        @Override
         public Builder addCustomizers(Customizer... customizers) {
             for (Customizer customizer : customizers) {
                 if (customizer != null) {
@@ -1605,6 +1626,7 @@ class JSqlClientImpl implements JSqlClientImplementor {
                     maxCommandJoinCount,
                     targetTransferable,
                     ExceptionTranslator.of(exceptionTranslators),
+                    investigateConstraintViolationEnabled,
                     null,
                     entityManager(),
                     caches,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
@@ -368,6 +368,11 @@ public abstract class AbstractJSqlClientDelegate implements JSqlClientImplemento
     }
 
     @Override
+    public Boolean getInvestigateConstraintViolationEnabled() {
+        return sqlClient().getInvestigateConstraintViolationEnabled();
+    }
+
+    @Override
     public TransientResolver<?, ?> getResolver(ImmutableProp prop) {
         return sqlClient().getResolver(prop);
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -125,7 +125,9 @@ public class DefaultExecutor implements Executor {
                 ExecutorContext executorContext,
                 JSqlClientImplementor sqlClient
         ) {
-            if (sqlClient.getDialect().isTransactionAbortedByError()) {
+            if (Boolean.TRUE.equals(sqlClient.getInvestigateConstraintViolationEnabled())
+                    && sqlClient.getDialect().isTransactionAbortedByError()
+            ) {
                 try {
                     savepoint = con.getAutoCommit() ? null : con.setSavepoint();
                 } catch (SQLException ex) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JSqlClientImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JSqlClientImplementor.java
@@ -76,6 +76,8 @@ public interface JSqlClientImplementor extends JSqlClient, SqlContext {
     @Nullable
     ExceptionTranslator<Exception> getExceptionTranslator();
 
+    Boolean getInvestigateConstraintViolationEnabled();
+
     TransientResolver<?, ?> getResolver(ImmutableProp prop);
 
     StrategyProvider<UserIdGenerator<?>> getUserIdGeneratorProvider();

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
@@ -67,6 +67,7 @@ public class AbstractTest extends Tests {
     private JSqlClient sqlClient = getSqlClient(it -> {
         UserIdGenerator<?> idGenerator = this::autoId;
         it.setIdGenerator(idGenerator);
+        it.setInvestigateConstraintViolationEnabled(true);
     });
 
     private LambdaClient lambdaClient = new LambdaClient(getSqlClient());


### PR DESCRIPTION
## Background

While Jimmer’s feature of investigating constraint violations greatly facilitates debugging and make functions like automatic retries in specific scenarios more easier to be implemented, it can impose unexpected and uncontrollable query loads on the database during large-scale data insertions. Therefore, I think this feature:

- should be user-controllable
- should be disabled by default 

to minimize the risk of production incidents caused by unexpected query loads, and let users take the blame for them. 

Additionally, Jimmer’s current behavior is inconsistent for databases that abort transactions upon errors (these databases do not investigate without an active transaction, while the others investigate constraint violations under any circumstances) and lacks notifications. Providing such notifications would enhance user-friendliness.

## Modification

1. Add a `Boolean` property `investigateConstraintViolationEnabled` to `SqlClient`. When set to `true`, the investigation feature is enabled; when set to `false`, it is disabled. If set to `null`, it indicates that the setting is not explicitly configured (default is disabled).
2. Add the above property to the Spring Boot application properties.
3. When this feature is not enabled, do not set a savepoint or conduct an investigation; directly execute `convertFinalException`.
4. If the user has not explicitly set `investigateConstraintViolationEnabled` and a constraint violation exception occurs, issue a warning log prompting the user to explicitly set this value.
5. If the user enables this feature and is using a database that aborts transactions upon errors, and the transaction is not activated, issue a warning log prompting the user to activate a transaction.