### PR TITLE
feat: Support inline reified usage for AbstractKotlinRepository & KSqlClient

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repo/support/AbstractKotlinRepository.kt
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/repo/support/AbstractKotlinRepository.kt
@@ -151,6 +151,31 @@ abstract class AbstractKotlinRepository<E: Any, ID: Any>(
     override fun deleteByIds(ids: Iterable<ID>, deleteMode: DeleteMode): Int =
         sql.deleteByIds(entityType, ids, deleteMode).affectedRowCount(entityType)
 
+    inline fun <reified V : View<E>> findView(id: ID): V? {
+        return findById(id, V::class)
+    }
+
+    inline fun <reified V : View<E>> findViews(ids: Iterable<ID>): List<V> {
+        return findByIds(ids, V::class)
+    }
+
+    inline fun <reified V : View<E>> findMapView(ids: Iterable<ID>): Map<ID, V> {
+        return findMapByIds(ids, V::class)
+    }
+
+    inline fun <reified V : View<E>> findAllViews(
+        noinline block: (SortDsl<E>.() -> Unit)? = null
+    ): List<V> {
+        return findAll(V::class, block)
+    }
+
+    inline fun <reified V : View<E>> findPageView(
+        pageParam: PageParam,
+        noinline block: (SortDsl<E>.() -> Unit)? = null
+    ): Page<V> {
+        return findPage(pageParam, V::class, block)
+    }
+
     protected fun <R> executeQuery(
         block: KMutableRootQuery.ForEntity<E>.() -> KConfigurableRootQuery<KNonNullTable<E>, R>
     ): List<R> =

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
@@ -1,11 +1,23 @@
 package org.babyfish.jimmer.sql.kt
 
+import org.babyfish.jimmer.View
 import org.babyfish.jimmer.sql.association.Association
+import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
+import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.constant
-import org.babyfish.jimmer.sql.kt.ast.query.KMutableRootQuery
+import org.babyfish.jimmer.sql.kt.ast.mutation.KDeleteCommandDsl
+import org.babyfish.jimmer.sql.kt.ast.mutation.KDeleteResult
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
+import org.babyfish.jimmer.sql.kt.ast.query.*
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
+import org.babyfish.jimmer.sql.kt.ast.table.KPropsWeakJoinFun
+import org.babyfish.jimmer.sql.kt.ast.table.KRecursiveRef
+import java.sql.Connection
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
+
 
 fun <E : Any> KSqlClient.exists(
     type: KClass<E>,
@@ -30,3 +42,104 @@ fun <S : Any, T : Any> KSqlClient.refExists(
     block()
     select(constant(1))
 }.limit(1).execute().isNotEmpty()
+
+inline fun <reified E : Any, R> KSqlClient.createQuery(
+    noinline block: KMutableRootQuery.ForEntity<E>.() -> KConfigurableRootQuery<KNonNullTable<E>, R>
+): KConfigurableRootQuery<KNonNullTable<E>, R> =
+    this.createQuery(E::class, block)
+
+inline fun <reified E : Any> KSqlClient.createUpdate(
+    noinline block: KMutableUpdate<E>.() -> Unit
+): KExecutable<Int> =
+    this.createUpdate(E::class, block)
+
+inline fun <reified E : Any> KSqlClient.createDelete(
+    noinline block: KMutableDelete<E>.() -> Unit
+): KExecutable<Int> =
+    this.createDelete(E::class, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuery(
+    noinline block: KMutableBaseQuery<E>.() -> KConfigurableBaseQuery<B>
+): KConfigurableBaseQuery<B> =
+    this.createBaseQuery(E::class, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuery(
+    recursiveRef: KRecursiveRef<B>,
+    joinBlock: KPropsWeakJoinFun<KNonNullTable<E>, B>,
+    noinline block: KMutableRecursiveBaseQuery<E, B>.() -> KConfigurableBaseQuery<B>
+): KConfigurableBaseQuery<B> =
+    this.createBaseQuery(E::class, recursiveRef, joinBlock, block)
+
+inline fun <reified E : Any, R> KSqlClient.executeQuery(
+    limit: Int? = null,
+    con: Connection? = null,
+    noinline block: KMutableRootQuery.ForEntity<E>.() -> KConfigurableRootQuery<KNonNullTable<E>, R>
+): List<R> =
+    this.executeQuery(E::class, limit, con, block)
+
+inline fun <reified E : Any> KSqlClient.executeUpdate(
+    con: Connection? = null,
+    noinline block: KMutableUpdate<E>.() -> Unit
+): Int =
+    this.executeUpdate(E::class, con, block)
+
+inline fun <reified E : Any> KSqlClient.executeDelete(
+    con: Connection? = null,
+    noinline block: KMutableDelete<E>.() -> Unit
+): Int =
+    this.executeDelete(E::class, con, block)
+
+inline fun <reified T : Any> KSqlClient.findById(id: Any): T? =
+    this.findById(T::class, id)
+
+inline fun <reified T : Any> KSqlClient.findByIds(ids: Iterable<*>): List<T> =
+    this.findByIds(T::class, ids)
+
+inline fun <K, reified T : Any> KSqlClient.findMapByIds(ids: Iterable<K>): Map<K, T> =
+    this.findMapByIds(T::class, ids)
+
+inline fun <reified T : Any> KSqlClient.findOneById(id: Any): T =
+    this.findOneById(T::class, id)
+
+inline fun <reified V : View<E>, E : Any> KSqlClient.findAll(
+    limit: Int? = null,
+    con: Connection? = null,
+    noinline block: KMutableRootQuery.ForEntity<E>.() -> Unit = {}
+): List<V> =
+    this.findAll(V::class, limit, con, block)
+
+inline fun <reified V : View<E>, E : Any> KSqlClient.findOne(
+    con: Connection? = null,
+    noinline block: KMutableRootQuery.ForEntity<E>.() -> Unit
+): V =
+    this.findOne(V::class, con, block)
+
+inline fun <reified V : View<E>, E : Any> KSqlClient.findOneOrNull(
+    con: Connection? = null,
+    noinline block: KMutableRootQuery.ForEntity<E>.() -> Unit
+): V? =
+    this.findOneOrNull(V::class, con, block)
+
+inline fun <reified E : Any> KSqlClient.deleteById(
+    id: Any,
+    mode: DeleteMode = DeleteMode.AUTO
+): KDeleteResult =
+    this.deleteById(E::class, id, mode)
+
+inline fun <reified E : Any> KSqlClient.deleteById(
+    id: Any,
+    noinline block: KDeleteCommandDsl.() -> Unit
+): KDeleteResult =
+    this.deleteById(E::class, id, block)
+
+inline fun <reified E : Any> KSqlClient.deleteByIds(
+    ids: Iterable<*>,
+    mode: DeleteMode = DeleteMode.AUTO
+): KDeleteResult =
+    this.deleteByIds(E::class, ids, mode)
+
+inline fun <reified E : Any> KSqlClient.deleteByIds(
+    ids: Iterable<*>,
+    noinline block: KDeleteCommandDsl.() -> Unit
+): KDeleteResult =
+    this.deleteByIds(E::class, ids, block)


### PR DESCRIPTION
This PR introduces `inline reified` extensions for both `AbstractKotlinRepository` and `KSqlClient` to eliminate the need for passing explicit `::class` arguments.

**Usage Examples:**

```kotlin
fun findBookView(id: Long): BookView? = kSqlClient.findById(id)

fun findBookView(id: Long): BookView? = bookRepository.findView(id)
```

**Key Implementation Details:**

* **AbstractKotlinRepository:** I introduced new method names (e.g., `findView`) instead of overloading existing ones. This was necessary to avoid overload resolution conflicts (and potential "hijacking") with existing member functions, ensuring 100% backward compatibility. I am open to suggestions if the naming convention needs adjustment.
* **Motivation:** Minimizing manual `Class` parameter passing makes the API more idiomatic and elegant in Kotlin, similar to the approach taken by libraries like [Jackson](https://github.com/FasterXML/jackson-module-kotlin/blob/3.x/src/main/kotlin/tools/jackson/module/kotlin/Extensions.kt).