### PR TITLE
Fallback use JDBC `getTimestamp`

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
@@ -335,6 +335,6 @@ public class SQLiteDialect extends DefaultDialect {
                 return Timestamp.from(offsetDateTime.toInstant());
             }
         }
-        return Timestamp.valueOf(text);
+        return rs.getTimestamp(col);
     }
 }


### PR DESCRIPTION
SQLite JDBC supports yyyy-mm-dd hh:mm:ss and timestamp, so the custom getTimestamp's fallback doesn't support timestamp