### PR TITLE
feat(sql): 添加对任意数量选择项的支持

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KRootSelectable.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KRootSelectable.kt
@@ -9,6 +9,8 @@ interface KRootSelectable<P: KPropsLike> {
 
     fun <T> select(selection: Selection<T>): KConfigurableRootQuery<P, T>
 
+    fun select(vararg selection: Selection<*>): KConfigurableRootQuery<P, Tuple>
+
     fun <T1, T2> select(
         selection1: Selection<T1>,
         selection2: Selection<T2>

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
@@ -10,7 +10,6 @@ import org.babyfish.jimmer.sql.ast.impl.query.MutableStatementImplementor
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor
 import org.babyfish.jimmer.sql.ast.query.Order
 import org.babyfish.jimmer.sql.ast.query.specification.PredicateApplier
-import org.babyfish.jimmer.sql.ast.table.Table
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike
 import org.babyfish.jimmer.sql.ast.tuple.*
 import org.babyfish.jimmer.sql.kt.KSubQueries
@@ -26,10 +25,8 @@ import org.babyfish.jimmer.sql.kt.ast.query.specification.KSpecificationArgs
 import org.babyfish.jimmer.sql.kt.ast.query.specification.KSpecification
 import org.babyfish.jimmer.sql.kt.ast.table.KBaseTable
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
-import org.babyfish.jimmer.sql.kt.ast.table.KNullableTableEx
 import org.babyfish.jimmer.sql.kt.ast.table.KPropsLike
 import org.babyfish.jimmer.sql.kt.ast.table.impl.KNonNullTableExImpl
-import org.babyfish.jimmer.sql.kt.ast.table.impl.KNullableTableExImpl
 import org.babyfish.jimmer.sql.kt.impl.KSubQueriesImpl
 import org.babyfish.jimmer.sql.kt.impl.KWildSubQueriesImpl
 
@@ -68,6 +65,10 @@ internal abstract class KMutableRootQueryImpl<P: KPropsLike>(
     override fun having(vararg predicates: KNonNullExpression<Boolean>?) {
         javaQuery.having(*predicates.mapNotNull { it?.toJavaPredicate() }.toTypedArray())
     }
+
+    override fun select(vararg selection: Selection<*>): KConfigurableRootQuery<P, Tuple> =
+        KConfigurableRootQueryImpl(javaQuery.select(*selection))
+
 
     override fun <T> select(selection: Selection<T>): KConfigurableRootQuery<P, T> =
         KConfigurableRootQueryImpl(javaQuery.select(selection))

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
@@ -7,8 +7,6 @@ import org.babyfish.jimmer.sql.ast.Expression;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
-import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbol;
-import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbols;
 import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
 import org.babyfish.jimmer.sql.ast.query.*;
 import org.babyfish.jimmer.sql.ast.query.specification.PredicateApplier;
@@ -27,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MutableRootQueryImpl<T extends TableLike<?>>
         extends AbstractMutableQueryImpl
@@ -100,6 +100,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
                 this
         );
     }
+
 
     @Override
     public <T1, T2> ConfigurableRootQuery<T, Tuple2<T1, T2>> select(Selection<T1> selection1, Selection<T2> selection2) {
@@ -226,6 +227,16 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
                 ),
                 this
         );
+    }
+
+    @Override
+    public ConfigurableRootQuery<T, Tuple> select(Selection<?>... selection) {
+        return new ConfigurableRootQueryImpl<>(
+                new TypedQueryData(
+                        Stream.of(selection).collect(Collectors.toList())),
+                this
+        );
+
     }
 
     @SuppressWarnings("unchecked")

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/RootSelectable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/RootSelectable.java
@@ -80,6 +80,10 @@ public interface RootSelectable<T extends TableLike<?>> {
             Selection<T9> selection9
     );
 
