### PR TITLE
Fix null-value json ScalarProvider property on postgres

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderManager.java
@@ -25,6 +25,8 @@ import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
+
 class ScalarProviderManager implements ScalarTypeStrategy {
 
     private static final Set<Class<?>> GENERIC_TYPES;
@@ -72,10 +74,7 @@ class ScalarProviderManager implements ScalarTypeStrategy {
     @Override
     public Class<?> getOverriddenSqlType(ImmutableProp prop) {
         ScalarProvider<?, ?> provider = getProvider(prop);
-        if (provider == null) {
-            return null;
-        }
-        return provider.getSqlType();
+        return provider == null ? null : getSqlType(provider, dialect);
     }
 
     public ScalarProvider<?, ?> getProvider(ImmutableProp prop) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderUtils.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ScalarProviderUtils.java
@@ -13,4 +13,10 @@ public class ScalarProviderUtils {
         Object sqlValue = scalarProvider.toSql(literal);
         return scalarProvider.isJsonScalar() ? dialect.jsonToBaseValue((String) sqlValue) : sqlValue;
     }
+
+    @NotNull
+    public static Class<?> getSqlType(@NotNull ScalarProvider<?, ?> scalarProvider,
+                                      @NotNull Dialect dialect) {
+        return scalarProvider.isJsonScalar() ? dialect.getJsonBaseType() : scalarProvider.getSqlType();
+    }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Variables.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/Variables.java
@@ -18,6 +18,7 @@ import java.sql.Timestamp;
 import java.time.*;
 import java.util.Collection;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
 import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
 
 public class Variables {
@@ -67,7 +68,7 @@ public class Variables {
             if (value == null) {
                 return new DbLiteral.DbNull(
                         scalarProvider != null ?
-                                scalarProvider.getSqlType() :
+                                getSqlType(scalarProvider, sqlClient.getDialect()) :
                                 prop.getReturnClass()
                         );
             }
@@ -107,7 +108,7 @@ public class Variables {
         if (value == null) {
             return new DbLiteral.DbNull(
                     scalarProvider != null ?
-                            scalarProvider.getSqlType() :
+                            getSqlType(scalarProvider, sqlClient.getDialect()) :
                             type
             );
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/AbstractValueGetter.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/AbstractValueGetter.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.lang.Ref;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.TargetLevel;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
+import org.babyfish.jimmer.sql.ScalarProviderUtils;
 import org.babyfish.jimmer.sql.ast.impl.ExpressionImplementor;
 import org.babyfish.jimmer.sql.ast.impl.Variables;
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
@@ -309,10 +310,9 @@ abstract class AbstractValueGetter implements ValueGetter, GetterMetadata {
 
     @Override
     public Class<?> getSqlType() {
-        if (scalarProvider != null) {
-            return scalarProvider.getSqlType();
-        }
-        return getValueProp().getReturnClass();
+        return scalarProvider != null ?
+                ScalarProviderUtils.getSqlType(scalarProvider, sqlClient.getDialect()) :
+                getValueProp().getReturnClass();
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -62,9 +62,18 @@ public interface Dialect extends SqlTypeStrategy {
     @Nullable
     default String getConstantTableName() { return null; }
 
+    default Class<?> getJsonBaseType() {
+        return String.class;
+    }
+
     @Nullable
-    default Object jsonToBaseValue(@Nullable String json) throws Exception {
+    default Object jsonToBaseValue(@Nullable String json) throws SQLException {
         return json;
+    }
+
+    @Nullable
+    default String baseValueToJson(@Nullable Object baseValue) throws SQLException {
+        return (String) baseValue;
     }
 
     default boolean isForeignKeySupported() {
@@ -75,10 +84,6 @@ public interface Dialect extends SqlTypeStrategy {
 
     default int resolveJdbcType(Class<?> sqlType) {
         return Types.OTHER;
-    }
-
-    default Reader<String> jsonReader() {
-        return (rs, ctx) -> rs.getString(ctx.col());
     }
 
     default Reader<?> unknownReader(Class<?> sqlType) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -96,7 +96,7 @@ public class H2Dialect extends DefaultDialect {
 
     @Nullable
     @Override
-    public Object jsonToBaseValue(@Nullable String json) throws Exception {
+    public Object jsonToBaseValue(@Nullable String json) throws SQLException {
         return json == null ? null : ValueJson.fromJson(json);
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/event/binlog/impl/ValueParser.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/event/binlog/impl/ValueParser.java
@@ -19,6 +19,8 @@ import java.math.BigInteger;
 import java.time.temporal.Temporal;
 import java.util.*;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
+
 class ValueParser {
 
     private static final Map<Class<?>, Caster> CASTER_MAP =
@@ -126,7 +128,9 @@ class ValueParser {
                         (ScalarProvider<Object, Object>)
                                 parser.sqlClient().getScalarProvider(javaType) :
                         null;
-        Class<?> sqlType = provider != null ? provider.getSqlType() : javaType;
+        Class<?> sqlType = provider != null ?
+                getSqlType(provider, parser.sqlClient().getDialect()) :
+                javaType;
         if (Date.class.isAssignableFrom(sqlType) || Temporal.class.isAssignableFrom(sqlType)) {
             return ILLEGAL_VALUE;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DbLiteral.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DbLiteral.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import java.sql.PreparedStatement;
 import java.util.Objects;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
 import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
 
 public interface DbLiteral {
@@ -132,7 +133,9 @@ public interface DbLiteral {
                 stmt.setNull(
                         index.get(),
                         JdbcTypes.toJdbcType(
-                                scalarProvider != null ? scalarProvider.getSqlType() : prop.getReturnClass(),
+                                scalarProvider != null ?
+                                        getSqlType(scalarProvider, sqlClient.getDialect()) :
+                                        prop.getReturnClass(),
                                 sqlClient.getDialect()
                         )
                 );

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
 import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
 
 public class DefaultExecutor implements Executor {
@@ -250,7 +251,9 @@ public class DefaultExecutor implements Executor {
             Object[] ids = new Object[batchCount];
             int index = 0;
             ScalarProvider<Object, Object> provider = sqlClient.getScalarProvider(generatedIdProp);
-            Class<?> sqlType = provider != null ? provider.getSqlType() : Classes.boxTypeOf(generatedIdProp.getReturnClass());
+            Class<?> sqlType = provider != null ?
+                    getSqlType(provider, sqlClient.getDialect()) :
+                    Classes.boxTypeOf(generatedIdProp.getReturnClass());
             try (ResultSet rs = statement.getGeneratedKeys()) {
                 while (rs.next()) {
                     Object id = rs.getObject(1, sqlType);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/SqlBuilder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/SqlBuilder.java
@@ -16,6 +16,7 @@ import org.babyfish.jimmer.sql.meta.SingleColumn;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.babyfish.jimmer.sql.ScalarProviderUtils.getSqlType;
 import static org.babyfish.jimmer.sql.ScalarProviderUtils.toSql;
 
 public class SqlBuilder extends AbstractSqlBuilder<SqlBuilder> {
@@ -346,7 +347,7 @@ public class SqlBuilder extends AbstractSqlBuilder<SqlBuilder> {
                         "Cannot convert the jvm type \"" +
                                 value +
                                 "\" to the sql type \"" +
-                                scalarProvider.getSqlType() +
+                                getSqlType(scalarProvider, sqlClient().getDialect()) +
                                 "\"",
                         ex
                 );
@@ -476,7 +477,7 @@ public class SqlBuilder extends AbstractSqlBuilder<SqlBuilder> {
                 ctx.getSqlClient().getScalarProvider((Class<Object>)type);
         Object finalValue;
         if (scalarProvider != null) {
-            finalValue = new DbLiteral.DbNull(scalarProvider.getSqlType());
+            finalValue = new DbLiteral.DbNull(getSqlType(scalarProvider, ctx.getSqlClient().getDialect()));
         } else {
             finalValue = new DbLiteral.DbNull(type);
         }


### PR DESCRIPTION
Automatically set a correct vendor-specific jdbc type when set null to a json column.