### PR TITLE
✨ fix(#1182): 支持原始数值类型的子查询

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableSubQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableSubQueryImpl.java
@@ -78,6 +78,10 @@ public class ConfigurableSubQueryImpl<R>
                 if (type == String.class) {
                     return (TypedSubQuery<R>) new Str(data, baseQuery);
                 }
+                // 基础类型 long int double之类
+                if (isNumericType(type)) {
+                    return (TypedSubQuery<R>) new Num<>(data, baseQuery);
+                }
                 if (Number.class.isAssignableFrom(type)) {
                     return (TypedSubQuery<R>) new Num<>(data, baseQuery);
                 }
@@ -93,6 +97,11 @@ public class ConfigurableSubQueryImpl<R>
             }
         }
         return new ConfigurableSubQueryImpl<>(data, baseQuery);
+    }
+
+    private static boolean isNumericType(Class<?> type) {
+        return type == long.class || type == int.class || type == double.class ||
+                type == float.class || type == short.class || type == byte.class;
     }
 
     @Override


### PR DESCRIPTION
添加对 long/int/double 等原始数值类型的子查询支持，
使其与包装类型具有相同的处理逻辑。
#1182