+    ConfigurableRootQuery<T, ?> select(
+            Selection<?> ...selection
+    );
+
     default ConfigurableRootQuery<T, Long> selectCount() {
         return select(Expression.rowCount());
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/tuple/Tuple.kt
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/tuple/Tuple.kt
@@ -1,0 +1,42 @@
+package org.babyfish.jimmer.sql.ast.tuple
+
+import org.babyfish.jimmer.sql.ast.impl.TupleImplementor
+import java.util.function.BiFunction
+
+data class Tuple (
+    val items: Array<out Any?>
+): TupleImplementor {
+
+    companion object {
+        @JvmStatic
+        fun from(vararg items: Any?): Tuple = Tuple(items)
+        @JvmStatic
+        fun fromList(items: List<Any>): Tuple = Tuple(items.toTypedArray())
+    }
+
+    override fun size(): Int {
+        return items.size
+    }
+
+    override operator fun get(index: Int): Any? {
+        if (index !in items.indices) {
+            throw IllegalArgumentException("Index out of range: $index")
+        }
+
+        return items[index]
+    }
+
+    override fun convert(block: BiFunction<in Any, Int?, in Any>?): TupleImplementor? {
+        return Tuple(items.mapIndexed { index, any ->
+            block?.apply(any as Any, index) ?: any
+        }.toTypedArray())
+
+    }
+
+    fun <T> getAs(index: Int): T? {
+        return get(index) as? T
+    }
+
+    fun toList(): List<Any?> = items.toList()
+
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/tuple/TupleExtension.kt
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/tuple/TupleExtension.kt
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.ast.tuple
 
+fun Tuple.map(block: (Any) -> Any): Any = block(items)
 fun <T1, T2, R> Tuple2<T1, T2>.map(block: (T1, T2) -> R): R = block(_1, _2)
 
 fun <T1, T2, T3, R> Tuple3<T1, T2, T3>.map(block: (T1, T2, T3) -> R): R = block(_1, _2, _3)

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Reader.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Reader.java
@@ -10,6 +10,8 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 public interface Reader<T> {
 
@@ -66,6 +68,7 @@ public interface Reader<T> {
             return draftContext().resolveObject(spi);
         }
     }
+
 
     static <T1, T2> Reader<Tuple2<T1, T2>> tuple(Reader<T1> reader1, Reader<T2> reader2) {
         return new Reader<Tuple2<T1, T2>>() {
@@ -312,6 +315,25 @@ public interface Reader<T> {
                         reader8.read(rs, ctx),
                         reader9.read(rs, ctx)
                 );
+            }
+        };
+    }
+
+    static  Reader<Tuple> tuple(List<Reader<?>> readers) {
+        return new Reader<Tuple>() {
+
+            @Override
+            public void skip(Context ctx) {
+                readers.forEach(reader -> reader.skip(ctx));
+            }
+
+            @Override
+            public Tuple read(ResultSet rs, Context ctx) throws SQLException {
+                List<Object> items = new ArrayList<>(readers.size());
+                for(Reader<?> reader : readers) {
+                    items.add(reader.read(rs, ctx));
+                }
+                return Tuple.fromList(items);
             }
         };
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Readers.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Readers.java
@@ -14,6 +14,7 @@ import org.babyfish.jimmer.sql.fetcher.impl.FetcherSelection;
 import org.babyfish.jimmer.sql.fetcher.impl.JoinFetchFieldVisitor;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 class Readers {
 
@@ -92,7 +93,14 @@ class Readers {
                         createSingleReader(sqlClient, selections.get(8))
                 );
             default:
-                throw new IllegalArgumentException("The selection count must between 1 and 9");
+                return Reader.tuple(
+                        selections
+                                .stream()
+                                .map(selection ->
+                                     createSingleReader(sqlClient, selection)
+                                )
+                                .collect(Collectors.toList())
+                );
         }
     }
 


### PR DESCRIPTION
- 在 KRootSelectable 和 RootSelectable 接口中添加了支持可变数量选择项的 select 方法
- 实现了对应的查询和读取逻辑，支持任意数量的选择项
- 新增 Tuple 类和相关扩展方法，用于处理多个选择项的结果

在select 超过9个的时候会使用 返回List<Tuple> 类型的结果 
```
data class Data(
    val field: Long,
    val field1: Long,
    val field2: Professional,
...
)
var rows = select(table.xxx,table.xxx, sum(table.xxx), avg(table.xxx), ....)
var typedRows = row.map{
   Data(
     field: it.getAs(0)!!,
     field1: it.getAs(1)!!,
     field2: it.getAs(2)!!,
     ...
   )
}
```

这样虽然不能达到完全的类型校验但是在映射的时候可以通过class 中定义的类型校验下，唯一需要处理的地方就是在获取列和字段对应需要明确，这样可以完成对于统计业务时不需要切换到jdbc =