### PR TITLE
Fix fetchOne and fetchOneOrNull for kotlin query with limit(1)

### DIFF
--- a/project/jimmer-core/src/test/java/org/babyfish/jimmer/Issue748Test.java
+++ b/project/jimmer-core/src/test/java/org/babyfish/jimmer/Issue748Test.java
@@ -1,22 +1,23 @@
 package org.babyfish.jimmer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.babyfish.jimmer.model.Hospital;
 import org.babyfish.jimmer.model.Immutables;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.babyfish.jimmer.support.JsonAssertions.assertJsonEquals;
+
 public class Issue748Test {
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     public void test() throws JsonProcessingException {
         Hospital hospital = Immutables.createHospital(it -> it.setName("XieHe").setISPublic(true));
         String json = hospital.toString();
-        Assertions.assertEquals("{\"name\":\"XieHe\",\"ispublic\":true}", json);
+        assertJsonEquals("{\"name\":\"XieHe\",\"ispublic\":true}", json);
+
         Hospital hospital2 = ImmutableObjects.fromString(Hospital.class, json);
-        Assertions.assertEquals(
-                "{\"name\":\"XieHe\",\"ispublic\":true}",
-                hospital2.toString()
-        );
+        assertJsonEquals("{\"name\":\"XieHe\",\"ispublic\":true}", hospital2.toString());
     }
 }

