### PR TITLE
fix where dsl in kotlin

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KFilterable.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KFilterable.kt
@@ -14,7 +14,7 @@ interface KFilterable<P: KPropsLike> : KSubQueryProvider<P> {
 
     fun where(vararg predicates: KNonNullExpression<Boolean>?)
 
-    fun where(block: () -> KNonNullPropExpression<Boolean>?)
+    fun where(block: () -> KNonNullExpression<Boolean>?)
 }
 
 @JvmInline


### PR DESCRIPTION
<img width="1073" height="188" alt="截屏2025-10-30 10 07 41" src="https://github.com/user-attachments/assets/bf772e01-a388-4949-ad17-d13b9f6fa866" />
When the where statement is changed to Kotlin DSL, an error is reported due to a problem with the receiving parameter. The same receive parameters should be maintained as the where() method