### PR TITLE
Remove custom `getTimestamp` for sqlite

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
@@ -320,21 +320,4 @@ public class SQLiteDialect extends DefaultDialect {
                 break;
         }
     }
-
-    @Override
-    public Timestamp getTimestamp(ResultSet rs, int col) throws SQLException {
-        String text = rs.getString(col);
-        if (text == null) {
-            return null;
-        }
-        if (text.length() > 6) {
-            char c = text.charAt(text.length() - 6);
-            if (c == '+' || c == '-') {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX");
-                OffsetDateTime offsetDateTime = OffsetDateTime.parse(text, formatter);
-                return Timestamp.from(offsetDateTime.toInstant());
-            }
-        }
-        return Timestamp.valueOf(text);
-    }
 }


### PR DESCRIPTION
SQLite JDBC supports `yyyy-mm-dd hh:mm:ss` and `timestamp`, so the custom `getTimestamp` needs to be removed

https://github.com/xerial/sqlite-jdbc/blob/404201113595f2d08d3d441c82afd9ac80670bf2/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java#L438