### PR TITLE
#1046

### DIFF
--- a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/runtime/impl/MetadataBuilder.java
+++ b/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/runtime/impl/MetadataBuilder.java
@@ -101,7 +101,7 @@ public class MetadataBuilder implements Metadata.Builder {
     }
 
     @Override
-    public Metadata.Builder addIgnoredParameterTypes(Class<?> ... types) {
+    public Metadata.Builder addIgnoredParameterTypes(Class<?>... types) {
         ignoredParameterTypes.addAll(Arrays.asList(types));
         return this;
     }
@@ -113,13 +113,13 @@ public class MetadataBuilder implements Metadata.Builder {
     }
 
     @Override
-    public Metadata.Builder addIgnoredParameterTypeNames(String ... typeNames) {
+    public Metadata.Builder addIgnoredParameterTypeNames(String... typeNames) {
         ignoredParameterTypeNames.addAll(Arrays.asList(typeNames));
         return this;
     }
 
     @Override
-    public Metadata.Builder addIllegalReturnTypeNames(String ... typeNames) {
+    public Metadata.Builder addIllegalReturnTypeNames(String... typeNames) {
         illegalReturnTypeNames.addAll(Arrays.asList(typeNames));
         return this;
     }
@@ -176,9 +176,9 @@ public class MetadataBuilder implements Metadata.Builder {
                         if (groups == null || groups.isEmpty()) {
                             // 没有分组查询的情况 全部放入
                             serviceMap.putIfAbsent(service.getTypeName(), (ApiServiceImpl<Void>) service);
-                        }else {
+                        } else {
                             // 有分组查询的时候 需要判断service的groups不为null 且 需要包含在groups里
-                            if(service.getGroups()!=null && groups.containsAll(service.getGroups())) {
+                            if (service.getGroups() != null && groups.containsAll(service.getGroups())) {
                                 serviceMap.putIfAbsent(service.getTypeName(), (ApiServiceImpl<Void>) service);
                             }
                         }

--- a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/runtime/impl/MetadataBuilder.java
+++ b/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/runtime/impl/MetadataBuilder.java
@@ -173,7 +173,15 @@ public class MetadataBuilder implements Metadata.Builder {
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
                     Schema schema = Schemas.readFrom(reader, groups);
                     for (ApiService service : schema.getApiServiceMap().values()) {
-                        serviceMap.putIfAbsent(service.getTypeName(), (ApiServiceImpl<Void>) service);
+                        if (groups == null || groups.isEmpty()) {
+                            // 没有分组查询的情况 全部放入
+                            serviceMap.putIfAbsent(service.getTypeName(), (ApiServiceImpl<Void>) service);
+                        }else {
+                            // 有分组查询的时候 需要判断service的groups不为null 且 需要包含在groups里
+                            if(service.getGroups()!=null && groups.containsAll(service.getGroups())) {
+                                serviceMap.putIfAbsent(service.getTypeName(), (ApiServiceImpl<Void>) service);
+                            }
+                        }
                     }
                     for (TypeDefinition definition : schema.getTypeDefinitionMap().values()) {
                         definitionMap.putIfAbsent(definition.getTypeName(), (TypeDefinitionImpl<Void>) definition);


### PR DESCRIPTION
fix(client): 修复分组查询时服务过滤逻辑错误
- 当存在分组参数时，增加服务分组匹配条件检查
- 仅当服务的分组列表非空且全部包含在查询分组中时才添加服务
- 修复原逻辑未过滤分组导致所有服务被加载的问题
- 无分组参数时保持原有全部加载逻辑不变