### PR TITLE
Update exception message for invalid entity type

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
@@ -635,7 +635,7 @@ public class EntitiesImpl implements Entities {
     @Override
     public <E> SimpleEntitySaveCommand<E> saveCommand(E entity) {
         if (entity instanceof Iterable<?>) {
-            throw new IllegalArgumentException("entity cannot be collection, do you want to call `saveAll/saveAllCommand`?");
+            throw new IllegalArgumentException("entity cannot be collection, do you want to call `saveEntities/saveEntitiesCommand`?");
         }
         if (entity instanceof Input<?>) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
Changed the exception message in saveCommand to suggest 'saveEntities/saveEntitiesCommand' instead of 'saveAll/saveAllCommand' when a collection is passed as an entity.