### PR TITLE
MutableDelete添加Specification查询删除

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
@@ -1,11 +1,15 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
+import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.LogicalDeletedInfo;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.PropExpression;
-import org.babyfish.jimmer.sql.ast.impl.*;
+import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
+import org.babyfish.jimmer.sql.ast.impl.Ast;
+import org.babyfish.jimmer.sql.ast.impl.AstContext;
+import org.babyfish.jimmer.sql.ast.impl.PropExpressionImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.UseTableVisitor;
 import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
@@ -24,7 +28,9 @@ import org.babyfish.jimmer.sql.meta.impl.LogicalDeletedValueGenerators;
 import org.babyfish.jimmer.sql.runtime.*;
 
 import java.sql.Connection;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 
 public class MutableDeleteImpl
         extends AbstractMutableStatementImpl
@@ -79,6 +85,12 @@ public class MutableDeleteImpl
     @Override
     public MutableDelete where(Predicate... predicates) {
         deleteQuery.where(predicates);
+        return this;
+    }
+
+    @Override
+    public MutableDelete where(Specification<?> specification) {
+        deleteQuery.where(specification);
         return this;
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableDelete.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableDelete.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.ast.mutation;
 
+import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.lang.OldChain;
 import org.babyfish.jimmer.sql.ast.Executable;
 import org.babyfish.jimmer.sql.ast.Predicate;
@@ -11,6 +12,9 @@ public interface MutableDelete extends Filterable, Executable<Integer> {
 
     @OldChain
     MutableDelete where(Predicate... predicates);
+
+    @OldChain
+    MutableDelete where(Specification<?> specification);
 
     /**
      * This method is deprecated, using {@code Dynamic Predicates}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/PredicateApplier.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/PredicateApplier.java
@@ -7,7 +7,6 @@ import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableSubQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.table.TableProxies;
-import org.babyfish.jimmer.sql.ast.query.MutableQuery;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 
@@ -17,9 +16,8 @@ public class PredicateApplier {
 
     private Context context;
 
-    public PredicateApplier(MutableQuery query) {
-        AbstractMutableStatementImpl statement = (AbstractMutableStatementImpl) query;
-        this.context = new Context(null, statement, null);
+    public PredicateApplier(AbstractMutableStatementImpl query) {
+        this.context = new Context(null, query, null);
     }
 
     public void push(ImmutableProp prop) {


### PR DESCRIPTION
在尝试在删除时使用Specification查询时发现无对应方法，所以添加一个根据Specification查询删除的方法。
在查看源码时发现PredicateApplier构造参数可有可优化空间，所以一起修改。
以下是修改内容：

1. MutableDelete添加Specification查询删除
2. PredicateApplier构造参数由MutableQuery修改为AbstractMutableStatementImpl
