### PR TITLE
Revert "Remove custom `getTimestamp` for sqlite"

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
@@ -320,4 +320,21 @@ public class SQLiteDialect extends DefaultDialect {
                 break;
         }
     }
+
+    @Override
+    public Timestamp getTimestamp(ResultSet rs, int col) throws SQLException {
+        String text = rs.getString(col);
+        if (text == null) {
+            return null;
+        }
+        if (text.length() > 6) {
+            char c = text.charAt(text.length() - 6);
+            if (c == '+' || c == '-') {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX");
+                OffsetDateTime offsetDateTime = OffsetDateTime.parse(text, formatter);
+                return Timestamp.from(offsetDateTime.toInstant());
+            }
+        }
+        return Timestamp.valueOf(text);
+    }
 }


### PR DESCRIPTION
Reverts babyfish-ct/jimmer#1105
Because unit test failed.
Jimmer has smarter solution
