### PR TITLE
Fix Postgres insert on conflict optimistic lock condition

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MiddleTableOperator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MiddleTableOperator.java
@@ -842,7 +842,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
         }
 
         @Override
-        public Dialect.UpsertContext appendOptimisticLockCondition() {
+        public Dialect.UpsertContext appendOptimisticLockCondition(String prefix, String suffix) {
             return this;
         }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -902,11 +902,13 @@ class Operator {
         }
 
         @Override
-        public Dialect.UpsertContext appendOptimisticLockCondition() {
+        public Dialect.UpsertContext appendOptimisticLockCondition(String prefix, String suffix) {
             if (userOptimisticLockPredicate != null) {
                 ((Ast)userOptimisticLockPredicate).renderTo(builder);
             } if (versionGetter != null) {
-                builder.sql(versionGetter)
+                builder.sql(prefix)
+                        .sql(versionGetter)
+                        .sql(suffix)
                         .sql(" = ")
                         .variable(versionGetter);
             }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -174,7 +174,7 @@ public interface Dialect extends SqlTypeStrategy {
         UpsertContext appendConflictColumns();
         UpsertContext appendInsertingValues();
         UpsertContext appendUpdatingAssignments(String prefix, String suffix);
-        UpsertContext appendOptimisticLockCondition();
+        UpsertContext appendOptimisticLockCondition(String prefix, String suffix);
         UpsertContext appendGeneratedId();
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
@@ -205,7 +205,7 @@ public class PostgresDialect extends DefaultDialect {
         if (ctx.hasUpdatedColumns()) {
             ctx.sql(" do update set ").appendUpdatingAssignments("excluded.", "");
             if (ctx.hasOptimisticLock()) {
-                ctx.sql(" where ").appendOptimisticLockCondition();
+                ctx.sql(" where ").appendOptimisticLockCondition("excluded.", "");
             }
             if (ctx.hasGeneratedId()) {
                 ctx.sql(" returning ").appendGeneratedId();


### PR DESCRIPTION
version column name is ambiguous, it should be prefixed with `excluded`.