### PR TITLE
Improve the expression code and logic of `Deprecated.replaceWith`

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repository/KRepository.kt
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repository/KRepository.kt
@@ -234,7 +234,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entity) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(entity, block).execute(fetcher).modifiedEntity")
     )
     fun save(
         entity: E ,
@@ -248,7 +248,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode, block).execute(fetcher).modifiedEntity")
     )
     fun save(
         entity: E ,
@@ -264,7 +264,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entities) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(entities, block).execute(fetcher).items.map { it.modifiedEntity }")
     )
     fun saveEntities(
         entities: Iterable<E> ,
@@ -278,7 +278,9 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entities, mode, associatedMode) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith(
+            "saveCommand(entities, mode, associatedMode, block).execute(fetcher).items.map { it.modifiedEntity }"
+        )
     )
     fun saveEntities(
         entities: Iterable<E> ,
@@ -294,7 +296,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(input) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(input, block).execute(fetcher).modifiedEntity")
     )
     fun save(
         input: Input<E> ,
@@ -308,7 +310,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode, block).execute(fetcher).modifiedEntity")
     )
     fun save(
         input: Input<E> ,
@@ -324,7 +326,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveInputsCommand(inputs) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith("saveInputsCommand(inputs, block).execute(fetcher).items.map { it.modifiedEntity }")
     )
     fun saveInputs(
         inputs: Iterable<Input<E>> ,
@@ -338,7 +340,9 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode) {...}.execute(fetcher)")
+        replaceWith = ReplaceWith(
+            "saveCommand(entity, mode, associatedMode, block).execute(fetcher).items.map { it.modifiedEntity }"
+        )
     )
     fun saveInputs(
         inputs: Iterable<Input<E>> ,
@@ -354,7 +358,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entity) {...}.execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(entity, block).execute(viewType).modifiedView")
     )
     fun <V: View<E>> save(
         entity: E ,
@@ -368,7 +372,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode) {...}.execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode, block).execute(viewType).modifiedView")
     )
     fun <V: View<E>> save(
         entity: E ,
@@ -384,7 +388,9 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveEntitiesCommand(entities) {...}.execute(viewType)")
+        replaceWith = ReplaceWith(
+            "saveEntitiesCommand(entities, block).execute(viewType).viewItems.map { it.modifiedView }"
+        )
     )
     fun <V: View<E>> saveEntities(
         entities: Iterable<E> ,
@@ -398,7 +404,10 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveEntitiesCommand(entity, mode, associatedMode) {...}.execute(viewType)")
+        replaceWith = ReplaceWith(
+            "saveEntitiesCommand(entity, mode, associatedMode, block).execute(viewType)" +
+                    ".viewItems.map { it.modifiedView }"
+        )
     )
     fun <V: View<E>> saveEntities(
         entities: Iterable<E> ,
@@ -414,7 +423,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(input) {...}.execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(input, block).execute(viewType).modifiedView")
     )
     fun <V: View<E>> save(
         input: Input<E> ,
@@ -428,7 +437,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode) {...}.execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode, block).execute(viewType).modifiedView")
     )
     fun <V: View<E>> save(
         input: Input<E> ,
@@ -444,7 +453,9 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveInputsCommand(inputs) {...}.execute(viewType)")
+        replaceWith = ReplaceWith(
+            "saveInputsCommand(inputs, block).execute(viewType).viewItems.map { it.modifiedView }"
+        )
     )
     fun <V: View<E>> saveInputs(
         inputs: Iterable<Input<E>> ,
@@ -458,7 +469,10 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
     @Deprecated(
         "saving and re-fetching by fetcher/viewType is advanced feature, " +
             "please use `saveCommand`",
-        replaceWith = ReplaceWith("saveInputsCommand(inputs, mode, associatedMode) {...}.execute(viewType)")
+        replaceWith = ReplaceWith(
+            "saveInputsCommand(inputs, mode, associatedMode, block).execute(viewType)" +
+                    ".viewItems.map { it.modifiedView }"
+        )
     )
     fun <V: View<E>> saveInputs(
         inputs: Iterable<Input<E>> ,
@@ -472,7 +486,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
             .viewItems.map { it.modifiedView }
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(input, SaveMode.INSERT_ONLY, associatedMode, null, block)",
+        "save(input, SaveMode.INSERT_ONLY, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -484,7 +498,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(input, SaveMode.INSERT_ONLY, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(entity, SaveMode.INSERT_ONLY, associatedMode, null, block)",
+        "save(entity, SaveMode.INSERT_ONLY, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -496,7 +510,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(entity, SaveMode.INSERT_ONLY, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(input, SaveMode.INSERT_IF_ABSENT, associatedMode, null, block)",
+        "save(input, SaveMode.INSERT_IF_ABSENT, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -508,7 +522,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(input, SaveMode.INSERT_IF_ABSENT, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(entity, SaveMode.INSERT_IF_ABSENT, associatedMode, null, block)",
+        "save(entity, SaveMode.INSERT_IF_ABSENT, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -520,7 +534,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(entity, SaveMode.INSERT_IF_ABSENT, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(input, SaveMode.UPDATE_ONLY, associatedMode, null, block)",
+        "save(input, SaveMode.UPDATE_ONLY, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -532,7 +546,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(input, SaveMode.UPDATE_ONLY, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(entity, SaveMode.UPDATE_ONLY, associatedMode, null, block)",
+        "save(entity, SaveMode.UPDATE_ONLY, associatedMode, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode"
     )
     )
