### PR TITLE
Fix Operator#translateException NPE issue

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -567,7 +567,8 @@ class Operator {
             Collection<? extends ImmutableSpi> entities,
             boolean updatable
     ) {
-        if (!ex.getSQLState().startsWith("23") || !(ex instanceof BatchUpdateException)) {
+        if (!Optional.ofNullable(ex.getSQLState()).map(s -> s.startsWith("23")).orElse(false)
+                || !(ex instanceof BatchUpdateException)) {
             return convertFinalException(ex, ctx);
         }
         BatchUpdateException bue = (BatchUpdateException) ex;


### PR DESCRIPTION
我自己简单的写了个`sqlite dialect`对接 SQLite 数据库，碰到了`[SQLITE_BUSY] The database file is locked (database is locked)`异常，但是代码报空指针 
```
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because the return value of "java.sql.SQLException.getSQLState()" is null
```
稍微定位了下在[Operator.java#L570](https://github.com/babyfish-ct/jimmer/blob/73fc65538ceeb7c5635a13842c9b65e3988774f7/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java#L570)，加了 Optional 修了下。