### PR TITLE
fix(ksp): When the property name is `base`, it causes a local variable conflict and prevents compilation

### DIFF
--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftImplGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/generator/DraftImplGenerator.kt
@@ -622,7 +622,7 @@ class DraftImplGenerator(
                                         )
                                         add("if (oldValue !== newValue)")
                                         beginControlFlow("")
-                                        addStatement("%L = newValue", prop.name)
+                                        addStatement("this@%L.%L = newValue", DRAFT_IMPL, prop.name)
                                         endControlFlow()
                                         endControlFlow()
                                     }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/Monster.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/Monster.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.sql.kt.model
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.ManyToOne
+
+@Entity
+interface Monster {
+    @Id
+    val id: Int
+
+    // Previously, using `base` would cause conflicts with local variables in the generated `Draft` file,
+    // resulting in compilation failures.
+    // Now, as long as it can generate the ` Draft ` file correctly and pass compilation, the problem is solved.
+    @ManyToOne
+    val base: Monster?
+}

--- a/project/jimmer-sql-kotlin/src/test/resources/database.sql
+++ b/project/jimmer-sql-kotlin/src/test/resources/database.sql
@@ -34,6 +34,7 @@ drop table book_store if exists;
 drop table tree_node if exists;
 drop table primitive if exists;
 drop table personal if exists;
+drop table monster if exists;
 
 drop sequence file_user_id_seq if exists;
 drop sequence file_id_seq if exists;
@@ -847,4 +848,12 @@ insert into camera(id, name) values(1, 'camera-1');
 insert into eyepiece(id, name, eye_relief, camera_id) values(1, 'eyepiece-1', 10, 1);
 insert into objective(id, name, working_distance, camera_id) values(1, 'objective-1', 2500, 1);
 
+create table monster(
+                         id int not null PRIMARY KEY,
+                         base_id int null
+);
 
+alter table monster
+    add constraint fk_monster_base
+        foreign key(base_id)
+            references monster(id);


### PR DESCRIPTION
Suppose there is an entity:

```Kotlin
@Entity
interface Monster {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    val id: Int

    @Key
    val name: String

    @ManyToOne
    val base: Monster?
}
```
In the generated `DraftImpl`, this attribute `base` conflicts with the local variable name.

![de90ebc88749360e0c60dd3e3ceaaea3](https://github.com/user-attachments/assets/173c5f71-e7ba-4456-a943-fde605c56f02)

This PR uses `this@DraftImpl` to explicitly reference properties in `DraftImpl` in the part that generates code.

```diff
if (oldValue !== newValue) {
-    base = newValue
+    this@DraftImpl.base = newValue
}
```

