### PR TITLE
Support custom json ScalarProvider without dependency to vendor driver

### DIFF
--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/PointProvider.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/PointProvider.kt
@@ -2,18 +2,16 @@ package org.babyfish.jimmer.sql.kt.model.pg
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.babyfish.jimmer.sql.runtime.ScalarProvider
-import org.postgresql.util.PGobject
 
-class PointProvider : ScalarProvider<Point, PGobject> {
+class PointProvider : ScalarProvider<Point, String> {
 
-    override fun toScalar(sqlValue: PGobject): Point =
-        MAPPER.readValue(sqlValue.value, Point::class.java)
+    override fun toScalar(sqlValue: String): Point =
+        MAPPER.readValue(sqlValue, Point::class.java)
 
-    override fun toSql(scalarValue: Point): PGobject =
-        PGobject().apply {
-            type = "jsonb"
-            value = MAPPER.writeValueAsString(scalarValue)
-        }
+    override fun toSql(scalarValue: Point): String =
+        MAPPER.writeValueAsString(scalarValue)
+
+    override fun isJsonScalar(): Boolean = true
 
     companion object {
 

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/ScoresProvider.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/ScoresProvider.kt
@@ -5,18 +5,16 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.babyfish.jimmer.kt.toImmutableProp
 import org.babyfish.jimmer.meta.ImmutableProp
 import org.babyfish.jimmer.sql.runtime.ScalarProvider
-import org.postgresql.util.PGobject
 
-class ScoresProvider : ScalarProvider<Map<Long, Int>, PGobject> {
+class ScoresProvider : ScalarProvider<Map<Long, Int>, String> {
 
-    override fun toScalar(sqlValue: PGobject): Map<Long, Int> =
-        MAPPER.readValue(sqlValue.value, TYPE_REFERENCE)
+    override fun toScalar(sqlValue: String): Map<Long, Int> =
+        MAPPER.readValue(sqlValue, TYPE_REFERENCE)
 
-    override fun toSql(scalarValue: Map<Long, Int>): PGobject =
-        PGobject().apply {
-            type = "jsonb"
-            value = MAPPER.writeValueAsString(scalarValue)
-        }
+    override fun toSql(scalarValue: Map<Long, Int>): String =
+        MAPPER.writeValueAsString(scalarValue)
+
+    override fun isJsonScalar(): Boolean = true
 
     override fun getHandledProps(): Collection<ImmutableProp> =
         listOf(JsonWrapper::scores.toImmutableProp())

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/TagsProvider.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/pg/TagsProvider.kt
@@ -1,23 +1,20 @@
 package org.babyfish.jimmer.sql.kt.model.pg
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.babyfish.jimmer.kt.toImmutableProp
 import org.babyfish.jimmer.meta.ImmutableProp
 import org.babyfish.jimmer.sql.runtime.ScalarProvider
-import org.postgresql.util.PGobject
 
-class TagsProvider : ScalarProvider<List<String>, PGobject> {
+class TagsProvider : ScalarProvider<List<String>, String> {
 
-    override fun toScalar(sqlValue: PGobject): List<String> =
-        MAPPER.readValue(sqlValue.value, TYPE_REFERENCE)
+    override fun toScalar(sqlValue: String): List<String> =
+        MAPPER.readValue(sqlValue, TYPE_REFERENCE)
 
-    override fun toSql(scalarValue: List<String>): PGobject =
-        PGobject().apply {
-            type = "jsonb"
-            value = MAPPER.writeValueAsString(scalarValue)
-        }
+    override fun toSql(scalarValue: List<String>): String =
+        MAPPER.writeValueAsString(scalarValue)
+
+    override fun isJsonScalar(): Boolean = true
 
     override fun getHandledProps(): Collection<ImmutableProp> =
         listOf(JsonWrapper::tags.toImmutableProp())

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/H2MutationTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/H2MutationTest.kt
@@ -42,7 +42,7 @@ class H2MutationTest : AbstractMutationTest() {
             statement {
                 sql(
                     """insert into MACHINE(ID, HOST, PORT, factory_map, patent_map) 
-                    |values(?, ?, ?, ? format json, ? format json)""".trimMargin()
+                    |values(?, ?, ?, ?, ?)""".trimMargin()
                 )
             }
             statement {
@@ -95,7 +95,7 @@ class H2MutationTest : AbstractMutationTest() {
             statement {
                 sql(
                     """update MACHINE 
-                        |set patent_map = ? format json 
+                        |set patent_map = ? 
                         |where ID = ?""".trimMargin()
                 )
             }

--- a/project/jimmer-sql/build.gradle.kts
+++ b/project/jimmer-sql/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.jetbrains.annotations)
     implementation(libs.apache.commons.lang3)
     implementation(libs.jackson.datatype.jsr310)
+    compileOnly(libs.h2)
     compileOnly(libs.postgresql)
     compileOnly(libs.jackson.module.kotlin)
     compileOnly(libs.caffeine)

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderManager.java
@@ -241,29 +241,22 @@ class ScalarProviderManager implements ScalarTypeStrategy {
     }
 
     @SuppressWarnings("unchecked")
-    private ScalarProvider<?, ?> createJsonProvider(Class<?> type, JavaType javaType, ObjectMapper objectMapper) {
-        return new AbstractScalarProvider<Object, Object>(
+    private ScalarProvider<?, String> createJsonProvider(Class<?> type, JavaType javaType, ObjectMapper objectMapper) {
+        return new AbstractScalarProvider<Object, String>(
                 (Class<Object>) type,
-                (Class<Object>) dialect.getJsonBaseType()
+                String.class
         ) {
 
+            private final ObjectMapper mapper = objectMapper != null ? objectMapper : DEFAULT_OBJECT_MAPPER;
+
             @Override
-            public @NotNull Object toScalar(@NotNull Object sqlValue) throws Exception {
-                if (!dialect.getJsonBaseType().isAssignableFrom(sqlValue.getClass())) {
-                    throw new IllegalArgumentException(
-                            "The type of the sql value is not the json base type \"" +
-                                    dialect.getJsonBaseType().getName() +
-                                    "\" of the dialect \"" +
-                                    dialect.getClass().getName() +
-                                    "\""
-                    );
-                }
-                return dialect.baseValueToJson(sqlValue, javaType, objectMapper != null ? objectMapper : DEFAULT_OBJECT_MAPPER);
+            public @NotNull Object toScalar(@NotNull String sqlValue) throws Exception {
+                return mapper.readValue(sqlValue, javaType);
             }
 
             @Override
-            public @NotNull Object toSql(@NotNull Object scalarValue) throws Exception {
-                return dialect.jsonToBaseValue(scalarValue, objectMapper != null ? objectMapper : DEFAULT_OBJECT_MAPPER);
+            public @NotNull String toSql(@NotNull Object scalarValue) throws Exception {
+                return mapper.writeValueAsString(scalarValue);
             }
 
             @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderUtils.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderUtils.java
@@ -1,0 +1,16 @@
+package org.babyfish.jimmer.sql;
+
+import org.babyfish.jimmer.sql.dialect.Dialect;
+import org.babyfish.jimmer.sql.runtime.ScalarProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ScalarProviderUtils {
+    @Nullable
+    public static <T> Object toSql(@NotNull T literal,
+                                   @NotNull ScalarProvider<T, ?> scalarProvider,
+                                   @NotNull Dialect dialect) throws Exception {
+        Object sqlValue = scalarProvider.toSql(literal);
+        return scalarProvider.isJsonScalar() ? dialect.jsonToBaseValue((String) sqlValue) : sqlValue;
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Literals.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Literals.java
@@ -14,6 +14,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
+
 public class Literals {
 
     private Literals() {}
@@ -68,7 +70,7 @@ public class Literals {
             List<Object> newLiterals = new ArrayList<>(literals.size());
             for (Object literal : literals) {
                 try {
-                    newLiterals.add(literal != null ? scalarProvider.toSql(literal) : null);
+                    newLiterals.add(literal != null ? toSql(literal, scalarProvider, sqlClient.getDialect()) : null);
                 } catch (Exception ex) {
                     throw new ExecutionException(
                             "Cannot convert the value \"" +
@@ -112,7 +114,7 @@ public class Literals {
                                 ScalarProvider<Object, Object> scalarProvider = scalarProviders[index];
                                 if (scalarProvider != null) {
                                     try {
-                                        return scalarProvider.toSql(value);
+                                        return toSql(literal, scalarProvider, sqlClient.getDialect());
                                     } catch (Exception ex) {
                                         throw new ExecutionException(
                                                 "Cannot convert the tuple item[" +
@@ -208,7 +210,7 @@ public class Literals {
                 ScalarProvider<Object, Object> scalarProvider = sqlClient.getScalarProvider(matchedProp);
                 if (scalarProvider != null) {
                     try {
-                        return scalarProvider.toSql(value);
+                        return toSql(value, scalarProvider, sqlClient.getDialect());
                     } catch (Exception ex) {
                         throw new ExecutionException(
                                 "Cannot convert the value \"" +
@@ -229,7 +231,7 @@ public class Literals {
                             sqlClient.getScalarProvider(prop);
                     if (scalarProvider != null) {
                         try {
-                            return scalarProvider.toSql(it);
+                            return toSql(it, scalarProvider, sqlClient.getDialect());
                         } catch (Exception ex) {
                             throw new ExecutionException(
                                     "Cannot convert the tuple item[" +

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Variables.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Variables.java
@@ -16,8 +16,9 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Array;
 import java.sql.Timestamp;
 import java.time.*;
-import java.util.Arrays;
 import java.util.Collection;
+
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
 
 public class Variables {
 
@@ -52,7 +53,7 @@ public class Variables {
             ScalarProvider<Object, Object> scalarProvider = sqlClient.getScalarProvider(prop);
             if (scalarProvider != null && value != null) {
                 try {
-                    value = scalarProvider.toSql(value);
+                    value = toSql(value, scalarProvider, sqlClient.getDialect());
                 } catch (Exception ex) {
                     throw new ExecutionException(
                             "The value \"" +
@@ -112,7 +113,7 @@ public class Variables {
         }
         if (scalarProvider != null) {
             try {
-                return ((ScalarProvider<Object, Object>)scalarProvider).toSql(value);
+                return toSql(value, (ScalarProvider<Object, Object>) scalarProvider, sqlClient.getDialect());
             } catch (Exception e) {
                 throw new ExecutionException(
                         "Cannot convert \"" +

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/render/BatchSqlBuilder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/render/BatchSqlBuilder.java
@@ -25,19 +25,9 @@ public class BatchSqlBuilder extends AbstractSqlBuilder<BatchSqlBuilder> {
 
     final JSqlClientImplementor sqlClient;
 
-    private final String jsonSuffix;
 
     public BatchSqlBuilder(JSqlClientImplementor sqlClient) {
-        String jsonSuffix = sqlClient.getDialect().getJsonLiteralSuffix();
-        if (jsonSuffix != null) {
-            if (jsonSuffix.isEmpty()) {
-                jsonSuffix = null;
-            } else {
-                jsonSuffix = ' ' + jsonSuffix;
-            }
-        }
         this.sqlClient = sqlClient;
-        this.jsonSuffix = jsonSuffix;
     }
 
     @Override
@@ -47,14 +37,12 @@ public class BatchSqlBuilder extends AbstractSqlBuilder<BatchSqlBuilder> {
 
     public BatchSqlBuilder variable(ValueGetter getter) {
         sql("?");
-        appendJsonSuffix(getter.metadata().isJson());
         templateVariables.add(new GetterVariable(getter));
         return this;
     }
 
     public BatchSqlBuilder defaultVariable(ValueGetter getter) {
         sql("?");
-        appendJsonSuffix(getter.metadata().isJson());
         templateVariables.add(new DefaultVariable(getter));
         return this;
     }
@@ -107,12 +95,6 @@ public class BatchSqlBuilder extends AbstractSqlBuilder<BatchSqlBuilder> {
             );
         }
         return variable(PropertyGetter.propertyGetters(sqlClient, prop).get(0));
-    }
-
-    private void appendJsonSuffix(boolean isJson) {
-        if (jsonSuffix != null && isJson) {
-            sql(jsonSuffix);
-        }
     }
 
     public Tuple2<String, VariableMapper> build() {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -1,7 +1,5 @@
 package org.babyfish.jimmer.sql.dialect;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.value.ValueGetter;
 import org.babyfish.jimmer.sql.meta.SqlTypeStrategy;
@@ -64,16 +62,9 @@ public interface Dialect extends SqlTypeStrategy {
     @Nullable
     default String getConstantTableName() { return null; }
 
-    default Class<?> getJsonBaseType() {
-        return String.class;
-    }
-
-    default Object jsonToBaseValue(Object json, ObjectMapper objectMapper) throws Exception {
-        return objectMapper.writeValueAsString(json);
-    }
-
-    default Object baseValueToJson(Object baseValue, JavaType javaType, ObjectMapper objectMapper) throws Exception {
-        return objectMapper.readValue((String) baseValue, javaType);
+    @Nullable
+    default Object jsonToBaseValue(@Nullable String json) throws Exception {
+        return json;
     }
 
     default boolean isForeignKeySupported() {
@@ -86,12 +77,11 @@ public interface Dialect extends SqlTypeStrategy {
         return Types.OTHER;
     }
 
-    default Reader<?> unknownReader(Class<?> sqlType) {
-        return null;
+    default Reader<String> jsonReader() {
+        return (rs, ctx) -> rs.getString(ctx.col());
     }
 
-    @Nullable
-    default String getJsonLiteralSuffix() {
+    default Reader<?> unknownReader(Class<?> sqlType) {
         return null;
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.dialect;
 
+import org.h2.value.ValueJson;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
@@ -93,9 +94,10 @@ public class H2Dialect extends DefaultDialect {
         return "select nextval('" + sequenceName + "')";
     }
 
+    @Nullable
     @Override
-    public @Nullable String getJsonLiteralSuffix() {
-        return "format json";
+    public Object jsonToBaseValue(@Nullable String json) throws Exception {
+        return json == null ? null : ValueJson.fromJson(json);
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/AbstractScalarProvider.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/AbstractScalarProvider.java
@@ -55,6 +55,7 @@ public abstract class AbstractScalarProvider<T, S> implements ScalarProvider<T, 
 
     public AbstractScalarProvider(Class<T> scalarType, Class<S> sqlType) {
         Meta.validateScalarType(scalarType);
+        validateSqlType(sqlType);
         this.scalarType = scalarType;
         this.sqlType = sqlType;
     }
@@ -74,5 +75,15 @@ public abstract class AbstractScalarProvider<T, S> implements ScalarProvider<T, 
     @NotNull
     public final Class<S> getSqlType() {
         return sqlType;
+    }
+
+    private void validateSqlType(Class<S> sqlType) {
+        if (isJsonScalar() && !String.class.equals(sqlType)) {
+            throw new IllegalArgumentException(
+                    "Illegal sql type \"" +
+                    sqlType.getName() +
+                    "\", json scalar provider must have String sql type"
+            );
+        }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DbLiteral.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DbLiteral.java
@@ -5,6 +5,8 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import java.sql.PreparedStatement;
 import java.util.Objects;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
+
 public interface DbLiteral {
 
     Class<?> getType();
@@ -90,18 +92,6 @@ public interface DbLiteral {
         }
 
         @Override
-        public void render(StringBuilder builder, JSqlClientImplementor sqlClient) {
-            builder.append('?');
-            String suffix = sqlClient.getDialect().getJsonLiteralSuffix();
-            if (value != null && suffix != null) {
-                ScalarProvider<?, ?> scalarProvider = sqlClient.getScalarProvider(prop);
-                if (scalarProvider != null && scalarProvider.isJsonScalar()) {
-                    builder.append(' ').append(suffix);
-                }
-            }
-        }
-
-        @Override
         public void renderValue(StringBuilder builder) {
             if (value instanceof Number) {
                 builder.append("null");
@@ -126,7 +116,7 @@ public interface DbLiteral {
                 scalarProvider = sqlClient.getScalarProvider(prop);
                 if (scalarProvider != null) {
                     try {
-                        value = scalarProvider.toSql(value);
+                        value = toSql(value, scalarProvider, sqlClient.getDialect());
                     } catch (Exception ex) {
                         throw new ExecutionException(
                                 "The value \"" +

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
+
 public class DefaultExecutor implements Executor {
 
     public static final DefaultExecutor INSTANCE = new DefaultExecutor();
@@ -253,7 +255,7 @@ public class DefaultExecutor implements Executor {
                 while (rs.next()) {
                     Object id = rs.getObject(1, sqlType);
                     if (id != null && provider != null) {
-                        id = provider.toSql(id);
+                        id = toSql(id, provider, sqlClient.getDialect());
                     }
                     ids[index++] = id;
                 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/SqlBuilder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/SqlBuilder.java
@@ -16,6 +16,8 @@ import org.babyfish.jimmer.sql.meta.SingleColumn;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
+
 public class SqlBuilder extends AbstractSqlBuilder<SqlBuilder> {
 
     private final AstContext ctx;
@@ -338,7 +340,7 @@ public class SqlBuilder extends AbstractSqlBuilder<SqlBuilder> {
             ctx.getSqlClient().getScalarProvider((Class<Object>) value.getClass());
         if (scalarProvider != null) {
             try {
-                value = scalarProvider.toSql(value);
+                value = toSql(value, scalarProvider, getAstContext().getSqlClient().getDialect());
             } catch (Exception ex) {
                 throw new ExecutionException(
                         "Cannot convert the jvm type \"" +

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/OperatorTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/OperatorTest.java
@@ -25,6 +25,7 @@ import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.babyfish.jimmer.sql.runtime.SaveException;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
+import org.h2.value.ValueJson;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -576,7 +577,7 @@ public class OperatorTest extends AbstractMutationTest {
                                 "merge into MACHINE(" +
                                         "--->HOST, PORT, CPU_FREQUENCY, MEMORY_SIZE, DISK_SIZE, factory_map, patent_map" +
                                         ") key(HOST, PORT) values(" +
-                                        "--->?, ?, ?, ?, ?, ? format json, ? format json" +
+                                        "--->?, ?, ?, ?, ?, ?, ?" +
                                         ")"
                         );
                         it.batchVariables(
@@ -588,12 +589,12 @@ public class OperatorTest extends AbstractMutationTest {
                                 512,
                                 new DbLiteral.DbValue(
                                         MachineDetailProps.FACTORIES.unwrap(),
-                                        "{\"f-a\":\"factory-a\"}",
+                                        ValueJson.fromJson("{\"f-a\":\"factory-a\"}"),
                                         true
                                 ),
                                 new DbLiteral.DbValue(
                                         MachineDetailProps.PATENTS.unwrap(),
-                                        "{\"p-b\":\"patent-b\"}",
+                                        ValueJson.fromJson("{\"p-b\":\"patent-b\"}"),
                                         true
                                 )
                         );
@@ -606,12 +607,12 @@ public class OperatorTest extends AbstractMutationTest {
                                 256,
                                 new DbLiteral.DbValue(
                                         MachineDetailProps.FACTORIES.unwrap(),
-                                        "{\"f-x\":\"factory-x\"}",
+                                        ValueJson.fromJson("{\"f-x\":\"factory-x\"}"),
                                         true
                                 ),
                                 new DbLiteral.DbValue(
                                         MachineDetailProps.PATENTS.unwrap(),
-                                        "{\"p-y\":\"patent-y\"}",
+                                        ValueJson.fromJson("{\"p-y\":\"patent-y\"}"),
                                         true
                                 )
                         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/json/H2SaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/json/H2SaveTest.java
@@ -11,6 +11,7 @@ import org.babyfish.jimmer.sql.model.json.MedicineDraft;
 import org.babyfish.jimmer.sql.model.json.MedicineProps;
 import org.babyfish.jimmer.sql.model.json.MedicineTable;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
+import org.h2.value.ValueJson;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -34,11 +35,11 @@ public class H2SaveTest extends AbstractMutationTest {
                         .where(table.id().eq(1L)),
                 ctx -> {
                     ctx.statement(it -> {
-                        it.sql("update MEDICINE tb_1_ set TAGS = ? format json where tb_1_.ID = ?");
+                        it.sql("update MEDICINE tb_1_ set TAGS = ? where tb_1_.ID = ?");
                         it.variables(
                                 new DbLiteral.DbValue(
                                         MedicineProps.TAGS.unwrap(),
-                                        "[{\"name\":\"Tag-1\",\"description\":\"Description-1\"},{\"name\":\"Tag-2\",\"description\":\"Description-2\"}]",
+                                        ValueJson.fromJson("[{\"name\":\"Tag-1\",\"description\":\"Description-1\"},{\"name\":\"Tag-2\",\"description\":\"Description-2\"}]"),
                                         true
                                 ),
                                 1L
@@ -74,7 +75,7 @@ public class H2SaveTest extends AbstractMutationTest {
             return new Tuple2<>(affectedCount, medicine);
         }, ctx -> {
             ctx.statement(it -> {
-                it.sql("insert into MEDICINE(ID, TAGS) values(?, ? format json)");
+                it.sql("insert into MEDICINE(ID, TAGS) values(?, ?)");
             });
             ctx.statement(it -> {
                 it.sql(
@@ -123,7 +124,7 @@ public class H2SaveTest extends AbstractMutationTest {
             return new Tuple2<>(affectedCount, medicine);
         }, ctx -> {
             ctx.statement(it -> {
-                it.sql("update MEDICINE set TAGS = ? format json where ID = ?");
+                it.sql("update MEDICINE set TAGS = ? where ID = ?");
             });
             ctx.statement(it -> {
                 it.sql(
@@ -192,7 +193,7 @@ public class H2SaveTest extends AbstractMutationTest {
                                         "HOST, PORT, " +
                                         "CPU_FREQUENCY, MEMORY_SIZE, DISK_SIZE, " +
                                         "factory_map, patent_map" +
-                                        ") values(?, ?, ?, ?, ?, ?, ? format json, ? format json)"
+                                        ") values(?, ?, ?, ?, ?, ?, ?, ?)"
                         );
                     });
                     ctx.statement(it -> {
@@ -264,7 +265,7 @@ public class H2SaveTest extends AbstractMutationTest {
                                 "update MACHINE set " +
                                         "HOST = ?, PORT = ?, " +
                                         "CPU_FREQUENCY = ?, MEMORY_SIZE = ?, DISK_SIZE = ?, " +
-                                        "patent_map = ? format json " +
+                                        "patent_map = ? " +
                                         "where ID = ?"
                         );
                     });

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/pg/ScoresScalarProvider.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/pg/ScoresScalarProvider.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
 import org.jetbrains.annotations.NotNull;
-import org.postgresql.util.PGobject;
 
 import java.util.Map;
 
-public class ScoresScalarProvider implements ScalarProvider<Map<Long, Integer>, PGobject> {
+public class ScoresScalarProvider implements ScalarProvider<Map<Long, Integer>, String> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -16,15 +15,17 @@ public class ScoresScalarProvider implements ScalarProvider<Map<Long, Integer>, 
             new TypeReference<Map<Long, Integer>>() {};
 
     @Override
-    public @NotNull Map<Long, Integer> toScalar(@NotNull PGobject sqlValue) throws Exception {
-        return MAPPER.readValue(sqlValue.getValue(), TYPE_REFERENCE);
+    public @NotNull Map<Long, Integer> toScalar(@NotNull String sqlValue) throws Exception {
+        return MAPPER.readValue(sqlValue, TYPE_REFERENCE);
     }
 
     @Override
-    public @NotNull PGobject toSql(@NotNull Map<Long, Integer> scalarValue) throws Exception {
-        PGobject obj = new PGobject();
-        obj.setType("jsonb");
-        obj.setValue(MAPPER.writeValueAsString(scalarValue));
-        return obj;
+    public @NotNull String toSql(@NotNull Map<Long, Integer> scalarValue) throws Exception {
+        return MAPPER.writeValueAsString(scalarValue);
+    }
+
+    @Override
+    public boolean isJsonScalar() {
+        return true;
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/pg/TagsScalarProvider.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/pg/TagsScalarProvider.java
@@ -3,11 +3,11 @@ package org.babyfish.jimmer.sql.model.pg;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
-import org.postgresql.util.PGobject;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class TagsScalarProvider implements ScalarProvider<List<String>, PGobject> {
+public class TagsScalarProvider implements ScalarProvider<List<String>, String> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -15,15 +15,12 @@ public class TagsScalarProvider implements ScalarProvider<List<String>, PGobject
             new TypeReference<List<String>>() {};
 
     @Override
-    public List<String> toScalar(PGobject sqlValue) throws Exception {
-        return MAPPER.readValue(sqlValue.getValue(), TAGS_REFERENCE);
+    public List<String> toScalar(@NotNull String sqlValue) throws Exception {
+        return MAPPER.readValue(sqlValue, TAGS_REFERENCE);
     }
 
     @Override
-    public PGobject toSql(List<String> scalarValue) throws Exception {
-        PGobject obj = new PGobject();
-        obj.setType("jsonb");
-        obj.setValue(MAPPER.writeValueAsString(scalarValue));
-        return obj;
+    public String toSql(@NotNull List<String> scalarValue) throws Exception {
+        return MAPPER.writeValueAsString(scalarValue);
     }
 }


### PR DESCRIPTION
Users can define db specific json `ScalarProvider` (for example `PGObject`) as earlier.

But now users can define json `ScalarProvider` with `String` sql type and jimmer will do the conversion automatically.