### PR TITLE
fix(sql): 修复saveEntities 时对于根据ID直接更新的数据被忽略的问题

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -956,6 +956,8 @@ class UpsertPreHandler extends AbstractPreHandler {
                         items.add(newItem(draft, original));
                     }
                 }
+            } else {
+                updatedList = new ArrayList<>(draftsWithId);
             }
         }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -958,6 +958,7 @@ class UpsertPreHandler extends AbstractPreHandler {
                 }
             } else {
                 updatedList = new ArrayList<>(draftsWithId);
+                insertedList = new ArrayList<>();
             }
         }
 


### PR DESCRIPTION
当saveEntities 时 由于queryReason == QueryReason.NONE 导致例如 {id: 1, field: 'xxx', ...} 如果没有包含任何@Key的组合会导致这条数据直接被忽略

insertedList == null 的判断由于该情况下insertList 由draftsWithKey不为null 时赋值了 所以后续没有任何地方对draftsWithId有值但是又不需要数据库查询的情况下进行处理