### PR TITLE
feat: add orderByIf(condition, Supplier<List<Order>>) API

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/Sortable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/Sortable.java
@@ -111,4 +111,12 @@ public interface Sortable extends Filterable {
         }
         return this;
     }
+
+    @OldChain
+    default Sortable orderByIf(boolean condition, Supplier<List<Order>> block) {
+        if (condition) {
+            orderBy(block.get());
+        }
+        return this;
+    }
 }


### PR DESCRIPTION
I don't know whether I should mark orderByIf(condition, List<Order>) as deprecated, so I haven't done that yet.