### PR TITLE
Provide MySql5.7Dialect to disable Upsert & Fix Test

### DIFF
--- a/project/jimmer-core/src/test/java/org/babyfish/jimmer/ExceptionTest.java
+++ b/project/jimmer-core/src/test/java/org/babyfish/jimmer/ExceptionTest.java
@@ -10,17 +10,21 @@ public class ExceptionTest {
 
     @Test
     public void testException() {
-        Assertions.assertEquals(
-                "{x=hello, y=world}",
-                new AException("hello", "world").getFields().toString()
+        String string = new AException("hello", "world").getFields().toString();
+        Assertions.assertTrue(
+                "{x=hello, y=world}".equals(string)||
+                        "{y=world, x=hello}".equals(string)
+
         );
     }
 
     @Test
     public void testRuntimeException() {
-        Assertions.assertEquals(
-                "{x=hello, y=world}",
-                new BException("hello", "world").getFields().toString()
+        String string = new BException("hello", "world").getFields().toString();
+        Assertions.assertTrue(
+                "{x=hello, y=world}".equals(string) ||
+                        "{y=world, x=hello}".equals(string)
+
         );
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySql57Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySql57Dialect.java
@@ -1,0 +1,90 @@
+package org.babyfish.jimmer.sql.dialect;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.*;
+import java.util.UUID;
+
+/**
+ * For MySQL 5.7.x
+ * Not support upsert
+ */
+public class MySql57Dialect extends DefaultDialect {
+
+    public void paginate(PaginationContext ctx) {
+        ctx.origin().space().sql("limit ").variable(ctx.getOffset()).sql(", ").variable(ctx.getLimit());
+    }
+
+    public UpdateJoin getUpdateJoin() {
+        return new UpdateJoin(true, UpdateJoin.From.UNNECESSARY);
+    }
+
+    public boolean isDeletedAliasRequired() {
+        return true;
+    }
+
+    public String sqlType(Class<?> elementType) {
+        if (elementType == String.class) {
+            return "varchar";
+        } else if (elementType == UUID.class) {
+            return "char(36)";
+        } else if (elementType == Boolean.TYPE) {
+            return "boolean";
+        } else if (elementType == Byte.TYPE) {
+            return "tinyint";
+        } else if (elementType == Short.TYPE) {
+            return "smallint";
+        } else if (elementType == Integer.TYPE) {
+            return "int";
+        } else if (elementType == Long.TYPE) {
+            return "bigint";
+        } else if (elementType == Float.TYPE) {
+            return "float";
+        } else if (elementType == Double.TYPE) {
+            return "double";
+        } else if (elementType == BigDecimal.class) {
+            return "decimal";
+        } else if (elementType != Date.class && elementType != LocalDate.class) {
+            if (elementType != Time.class && elementType != LocalTime.class) {
+                if (elementType == OffsetTime.class) {
+                    return "datetime";
+                } else if (elementType != java.util.Date.class && elementType != Timestamp.class) {
+                    if (elementType == LocalDateTime.class) {
+                        return "timestamp";
+                    } else {
+                        return elementType != OffsetDateTime.class && elementType != ZonedDateTime.class ? null : "timestamp";
+                    }
+                } else {
+                    return "timestamp";
+                }
+            } else {
+                return "datetime";
+            }
+        } else {
+            return "date";
+        }
+    }
+
+    public boolean isUpsertWithMultipleUniqueConstraintSupported() {
+        return false;
+    }
+
+    public boolean isIdFetchableByKeyUpdate() {
+        return true;
+    }
+
+    public boolean isUpsertSupported() {
+        return false;
+    }
+
+    public void update(Dialect.UpdateContext ctx) {
+        super.update(ctx);
+    }
+
+
+    public String transCacheOperatorTableDDL() {
+        return "create table JIMMER_TRANS_CACHE_OPERATOR(\n\tID bigint unsigned not null auto_increment primary key,\n\tIMMUTABLE_TYPE varchar(128),\n\tIMMUTABLE_PROP varchar(128),\n\tCACHE_KEY varchar(64) not null,\n\tREASON varchar(32)\n) engine=innodb";
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlDialect.java
@@ -2,98 +2,12 @@ package org.babyfish.jimmer.sql.dialect;
 
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 
-import java.math.BigDecimal;
-import java.time.*;
-import java.util.UUID;
+
 
 /**
  * For MySQL or TiDB
  */
-public class MySqlDialect extends DefaultDialect {
-
-    @Override
-    public void paginate(PaginationContext ctx) {
-        ctx
-                .origin()
-                .space()
-                .sql("limit ")
-                .variable(ctx.getOffset())
-                .sql(", ")
-                .variable(ctx.getLimit());
-    }
-
-    @Override
-    public UpdateJoin getUpdateJoin() {
-        return new UpdateJoin(true, UpdateJoin.From.UNNECESSARY);
-    }
-
-    @Override
-    public boolean isDeletedAliasRequired() {
-        return true;
-    }
-
-    @Override
-    public String sqlType(Class<?> elementType) {
-        if (elementType == String.class) {
-            return "varchar";
-        }
-        if (elementType == UUID.class) {
-            return "char(36)";
-        }
-        if (elementType == boolean.class) {
-            return "boolean";
-        }
-        if (elementType == byte.class) {
-            return "tinyint";
-        }
-        if (elementType == short.class) {
-            return "smallint";
-        }
-        if (elementType == int.class) {
-            return "int";
-        }
-        if (elementType == long.class) {
-            return "bigint";
-        }
-        if (elementType == float.class) {
-            return "float";
-        }
-        if (elementType == double.class) {
-            return "double";
-        }
-        if (elementType == BigDecimal.class) {
-            return "decimal";
-        }
-        if (elementType == java.sql.Date.class || elementType == LocalDate.class) {
-            return "date";
-        }
-        if (elementType == java.sql.Time.class || elementType == LocalTime.class) {
-            return "datetime";
-        }
-        if (elementType == OffsetTime.class) {
-            return "datetime";
-        }
-        if (elementType == java.util.Date.class || elementType == java.sql.Timestamp.class) {
-            return "timestamp";
-        }
-        if (elementType == LocalDateTime.class) {
-            return "timestamp";
-        }
-        if (elementType == OffsetDateTime.class || elementType == ZonedDateTime.class) {
-            return "timestamp";
-        }
-        return null;
-    }
-
-    @Override
-    public boolean isUpsertWithMultipleUniqueConstraintSupported() {
-        return false;
-    }
-
-    @Override
-    public boolean isIdFetchableByKeyUpdate() {
-        return true;
-    }
+public class MySqlDialect extends MySql57Dialect {
 
     @Override
     public boolean isUpsertSupported() {
@@ -165,14 +79,4 @@ public class MySqlDialect extends DefaultDialect {
         }
     }
 
-    @Override
-    public String transCacheOperatorTableDDL() {
-        return "create table JIMMER_TRANS_CACHE_OPERATOR(\n" +
-                "\tID bigint unsigned not null auto_increment primary key,\n" +
-                "\tIMMUTABLE_TYPE varchar(128),\n" +
-                "\tIMMUTABLE_PROP varchar(128),\n" +
-                "\tCACHE_KEY varchar(64) not null,\n" +
-                "\tREASON varchar(32)\n" +
-                ") engine=innodb";
-    }
 }


### PR DESCRIPTION
1 增加Mysql57方言，禁用Upsert
2 修复单元测试，由于Class.getDeclaredMethods返回的数组顺序是未保证的，不能保证toString后哪个字段在前。在我的JDK中有20%的几率y会先出现。