### PR TITLE
Add log level and make ExecutorForLog constructor inheritable, increa…

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Investigators.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Investigators.java
@@ -1,11 +1,12 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
 import org.babyfish.jimmer.sql.runtime.*;
-import org.jetbrains.annotations.Nullable;
+import org.slf4j.event.Level;
 
 class Investigators {
 
-    private Investigators() {}
+    private Investigators() {
+    }
 
     public static JSqlClientImplementor toInvestigatorSqlClient(
             JSqlClientImplementor sqlClient,
@@ -20,10 +21,10 @@ class Investigators {
         }
         InvestigatorLogger investigatorLogger = new InvestigatorLogger(executorLog.getLogger());
         if (args instanceof Executor.BatchContext) {
-            ((Executor.BatchContext)args).addExecutedListener(investigatorLogger::submit);
+            ((Executor.BatchContext) args).addExecutedListener(investigatorLogger::submit);
         }
         return sqlClient.executor(
-                ExecutorForLog.wrap(sqlClient.getExecutor(), investigatorLogger)
+                ExecutorForLog.wrap(sqlClient.getExecutor(), investigatorLogger, Level.INFO)
         );
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Executor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Executor.java
@@ -5,11 +5,11 @@ import org.babyfish.jimmer.sql.exception.ExecutionException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -39,23 +39,53 @@ public interface Executor {
             ExecutionPurpose purpose,
             @Nullable ExecutorContext ctx,
             JSqlClientImplementor sqlClient
-    ) {}
+    ) {
+    }
 
     static Executor log() {
-        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, null);
+        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, null, Level.INFO);
+    }
+
+    /**
+     * Log the SQL execution result with the specified level
+     */
+    static Executor log(Level level) {
+        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, null, level);
     }
 
     static Executor log(Executor executor) {
-        return ExecutorForLog.wrap(executor, null);
+        return ExecutorForLog.wrap(executor, null, Level.INFO);
+    }
+
+    /**
+     * Log the SQL execution result with the specified level
+     */
+    static Executor log(Executor executor, Level level) {
+        return ExecutorForLog.wrap(executor, null, level);
     }
 
     static Executor log(Logger logger) {
-        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, logger);
+        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, logger, Level.INFO);
+    }
+
+    /**
+     * Log the SQL execution result with the specified level
+     */
+    static Executor log(Logger logger, Level level) {
+        return ExecutorForLog.wrap(DefaultExecutor.INSTANCE, logger, level);
     }
 
     static Executor log(Executor executor, Logger logger) {
-        return ExecutorForLog.wrap(executor, logger);
+        return ExecutorForLog.wrap(executor, logger, Level.INFO);
     }
+
+    /**
+     * Log the SQL execution result with the specified level
+     */
+    static Executor log(Executor executor, Logger logger, Level level) {
+        return ExecutorForLog.wrap(executor, logger, level);
+    }
+
 
     static void validateMutationConnection(Connection con) {
         try {
@@ -185,12 +215,19 @@ public interface Executor {
 
     interface BatchContext extends ExceptionTranslator.Args, AutoCloseable {
         JSqlClientImplementor sqlClient();
+
         String sql();
+
         ExecutionPurpose purpose();
+
         ExecutorContext ctx();
+
         void add(List<Object> variables);
+
         int[] execute(BiFunction<SQLException, ExceptionTranslator.Args, Exception> exceptionTranslator);
+
         Object[] generatedIds();
+
         void addExecutedListener(Runnable listener);
 
         @Override


### PR DESCRIPTION
…sing flexibility. Due to the additional changes involved in modifying the configuration of SQL Client, no changes will be made.

添加日志级别，使ExecutorForLog构造函数可继承，增加灵活性。由于修改SQL客户端配置时涉及其他更改，因此不会进行任何更改。

Add log level and make ExecutorForLog constructor inheritable, increasing flexibility. Due to the additional changes involved in modifying the configuration of SQL Client, no changes will be made.
添加日志级别，使ExecutorForLog构造函数可继承，增加灵活性。由于修改SQL客户端配置时涉及其他更改，因此不会进行任何更改。
