### PR TITLE
test(bug1126): 添加用户团队关联查询测试

### DIFF
--- a/project/jimmer-sql-kotlin/src/test/dto/WorkUser.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/WorkUser.dto
@@ -1,0 +1,13 @@
+export org.babyfish.jimmer.sql.kt.model.bug1126.WorkUser
+
+specification UserSpec {
+    id
+
+    name
+
+    flat(teamRecords) {
+        flat(team) {
+            name as teamName
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/TreeNodeFlatSpecificationTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/TreeNodeFlatSpecificationTest.kt
@@ -2,6 +2,8 @@ package org.babyfish.jimmer.sql.kt.dto
 
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.model.TreeNode
+import org.babyfish.jimmer.sql.kt.model.bug1126.WorkUser
+import org.babyfish.jimmer.sql.kt.model.bug1126.dto.UserSpec
 import org.babyfish.jimmer.sql.kt.model.dto.TreeNodeFlatSpecification
 import kotlin.test.Test
 
@@ -17,6 +19,20 @@ class TreeNodeFlatSpecificationTest : AbstractQueryTest() {
         ) {
             sql(
                 """select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID from TREE_NODE tb_1_"""
+            )
+        }
+    }
+
+    @Test
+    fun test2() {
+        executeAndExpect(
+            sqlClient.createQuery(WorkUser::class) {
+                where(UserSpec())
+                select(table)
+            }
+        ) {
+            sql(
+                """select tb_1_.ID, tb_1_.NAME from WORK_USER tb_1_"""
             )
         }
     }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkTeam.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkTeam.kt
@@ -1,0 +1,16 @@
+package org.babyfish.jimmer.sql.kt.model.bug1126
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.OneToMany
+
+@Entity
+interface WorkTeam {
+    @Id
+    val id: Long
+    val name: String
+
+    @OneToMany(mappedBy = "team")
+    val records: List<WorkTeamUserRecord>
+
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkTeamUserRecord.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkTeamUserRecord.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.sql.kt.model.bug1126
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.ManyToOne
+
+@Entity
+interface WorkTeamUserRecord {
+    @Id
+    val id: Long
+
+    @ManyToOne
+    val team: WorkTeam
+
+    @ManyToOne
+    val user: WorkUser
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkUser.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/bug1126/WorkUser.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.sql.kt.model.bug1126
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.OneToMany
+
+@Entity
+interface WorkUser {
+    @Id
+    val id: Long
+
+    val name: String
+
+    @OneToMany(mappedBy = "user")
+    val teamRecords: List<WorkTeamUserRecord>
+
+}


### PR DESCRIPTION
- 新增 WorkUser、WorkTeam 和 WorkTeamUserRecord 实体类- 创建 UserSpec 规范以查询用户及其团队信息
- 在 TreeNodeFlatSpecificationTest 中添加 test2 测试方法
- 验证用户团队关联查询的 SQL 语句