### PR TITLE
[feat]支持自定义Redis缓存键前缀提供器

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cache/RedisCacheCreator.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cache/RedisCacheCreator.java
@@ -7,12 +7,15 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.cache.Cache;
 import org.babyfish.jimmer.sql.cache.CacheCreator;
+import org.babyfish.jimmer.sql.cache.RemoteKeyPrefixProvider;
 import org.babyfish.jimmer.sql.cache.caffeine.CaffeineHashBinder;
 import org.babyfish.jimmer.sql.cache.caffeine.CaffeineValueBinder;
 import org.babyfish.jimmer.sql.cache.chain.ChainCacheBuilder;
 import org.babyfish.jimmer.sql.cache.chain.LoadingBinder;
 import org.babyfish.jimmer.sql.cache.chain.SimpleBinder;
 import org.babyfish.jimmer.sql.cache.spi.AbstractCacheCreator;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 import java.util.Objects;
@@ -150,6 +153,95 @@ public class RedisCacheCreator extends AbstractCacheCreator {
                 .publish(args.tracker)
                 .objectMapper(args.objectMapper)
                 .keyPrefixProvider(args.keyPrefixProvider)
+                .duration(args.multiVewDuration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.connectionFactory)
+                .build()
+                .lock(
+                        args.locker,
+                        args.lockWaitDuration,
+                        args.lockLeaseDuration
+                );
+    }
+
+    @Override
+    public <K, V> Cache<K, V> createForObject(ImmutableType type, @NonNull RemoteKeyPrefixProvider keyPrefixProvider) {
+        return new ChainCacheBuilder<K, V>()
+                .add(caffeineValueBinder(type))
+                .add(redisValueBinder(type, keyPrefixProvider))
+                .build();
+    }
+
+    @Override
+    public <K, V> Cache<K, V> createForProp(
+            ImmutableProp prop,
+            boolean multiView,
+            @NonNull RemoteKeyPrefixProvider keyPrefixProvider
+    ) {
+        if (multiView) {
+            return new ChainCacheBuilder<K, V>()
+                    .add(caffeineHashBinder(prop))
+                    .add(redisHashBinder(prop, keyPrefixProvider))
+                    .build();
+        }
+        return new ChainCacheBuilder<K, V>()
+                .add(caffeineValueBinder(prop))
+                .add(redisValueBinder(prop, keyPrefixProvider))
+                .build();
+    }
+
+    private <K, V> SimpleBinder<K, V> redisValueBinder(
+            ImmutableType type,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisValueBinder
+                .<K, V>forObject(type)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
+                .duration(args.duration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.connectionFactory)
+                .build()
+                .lock(
+                        args.locker,
+                        args.lockWaitDuration,
+                        args.lockLeaseDuration
+                );
+    }
+
+    private <K, V> SimpleBinder<K, V> redisValueBinder(
+            ImmutableProp prop,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisValueBinder
+                .<K, V>forProp(prop)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
+                .duration(args.duration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.connectionFactory)
+                .build()
+                .lock(
+                        args.locker,
+                        args.lockWaitDuration,
+                        args.lockLeaseDuration
+                );
+    }
+
+    private <K, V> SimpleBinder.Parameterized<K, V> redisHashBinder(
+            ImmutableProp prop,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisHashBinder
+                .<K, V>forProp(prop)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
                 .duration(args.multiVewDuration)
                 .randomPercent(args.randomDurationPercent)
                 .redis(args.connectionFactory)

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/CacheCreator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/CacheCreator.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Duration;
 
@@ -134,6 +135,14 @@ public interface CacheCreator {
     <K, V> Cache<K, V> createForObject(ImmutableType type);
 
     <K, V> Cache<K, V> createForProp(ImmutableProp prop, boolean multiView);
+
+    <K, V> Cache<K, V> createForObject(ImmutableType type, @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider);
+
+    <K, V> Cache<K, V> createForProp(
+            ImmutableProp prop,
+            boolean multiView,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    );
 
     Duration DEFAULT_REMOTE_DURATION = Duration.ofMinutes(30);
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/redis/quarkus/RedisCacheCreator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/redis/quarkus/RedisCacheCreator.java
@@ -7,6 +7,7 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.cache.Cache;
 import org.babyfish.jimmer.sql.cache.CacheCreator;
+import org.babyfish.jimmer.sql.cache.RemoteKeyPrefixProvider;
 import org.babyfish.jimmer.sql.cache.caffeine.CaffeineHashBinder;
 import org.babyfish.jimmer.sql.cache.caffeine.CaffeineValueBinder;
 import org.babyfish.jimmer.sql.cache.chain.ChainCacheBuilder;
@@ -18,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.quarkus.redis.datasource.RedisDataSource;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * framework-related classes should not be included in the jimmer-sql module.<br>
@@ -146,6 +149,86 @@ public class RedisCacheCreator extends AbstractCacheCreator {
                 .publish(args.tracker)
                 .objectMapper(args.objectMapper)
                 .keyPrefixProvider(args.keyPrefixProvider)
+                .duration(args.multiVewDuration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.redisDataSource)
+                .build()
+                .lock(args.locker, args.lockWaitDuration, args.lockLeaseDuration);
+    }
+
+    @Override
+    public <K, V> Cache<K, V> createForObject(
+            ImmutableType type,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        return new ChainCacheBuilder<K, V>()
+                .add(caffeineValueBinder(type))
+                .add(redisValueBinder(type,userKeyPrefixProvider))
+                .build();
+    }
+
+    @Override
+    public <K, V> Cache<K, V> createForProp(
+            ImmutableProp prop,
+            boolean multiView,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        if (multiView) {
+            return new ChainCacheBuilder<K, V>()
+                    .add(caffeineHashBinder(prop))
+                    .add(redisHashBinder(prop,userKeyPrefixProvider))
+                    .build();
+        }
+        return new ChainCacheBuilder<K, V>()
+                .add(caffeineValueBinder(prop))
+                .add(redisValueBinder(prop,userKeyPrefixProvider))
+                .build();
+    }
+
+    private <K, V> SimpleBinder<K, V> redisValueBinder(
+            ImmutableType type,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisValueBinder
+                .<K, V> forObject(type)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
+                .duration(args.duration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.redisDataSource)
+                .build()
+                .lock(args.locker, args.lockWaitDuration, args.lockLeaseDuration);
+    }
+
+    private <K, V> SimpleBinder<K, V> redisValueBinder(
+            ImmutableProp prop,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisValueBinder
+                .<K, V> forProp(prop)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
+                .duration(args.duration)
+                .randomPercent(args.randomDurationPercent)
+                .redis(args.redisDataSource)
+                .build()
+                .lock(args.locker, args.lockWaitDuration, args.lockLeaseDuration);
+    }
+
+    private <K, V> SimpleBinder.Parameterized<K, V> redisHashBinder(
+            ImmutableProp prop,
+            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
+    ) {
+        Args args = args();
+        return RedisHashBinder
+                .<K, V> forProp(prop)
+                .publish(args.tracker)
+                .objectMapper(args.objectMapper)
+                .keyPrefixProvider(userKeyPrefixProvider)
                 .duration(args.multiVewDuration)
                 .randomPercent(args.randomDurationPercent)
                 .redis(args.redisDataSource)


### PR DESCRIPTION
✨ feat(cache): 支持自定义Redis缓存键前缀提供器

- 为 `createForObject` 和 `createForProp` 方法新增 `userKeyPrefixProvider` 参数
- 添加 `getRemoteKeyPrefixProvider` 方法处理键前缀提供器优先级
- 当用户提供自定义前缀提供器时优先使用，否则使用默认配置

🎯 提升缓存键的灵活性和可定制性，支持多租户等场景

主要是提供两个重载方法以及子类重写
```java
    <K, V> Cache<K, V> createForObject(ImmutableType type, @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider);

    <K, V> Cache<K, V> createForProp(
            ImmutableProp prop,
            boolean multiView,
            @NonNull RemoteKeyPrefixProvider userKeyPrefixProvider
    );
```