### PR TITLE
Fix typo in exception message for database validation mode

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
@@ -193,8 +193,8 @@ public class JimmerProperties {
                 3;
         if (databaseValidationMode != null && databaseValidation != null) {
             throw new IllegalArgumentException(
-                    "Conflict configuration properties: \"jimmer.database-validation.mode\" and " +
-                            "\"jimmer.database-validation-mode(deprecated)\""
+                    "Conflict configuration properties: \"jimmer.database-validation-mode\" and " +
+                            "\"jimmer.database-validation.mode(deprecated)\""
             );
         }
         if (databaseValidationMode != null) {


### PR DESCRIPTION
The property `jimmer.database-validation.mode` (`DatabaseValidation.mode`) is the real deprecated property. The original error message had them reversed.