### PR TITLE
fix: TypedTupleTest.testLombokEntityTuple测试对象错误的问题

### DIFF
--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/tuple/TypedTupleTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/tuple/TypedTupleTest.java
@@ -222,7 +222,7 @@ public class TypedTupleTest extends AbstractQueryTest {
                 getSqlClient().createQuery(table)
                         .where(table.edition().eq(3))
                         .select(
-                                EntityTupleMapper
+                                LombokEntityTupleMapper
                                         .book(
                                                 table.fetch(
                                                         BookFetcher.$.name()


### PR DESCRIPTION
发现org.babyfish.jimmer.sql.tuple.TypedTupleTest中testLombokEntityTuple中应使用LombokEntityTupleMapper，但是却使用的是EntityTupleMapper，而这个在testEntityTuple中测试过，这里写错了。