### PR TITLE
修复批量的时候有insertedList不为空，导致同时拥有id和key的对象不进入updatedList出现updateMap为空的情况，缺失了一条数据的更新

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -1014,7 +1014,18 @@ class UpsertPreHandler extends AbstractPreHandler {
                     updatedMap.add(draft, true);
                 }
             }
-            this.mergedMap = ShapedEntityMap.empty();
+            // key如果在数据库存在的情况下 updatedMap不为空 如果不做判断会导致多一条merge sql
+            if (updatedMap != null) {
+                this.mergedMap = ShapedEntityMap.empty();
+            } else {
+                this.mergedMap = createEntityMap(
+                        null,
+                        draftsWithId,
+                        draftsWithKey,
+                        SaveMode.UPSERT,
+                        SaveMode.UPSERT
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
🐛 fix(PreHandler): Fixed the insertedList is not empty in batches, causing objects with both id and key to not enter the updatedList, and the updateMap is empty, and a data update is missing

#1150 