### PR TITLE
Revert "MutableDelete添加Specification查询删除"

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
@@ -1,15 +1,11 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
-import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.LogicalDeletedInfo;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.PropExpression;
-import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
-import org.babyfish.jimmer.sql.ast.impl.Ast;
-import org.babyfish.jimmer.sql.ast.impl.AstContext;
-import org.babyfish.jimmer.sql.ast.impl.PropExpressionImpl;
+import org.babyfish.jimmer.sql.ast.impl.*;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.UseTableVisitor;
 import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
@@ -28,9 +24,7 @@ import org.babyfish.jimmer.sql.meta.impl.LogicalDeletedValueGenerators;
 import org.babyfish.jimmer.sql.runtime.*;
 
 import java.sql.Connection;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 public class MutableDeleteImpl
         extends AbstractMutableStatementImpl
@@ -85,12 +79,6 @@ public class MutableDeleteImpl
     @Override
     public MutableDelete where(Predicate... predicates) {
         deleteQuery.where(predicates);
-        return this;
-    }
-
-    @Override
-    public MutableDelete where(Specification<?> specification) {
-        deleteQuery.where(specification);
         return this;
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableDelete.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableDelete.java
@@ -1,6 +1,5 @@
 package org.babyfish.jimmer.sql.ast.mutation;
 
-import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.lang.OldChain;
 import org.babyfish.jimmer.sql.ast.Executable;
 import org.babyfish.jimmer.sql.ast.Predicate;
@@ -12,9 +11,6 @@ public interface MutableDelete extends Filterable, Executable<Integer> {
 
     @OldChain
     MutableDelete where(Predicate... predicates);
-
-    @OldChain
-    MutableDelete where(Specification<?> specification);
 
     /**
      * This method is deprecated, using {@code Dynamic Predicates}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/PredicateApplier.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/PredicateApplier.java
@@ -7,6 +7,7 @@ import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableSubQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.table.TableProxies;
+import org.babyfish.jimmer.sql.ast.query.MutableQuery;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 
@@ -16,8 +17,9 @@ public class PredicateApplier {
 
     private Context context;
 
-    public PredicateApplier(AbstractMutableStatementImpl query) {
-        this.context = new Context(null, query, null);
+    public PredicateApplier(MutableQuery query) {
+        AbstractMutableStatementImpl statement = (AbstractMutableStatementImpl) query;
+        this.context = new Context(null, statement, null);
     }
 
     public void push(ImmutableProp prop) {


### PR DESCRIPTION
MutableUpdate and MutableDelete has no generic parameter types, so only Specification<?> can be accepted, it cannot accept Specification<T>, this is different with MutableQuery<T>

This API is not type safe, it goes against Jimmer's culture

Refactor MutableUpdate and MutableDelete to types with generic parameter will case big work load, and it is huge API change.

There is currently higher-priority complex work, so this PR is rejected.

If the project has similar requirements, please create utils within the project yourself.