### PR TITLE
improve(build): use `kotlin.compilerOptions` to replace the deprecated `KotlinCompile.kotlinOptions`

### DIFF
--- a/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/kotlin-convention.gradle.kts
+++ b/project/buildSrc/src/main/kotlin/org/babyfish/jimmer/kotlin-convention.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("java-convention")
@@ -6,9 +6,10 @@ plugins {
 }
 
 val javaVersion = extensions.getByName<JavaPluginExtension>("java").targetCompatibility.toString()
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all")
-        jvmTarget = javaVersion
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xjvm-default=all")
+        jvmTarget = JvmTarget.fromTarget(javaVersion)
+        javaParameters = true
     }
 }


### PR DESCRIPTION
The `KotlinCompile.kotlinOptions` [has been deprecated since Kotlin 2.0.0](https://kotlinlang.org/docs/compatibility-guide-22.html#remove-kotlin-incremental-useclasspathsnapshot-property), and it's recommended to replace it with [`kotlin.compilerOptions`](https://kotlinlang.org/docs/gradle-compiler-options.html#how-to-define-options).

In addition to replacing the deprecated API, I added an extra option: `javaParameters = true`. 
Because it exists `options.compilerArgs.add("-parameters")` in the Java configuration, I think the same metadata should also be added for Java reflection in Kotlin to make the behavior of Java and Kotlin more consistent.