@@ -544,7 +558,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(entity, SaveMode.UPDATE_ONLY, associatedMode, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(input, SaveMode.UPSERT, AssociatedSaveMode.MERGE, null, block)",
+        "save(input, SaveMode.UPSERT, AssociatedSaveMode.MERGE, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode",
         "org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode"
     )
@@ -556,7 +570,7 @@ interface KRepository<E: Any, ID: Any> : PagingAndSortingRepository<E, ID> {
         save(input, SaveMode.UPSERT, AssociatedSaveMode.MERGE, block)
 
     @Deprecated("Please use save", ReplaceWith(
-        "save(entity, SaveMode.UPSERT, AssociatedSaveMode.MERGE, null, block)",
+        "save(entity, SaveMode.UPSERT, AssociatedSaveMode.MERGE, block)",
         "org.babyfish.jimmer.sql.ast.mutation.SaveMode",
         "org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode"
     )

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KDeprecatedMoreSaveOperations.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KDeprecatedMoreSaveOperations.kt
@@ -11,7 +11,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features", 
-        replaceWith = ReplaceWith(".entities.saveInputs(inputs, mode, associatedMode, viewType, block")
+        replaceWith = ReplaceWith("entities.saveInputs(inputs, mode, associatedMode, viewType, block)")
     )
     override fun <E : Any, V : View<E>> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -25,7 +25,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveInputs(inputs, viewType, block")
+        replaceWith = ReplaceWith("entities.saveInputs(inputs, viewType, block)")
     )
     override fun <E : Any, V : View<E>> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -37,7 +37,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(input, mode, associatedMode, viewType, block")
+        replaceWith = ReplaceWith("entities.save(input, mode, associatedMode, viewType, block)")
     )
     override fun <E : Any, V : View<E>> save(
         input: Input<E>,
@@ -51,7 +51,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(input, viewType, block")
+        replaceWith = ReplaceWith("entities.save(input, viewType, block)")
     )
     override fun <E : Any, V : View<E>> save(
         input: Input<E>,
@@ -63,7 +63,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveEntities(entities, mode, associatedMode, viewType, block")
+        replaceWith = ReplaceWith("entities.saveEntities(entities, mode, associatedMode, viewType, block)")
     )
     override fun <E : Any, V : View<E>> saveEntities(
         entities: Iterable<E>,
@@ -77,7 +77,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveEntities(entities, viewType, block")
+        replaceWith = ReplaceWith("entities.saveEntities(entities, viewType, block)")
     )
     override fun <E : Any, V : View<E>> saveEntities(
         entities: Iterable<E>,
@@ -89,7 +89,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(entity, mode, associatedMode, viewType, block")
+        replaceWith = ReplaceWith("entities.save(entity, mode, associatedMode, viewType, block)")
     )
     override fun <E : Any, V : View<E>> save(
         entity: E,
@@ -103,7 +103,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(entity, viewType, block")
+        replaceWith = ReplaceWith("entities.save(entity, viewType, block)")
     )
     override fun <E : Any, V : View<E>> save(
         entity: E,
@@ -115,7 +115,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveInputs(inputs, mode, associatedMode, fetcher, block")
+        replaceWith = ReplaceWith("entities.saveInputs(inputs, mode, associatedMode, fetcher, block)")
     )
     override fun <E : Any> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -129,7 +129,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveInputs(inputs, fetcher, block")
+        replaceWith = ReplaceWith("entities.saveInputs(inputs, fetcher, block)")
     )
     override fun <E : Any> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -141,7 +141,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(input, mode, associatedMode, fetcher, block")
+        replaceWith = ReplaceWith("entities.save(input, mode, associatedMode, fetcher, block)")
     )
     override fun <E : Any> save(
         input: Input<E>,
@@ -155,7 +155,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(input, fetcher, block")
+        replaceWith = ReplaceWith("entities.save(input, fetcher, block)")
     )
     override fun <E : Any> save(
         input: Input<E>,
@@ -167,7 +167,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveEntities(entities, mode, associatedMode, fetcher, block")
+        replaceWith = ReplaceWith("entities.saveEntities(entities, mode, associatedMode, fetcher, block)")
     )
     override fun <E : Any> saveEntities(
         entities: Iterable<E>,
@@ -181,7 +181,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.saveEntities(entities, mode, associatedMode, fetcher, block")
+        replaceWith = ReplaceWith("entities.saveEntities(entities, mode, associatedMode, fetcher, block)")
     )
     override fun <E : Any> saveEntities(
         entities: Iterable<E>,
@@ -193,7 +193,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(entity, mode, associatedMode, fetcher, block")
+        replaceWith = ReplaceWith("entities.save(entity, mode, associatedMode, fetcher, block)")
     )
     override fun <E : Any> save(
         entity: E,
@@ -207,7 +207,7 @@ interface KDeprecatedMoreSaveOperations : KDeprecatedSaveOperations {
 
     @Deprecated(
         "Please use the function of `entities` with same features",
-        replaceWith = ReplaceWith(".entities.save(entity, fetcher, block")
+        replaceWith = ReplaceWith("entities.save(entity, fetcher, block)")
     )
     override fun <E : Any> save(
         entity: E,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KDeprecatedSaveOperations.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KDeprecatedSaveOperations.kt
@@ -517,7 +517,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(entity).execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(entity, block).execute(fetcher)")
     )
     fun <E: Any> save(
         entity: E,
@@ -529,7 +529,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(entity, mode, associatedMode).execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode, block).execute(fetcher)")
     )
     fun <E: Any> save(
         entity: E,
@@ -543,7 +543,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveEntitiesCommand(entities).execute(fetcher)")
+        replaceWith = ReplaceWith("saveEntitiesCommand(entities, block).execute(fetcher)")
     )
     fun <E: Any> saveEntities(
         entities: Iterable<E>,
@@ -555,7 +555,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveEntitiesCommand(entities, mode, associatedMode).execute(fetcher)")
+        replaceWith = ReplaceWith("saveEntitiesCommand(entities, mode, associatedMode, block).execute(fetcher)")
     )
     fun <E: Any> saveEntities(
         entities: Iterable<E>,
@@ -569,7 +569,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(input).execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(input, block).execute(fetcher)")
     )
     fun <E: Any> save(
         input: Input<E>,
@@ -581,7 +581,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(input, mode, associatedMode).execute(fetcher)")
+        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode, block).execute(fetcher)")
     )
     fun <E: Any> save(
         input: Input<E>,
@@ -595,7 +595,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveInputsCommand(inputs).execute(fetcher)")
+        replaceWith = ReplaceWith("saveInputsCommand(inputs, block).execute(fetcher)")
     )
     fun <E: Any> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -607,7 +607,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveInputsCommand(inputs, mode, associatedMode).execute(fetcher)")
+        replaceWith = ReplaceWith("saveInputsCommand(inputs, mode, associatedMode, block).execute(fetcher)")
     )
     fun <E: Any> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -621,7 +621,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(entity).execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(entity, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> save(
         entity: E,
@@ -633,7 +633,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(entity, mode, associatedMode).execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(entity, mode, associatedMode, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> save(
         entity: E,
@@ -647,7 +647,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveEntitiesCommand(entities).execute(viewType)")
+        replaceWith = ReplaceWith("saveEntitiesCommand(entities, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> saveEntities(
         entities: Iterable<E>,
@@ -659,7 +659,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveEntitiesCommand(entities, mode, associatedMode).execute(viewType)")
+        replaceWith = ReplaceWith("saveEntitiesCommand(entities, mode, associatedMode, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> saveEntities(
         entities: Iterable<E>,
@@ -673,7 +673,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(input).execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(input, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> save(
         input: Input<E>,
@@ -685,7 +685,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveCommand(input, mode, associatedMode).execute(viewType)")
+        replaceWith = ReplaceWith("saveCommand(input, mode, associatedMode, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> save(
         input: Input<E>,
@@ -699,7 +699,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveInputsCommand(inputs).execute(viewType)")
+        replaceWith = ReplaceWith("saveInputsCommand(inputs, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> saveInputs(
         inputs: Iterable<Input<E>>,
@@ -711,7 +711,7 @@ interface KDeprecatedSaveOperations : KSaveOperations {
 
     @Deprecated(
         "fetcher/viewType is advanced feature, please use saveCommand",
-        replaceWith = ReplaceWith(".saveInputsCommand(inputs, mode, associatedMode).execute(viewType)")
+        replaceWith = ReplaceWith("saveInputsCommand(inputs, mode, associatedMode, block).execute(viewType)")
     )
     fun <E: Any, V: View<E>> saveInputs(
         inputs: Iterable<Input<E>>,


### PR DESCRIPTION
Hello! I've noticed some issues with `Deprecated.ReplaceWith` in terms of the correctness and user-friendliness of the expression code, as well as the accuracy of the replacement logic.

### Quick Fix Usability Improvements

Some of the expression replacement code in `Deprecated.ReplaceWith` is not formatted correctly, which can lead to erroneous behavior or unfriendly replacements when performing quick fixes in the IDE.  
Take `KRepository.save` as an example. Originally, it was defined as:

```Kotlin  
@Deprecated(  
    "saving and re-fetching by fetcher/viewType is advanced feature, " +  
        "please use `saveCommand`",  
    replaceWith = ReplaceWith("saveCommand(entity) {...}.execute(fetcher)")  
)  
fun save(  
    entity: E ,  
    fetcher: Fetcher<E>,  
    block: (KSaveCommandDsl.() -> Unit)? = null  
): E =  
    saveCommand(entity, block)  
        .execute(fetcher)  
        .modifiedEntity  
```  

If the calling code is:

```Kotlin  
save(entity, fetcher) {  
    setMode(SaveMode.INSERT_ONLY)  
    println("hello")  
}  
```  

Using the quick fix, it would be replaced with:

```Kotlin  
fun KSaveCommandDsl.() {  
    setMode(SaveMode.INSERT_ONLY)  
    println("hello")  
}  
this.saveCommand(entity) { ... }.execute(fetcher)  
```  

As you can see, not only does this produce a meaningless `fun KSaveCommandDsl.()` (because the IDE cannot locate where the original block content should be placed), but it also includes `{ ... }`, which is not valid code.  
I understand that `{ ... }` is intended for users to manually replace with the original logic, but this is not ideal—since the IDE is capable of correctly replacing the block content.

If we change `ReplaceWith` to the following form:

```Kotlin  
@Deprecated(  
    "saving and re-fetching by fetcher/viewType is advanced feature, " +  
        "please use `saveCommand`",  
    replaceWith = ReplaceWith("saveCommand(entity, block).execute(fetcher).modifiedEntity")  
)  
fun save(  
    entity: E ,  
    fetcher: Fetcher<E>,  
    block: (KSaveCommandDsl.() -> Unit)? = null  
): E =  
    saveCommand(entity, block)  
        .execute(fetcher)  
        .modifiedEntity  
```  

Then the code can be correctly replaced with the actual logic represented by the deprecated `save`:

```Kotlin  
saveCommand(entity) {  
    setMode(SaveMode.INSERT_ONLY)  
    println("hello")  
}.execute(fetcher).modifiedEntity  
```  

### Logic Consistency Improvements

Additionally, some `ReplaceWith` implementations have replacement logic that doesn't fully match the actual logic, which could lead to inconsistent behavior before and after the replacement. For example:

```Kotlin  
@Deprecated(  
        "saving and re-fetching by fetcher/viewType is advanced feature, " +  
            "please use `saveCommand`",  
        replaceWith = ReplaceWith("saveCommand(entity) {...}.execute(fetcher)")  
    )  
    fun save(  
        entity: E ,  
        fetcher: Fetcher<E>,  
        block: (KSaveCommandDsl.() -> Unit)? = null  
    ): E =  
        saveCommand(entity, block)  
            .execute(fetcher)  
            .modifiedEntity  
```  

The original `save` logic retrieves `modifiedEntity` after `execute(...)`, but this is not reflected in `ReplaceWith`. This might confuse users after replacement (since the return type changes).  
Therefore, I updated it to ensure the replacement logic is consistent with the actual deprecated function:

```Kotlin  
@Deprecated(  
    "saving and re-fetching by fetcher/viewType is advanced feature, " +  
        "please use `saveCommand`",  
    replaceWith = ReplaceWith("saveCommand(entity, block).execute(fetcher).modifiedEntity")  
)  
fun save(  
    entity: E ,  
    fetcher: Fetcher<E>,  
    block: (KSaveCommandDsl.() -> Unit)? = null  
): E =  
    saveCommand(entity, block)  
        .execute(fetcher)  
        .modifiedEntity  
```  

Now, the modified code will behave consistently with the actual logic inside the deprecated function.

### Formatting Adjustments

For some replacements, I moved them to a new line, such as:

```Kotlin  
replaceWith = ReplaceWith("saveCommand(entities, mode, associatedMode) {...}.execute(fetcher)")  
```  

Changed to:

```Kotlin  
replaceWith = ReplaceWith(  
    "saveCommand(entities, mode, associatedMode, block).execute(fetcher).items.map { it.modifiedEntity }"  
)  
```  

This is because, after modification, a single line of code might exceed the typical character limit (120) in code style standards. Moving it to a new line ensures the code remains readable without undue strain.

### Summary

In summary, this PR fixes these non-standard and user-unfriendly `ReplaceWith` implementations, ensuring that quick fixes in the IDE replace them with correct and accurate code.  