### PR TITLE
improve(dto-apt): update DTO specification `applyTo` predicate operation to use getter methods for property access instead of property name

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -1277,6 +1277,7 @@ public class DtoGenerator {
 
     private void addPredicateOperation(MethodSpec.Builder builder, DtoProp<ImmutableType, ImmutableProp> prop) {
         String propName = prop.getName();
+        String propGetter = getterName(prop);
         DtoProp<ImmutableType, ImmutableProp> tailProp = prop.toTailProp();
         if (tailProp.getTargetType() != null) {
             builder.beginControlFlow("if (this.$L != null)", propName);
@@ -1330,12 +1331,12 @@ public class DtoGenerator {
         }
         if (isSpecificationConverterRequired(tailProp)) {
             cb.add(
-                    "$L(this.$L)",
+                    "$L(this.$L())",
                     StringUtil.identifier("__convert", propName),
-                    propName
+                    propGetter
             );
         } else {
-            cb.add("this.$L", propName);
+            cb.add("this.$L()", propGetter);
         }
         if ("like".equals(funcName) || "notLike".equals(funcName)) {
             cb.add(", ");


### PR DESCRIPTION
Hello!

I have the following DTO specification:

```
specification ChapterSpecification {
    associatedIdEq(parent)
    like(title)
    associatedIdEq(subject)!
    associatedIdEq(phase)!
    associatedIdEq(grade)!
    associatedIdEq(edition)!
}
```

In this specification, I want properties `subjectId`, `phaseId`, `gradeId`, and `editionId` to be required, so I added `!` to make them non-null.

But when I conducted the test:

```Java
    @GetMapping("all")
    public List<Chapter> all(ChapterSpecification specification) {
        return service.all(specification); // sql.createQuery(TABLE).where(specification).execute()
    }
```

```http
GET http://localhost:8100/chapter/all?subjectId=2&phaseId=2&gradeId=201&edition=74
```

I accidentally mistyped `editionId` as `edition`, but afterwards I discovered that the endpoint did not produce an error and could still query normally.

Then I discovered that in the generated Specification class, the `applyTo` function directly references internal properties instead of getter functions.

The `applyTo`:

```Java
@Override
    public void applyTo(SpecificationArgs<Chapter, ChapterTable> args) {
        PredicateApplier __applier = args.getApplier();
        __applier.associatedIdEq(new ImmutableProp[] { ChapterProps.PARENT.unwrap() }, this.parentId);
        __applier.like(new ImmutableProp[] { ChapterProps.TITLE.unwrap() }, this.title, false, false, false);
        __applier.associatedIdEq(new ImmutableProp[] { ChapterProps.SUBJECT.unwrap() }, this.subjectId);
        __applier.associatedIdEq(new ImmutableProp[] { ChapterProps.PHASE.unwrap() }, this.phaseId);
        __applier.associatedIdEq(new ImmutableProp[] { ChapterProps.GRADE.unwrap() }, this.gradeId);
        __applier.associatedIdEq(new ImmutableProp[] { ChapterProps.EDITION.unwrap() }, this.editionId);
    }
```

However, the null check for the property is performed within the getter function.
The getter for one of the properties:

```Java
public int getSubjectId() {
        if (subjectId == null) {
            throw new IllegalStateException("The property \"subjectId\" is not specified");
        }
        return subjectId;
    }
```

Therefore, I believe this should not be expected: if the getter is not manually called externally, null checks cannot be triggered in the `where(specification)` clause.
So I adjusted part of the apt implementation to use the getter instead of the property itself during the `__applier.xxx` process.

However, I did not modify the propName in the logic below:

https://github.com/babyfish-ct/jimmer/blob/4cc6a17abb02fbcd8c183fdb1a6e1b7965b48297/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java#L1281-L1290

Because I am unsure of the trigger conditions for this code (I couldn't reproduce it locally), and there is a clear `!= null` conditional branch here. 
I don't know if directly using the property itself here aligns with the original design intent.

If you have any questions, please feel free to point them out!