### PR TITLE
fix: method equal

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repository/parser/QueryMethodParser.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repository/parser/QueryMethodParser.java
@@ -315,7 +315,7 @@ class QueryMethodParser {
             }
         } else if (type instanceof TypeVariable<?>) {
             TypeVariable<?> typeVariable = (TypeVariable<?>) type;
-            if (typeVariable.getGenericDeclaration() == method) {
+            if (method.equals(typeVariable.getGenericDeclaration())) {
                 Type boundType = typeVariable.getBounds()[0];
                 if (boundType instanceof ParameterizedType) {
                     ParameterizedType parameterizedBoundType = (ParameterizedType) boundType;


### PR DESCRIPTION
在运行测试案例的时候，发现很多无法通过，报错信息：
```java
Caused by: java.lang.IllegalArgumentException: The returned element type must be "org.babyfish.jimmer.spring.java.model.BookStore", a class implements "org.babyfish.jimmer.View<org.babyfish.jimmer.spring.java.model.BookStore>" or a method level type variable extends "org.babyfish.jimmer.View<org.babyfish.jimmer.spring.java.model.BookStore>"
	at org.babyfish.jimmer.spring.repository.parser.QueryMethodParser.parse0(QueryMethodParser.java:179)
	at org.babyfish.jimmer.spring.repository.parser.QueryMethodParser.parse(QueryMethodParser.java:85)
```
进行 debug 后，发现是判断这个方法是否相同的时候，使用了`==`直接判断内存地址。
<img width="2880" height="1268" alt="image" src="https://github.com/user-attachments/assets/65e29194-642a-443a-98e0-28f8bf9ba893" />

个人认为这里应该是判断方法是不是一致的，应该使用 method 的 equals 方法，修改后测试案例通过。