### PR TITLE
使 Spring starter 中 `jimmer.language` 属性配置无视大小写

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
@@ -75,7 +75,7 @@ class JSpringSqlClient extends JLazyInitializationSqlClient {
     @Override
     protected JSqlClient.Builder createBuilder() {
 
-        boolean isCfgKotlin = "kotlin".equals(getRequiredBean(JimmerProperties.class).getLanguage());
+        boolean isCfgKotlin = "kotlin".equalsIgnoreCase(getRequiredBean(JimmerProperties.class).getLanguage());
         if (isCfgKotlin != isKotlin) {
             throw new IllegalStateException(
                     "Cannot create sql client for \"" +

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
@@ -108,7 +108,7 @@ public class JimmerProperties {
         if (language == null) {
             this.language = "java";
         } else {
-            if (!language.equals("java") && !language.equals("kotlin")) {
+            if (!language.equalsIgnoreCase("java") && !language.equalsIgnoreCase("kotlin")) {
                 throw new IllegalArgumentException("`jimmer.language` must be \"java\" or \"kotlin\"");
             }
             this.language = language;

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/SqlClientConfig.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/SqlClientConfig.java
@@ -4,8 +4,8 @@ import org.babyfish.jimmer.spring.SqlClients;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.cache.CacheAbandonedCallback;
 import org.babyfish.jimmer.sql.kt.KSqlClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,14 +19,14 @@ public class SqlClientConfig {
 
     @Bean(name = "sqlClient")
     @ConditionalOnMissingBean({JSqlClient.class, KSqlClient.class})
-    @ConditionalOnProperty(name = "jimmer.language", havingValue = "java", matchIfMissing = true)
+    @ConditionalOnExpression("'java'.equalsIgnoreCase(environment.getProperty('jimmer.language')) || !environment.containsProperty('jimmer.language')")
     public JSqlClient javaSqlClient(ApplicationContext ctx) {
         return SqlClients.java(ctx);
     }
 
     @Bean(name = "sqlClient")
     @ConditionalOnMissingBean({JSqlClient.class, KSqlClient.class})
-    @ConditionalOnProperty(name = "jimmer.language", havingValue = "kotlin")
+    @ConditionalOnExpression("'kotlin'.equalsIgnoreCase(environment.getProperty('jimmer.language'))")
     public KSqlClient kotlinSqlClient(ApplicationContext ctx) {
         return SqlClients.kotlin(ctx);
     }

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/DefaultJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/DefaultJimmerLanguageTest.java
@@ -1,0 +1,26 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {
+                SqlClientConfig.class,
+                JimmerLanguageTestHelper.DataSourceConfig.class}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class DefaultJimmerLanguageTest {
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.javaLanguage(sqlClient);
+        Assertions.assertEquals("java", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/FirstUpperJavaJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/FirstUpperJavaJimmerLanguageTest.java
@@ -1,0 +1,31 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=Java"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class FirstUpperJavaJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.javaLanguage(sqlClient);
+        Assertions.assertEquals("Java", jimmerLanguage);
+        Assertions.assertEquals("Java", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/FirstUpperKotlinJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/FirstUpperKotlinJimmerLanguageTest.java
@@ -1,0 +1,30 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=Kotlin"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class FirstUpperKotlinJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.kotlinLanguage(sqlClient);
+        Assertions.assertEquals("Kotlin", jimmerLanguage);
+        Assertions.assertEquals("Kotlin", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerLanguageTestHelper.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerLanguageTestHelper.java
@@ -1,0 +1,47 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.babyfish.jimmer.spring.datasource.DataSources;
+import org.babyfish.jimmer.spring.datasource.TxCallback;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.kt.KSqlClient;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.context.annotation.Bean;
+
+import javax.sql.DataSource;
+
+/**
+ * @author ForteScarlet
+ */
+public class JimmerLanguageTestHelper {
+    public static class DataSourceConfig {
+        @Bean
+        public DataSource dataSource() {
+            return DataSources.create(
+                    new TxCallback() {
+                        @Override
+                        public void open() {
+                        }
+
+                        @Override
+                        public void commit() {
+                        }
+
+                        @Override
+                        public void rollback() {
+                        }
+                    }
+            );
+        }
+    }
+
+    public static void javaLanguage(Object sqlClient) {
+        Assertions.assertNotNull(sqlClient);
+        Assertions.assertInstanceOf(JSqlClient.class, sqlClient);
+    }
+
+    public static void kotlinLanguage(Object sqlClient) {
+        Assertions.assertNotNull(sqlClient);
+        Assertions.assertInstanceOf(KSqlClient.class, sqlClient);
+    }
+
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/LowerJavaJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/LowerJavaJimmerLanguageTest.java
@@ -1,0 +1,30 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=java"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class LowerJavaJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.javaLanguage(sqlClient);
+        Assertions.assertEquals("java", jimmerLanguage);
+        Assertions.assertEquals("java", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/LowerKotlinJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/LowerKotlinJimmerLanguageTest.java
@@ -1,0 +1,30 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=kotlin"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class LowerKotlinJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.kotlinLanguage(sqlClient);
+        Assertions.assertEquals("kotlin", jimmerLanguage);
+        Assertions.assertEquals("kotlin", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/UpperJavaJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/UpperJavaJimmerLanguageTest.java
@@ -1,0 +1,30 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=JAVA"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class UpperJavaJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.javaLanguage(sqlClient);
+        Assertions.assertEquals("JAVA", jimmerLanguage);
+        Assertions.assertEquals("JAVA", jimmerProperties.getLanguage());
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/UpperKotlinJimmerLanguageTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/UpperKotlinJimmerLanguageTest.java
@@ -1,0 +1,30 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        classes = {SqlClientConfig.class, JimmerLanguageTestHelper.DataSourceConfig.class},
+        properties = {"jimmer.language=KOTLIN"}
+)
+@EnableConfigurationProperties(JimmerProperties.class)
+public class UpperKotlinJimmerLanguageTest {
+    @Value("${jimmer.language}")
+    private String jimmerLanguage;
+
+    @Autowired(required = false)
+    @Qualifier("sqlClient")
+    protected Object sqlClient;
+
+    @Test
+    public void javaLanguage(@Autowired JimmerProperties jimmerProperties) {
+        JimmerLanguageTestHelper.kotlinLanguage(sqlClient);
+        Assertions.assertEquals("KOTLIN", jimmerLanguage);
+        Assertions.assertEquals("KOTLIN", jimmerProperties.getLanguage());
+    }
+}


### PR DESCRIPTION
Spring starter 的配置项 `jimmer.language` 的可选值 `java` 和 `kotlin` 按照习惯通常会首字母大写，例如 `Kotlin`, 但是目前此属性似乎不可无视大小写。

此PR中我尝试使 `jimmer.language` 属性配置无视大小写，例如可以 `jimmer.language=Kotlin`，并新增了若干单元测试来校验其行为。

> 除了使用字符串，个人感觉用枚举也是一个不错的选择，配合IDE的提示也会有更好的体验。不过如果将 `JimmerProperties.language` 类型修改为新增的某个枚举类型，可能会导致二进制和源码不兼容问题。虽然目前版本尚未 1.0，不过还是没选择此方式。

如果此PR内容合适、符合项目需求或符合未来规划的话，请随时审查，如果有不合适的内容也可以随时让我修改或关闭，感谢～