--- a/project/jimmer-core/src/test/java/org/babyfish/jimmer/support/JsonAssertions.java
+++ b/project/jimmer-core/src/test/java/org/babyfish/jimmer/support/JsonAssertions.java
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+
+public class JsonAssertions {
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+
+    public static void assertJsonEquals(String expected, String actual) {
+        try {
+            Assertions.assertEquals(MAPPER.readTree(expected), MAPPER.readTree(actual));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Input strings are not json", e);
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
@@ -17,8 +17,11 @@ interface KTypedRootQuery<R> : KExecutable<List<R>> {
 
     fun fetchOne(con: Connection? = null): R
 
-    @Suppress("UNCHECKED_CAST")
     fun fetchOneOrNull(con: Connection? = null): R?
+
+    fun fetchFirst(con: Connection? = null): R
+
+    fun fetchFirstOrNull(con: Connection? = null): R?
 
     fun <X> map(con: Connection? = null, mapper: (R) -> X): List<X>
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
@@ -15,32 +15,10 @@ interface KTypedRootQuery<R> : KExecutable<List<R>> {
 
     infix fun intersect(other: KTypedRootQuery<R>): KTypedRootQuery<R>
 
-    fun fetchOne(con: Connection? = null): R =
-        if (this is KConfigurableRootQuery<*, *>) {
-            limit(2).execute(con) as List<R>
-        } else {
-            execute(con)
-        }.let {
-            when (it.size) {
-                0 -> throw EmptyResultException()
-                1 -> it[0]
-                else -> throw TooManyResultsException()
-            }
-        }
+    fun fetchOne(con: Connection? = null): R
 
     @Suppress("UNCHECKED_CAST")
-    fun fetchOneOrNull(con: Connection? = null): R? =
-        if (this is KConfigurableRootQuery<*, *>) {
-            limit(2).execute(con) as List<R>
-        } else {
-            execute(con)
-        }.let {
-            when (it.size) {
-                0 -> null
-                1 -> it[0]
-                else -> throw TooManyResultsException()
-            }
-        }
+    fun fetchOneOrNull(con: Connection? = null): R?
 
     fun <X> map(con: Connection? = null, mapper: (R) -> X): List<X>
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
@@ -23,6 +23,10 @@ internal open class KTypedRootQueryImpl<R>(
     override fun intersect(other: KTypedRootQuery<R>): KTypedRootQuery<R> =
         KTypedRootQueryImpl(_javaQuery.intersect((other as KTypedRootQueryImpl<R>)._javaQuery))
 
+    override fun fetchOne(con: Connection?): R = _javaQuery.fetchOne(con)
+
+    override fun fetchOneOrNull(con: Connection?): R? = javaQuery.fetchOneOrNull(con)
+
     override fun execute(con: Connection?): List<R> =
         _javaQuery.execute(con)
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
@@ -27,6 +27,10 @@ internal open class KTypedRootQueryImpl<R>(
 
     override fun fetchOneOrNull(con: Connection?): R? = javaQuery.fetchOneOrNull(con)
 
+    override fun fetchFirst(con: Connection?): R = _javaQuery.fetchFirst(con)
+
+    override fun fetchFirstOrNull(con: Connection?): R? = _javaQuery.fetchFirstOrNull(con)
+
     override fun execute(con: Connection?): List<R> =
         _javaQuery.execute(con)
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
@@ -377,9 +377,9 @@ public class ConfigurableRootQueryImpl<T extends Table<?>, R>
     }
 
     @Override
-    public TypedRootQuery<R> forOne() {
+    public TypedRootQuery<R> withLimit(int limit) {
         if (getData().limit == Integer.MAX_VALUE) {
-            return limit(2);
+            return limit(limit);
         }
         return this;
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedTypedRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedTypedRootQueryImpl.java
@@ -229,7 +229,7 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
     }
 
     @Override
-    public TypedRootQuery<R> forOne() {
+    public TypedRootQuery<R> withLimit(int limit) {
         return this;
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedRootQueryImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedRootQueryImplementor.java
@@ -6,5 +6,5 @@ public interface TypedRootQueryImplementor<R> extends TypedRootQuery<R>, TypedQu
 
     boolean isForUpdate();
 
-    TypedRootQuery<R> forOne();
+    TypedRootQuery<R> withLimit(int limit);
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/TypedRootQuery.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/TypedRootQuery.java
@@ -29,7 +29,7 @@ public interface TypedRootQuery<R> extends Executable<List<R>> {
 
     default R fetchOne(Connection con) {
         List<R> list = this instanceof TypedRootQueryImplementor<?> ?
-                ((TypedRootQueryImplementor<R>)this).forOne().execute(con) :
+                ((TypedRootQueryImplementor<R>) this).withLimit(2).execute(con) :
                 execute(con);
         if (list.isEmpty()) {
             throw new EmptyResultException();
@@ -48,13 +48,43 @@ public interface TypedRootQuery<R> extends Executable<List<R>> {
     @Nullable
     default R fetchOneOrNull(Connection con) {
         List<R> list = this instanceof TypedRootQueryImplementor<?> ?
-                ((TypedRootQueryImplementor<R>)this).forOne().execute(con) :
+                ((TypedRootQueryImplementor<R>) this).withLimit(2).execute(con) :
                 execute(con);
         if (list.isEmpty()) {
             return null;
         }
         if (list.size() > 1) {
             throw new TooManyResultsException();
+        }
+        return list.get(0);
+    }
+
+    default R fetchFirst() {
+        return fetchFirst(null);
+    }
+
+    default R fetchFirst(Connection con) {
+        List<R> list = this instanceof TypedRootQueryImplementor<?> ?
+                ((TypedRootQueryImplementor<R>) this).withLimit(1).execute(con) :
+                execute(con);
+        if (list.isEmpty()) {
+            throw new EmptyResultException();
+        }
+        return list.get(0);
+    }
+
+    @Nullable
+    default R fetchFirstOrNull() {
+        return fetchFirstOrNull(null);
+    }
+
+    @Nullable
+    default R fetchFirstOrNull(Connection con) {
+        List<R> list = this instanceof TypedRootQueryImplementor<?> ?
+                ((TypedRootQueryImplementor<R>) this).withLimit(1).execute(con) :
+                execute(con);
+        if (list.isEmpty()) {
+            return null;
         }
         return list.get(0);
     }


### PR DESCRIPTION
Property order can be different for different jvms.
This test failed on my machine, because `isPublic` property was the first.