### PR TITLE
fix(ts): avoid double-quoting hyphenated header keys (#1305)

### DIFF
--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/service/HeaderService.java
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/service/HeaderService.java
@@ -1,0 +1,18 @@
+package org.babyfish.jimmer.client.java.service;
+
+import org.babyfish.jimmer.client.common.GetMapping;
+import org.babyfish.jimmer.client.common.RequestHeader;
+import org.babyfish.jimmer.client.meta.Api;
+import org.jetbrains.annotations.Nullable;
+
+@Api("headerService")
+public interface HeaderService {
+
+    @Api
+    @GetMapping("/headers")
+    void headers(
+            @RequestHeader("Access-Token") String accessToken,
+            @Nullable @RequestHeader(value = "Optional-Token", required = false) String optionalToken
+    );
+}
+

--- a/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/ts/HeaderServiceTest.java
+++ b/project/jimmer-client/src/test/java/org/babyfish/jimmer/client/java/ts/HeaderServiceTest.java
@@ -1,0 +1,38 @@
+package org.babyfish.jimmer.client.java.ts;
+
+import org.babyfish.jimmer.client.common.OperationParserImpl;
+import org.babyfish.jimmer.client.common.ParameterParserImpl;
+import org.babyfish.jimmer.client.generator.Context;
+import org.babyfish.jimmer.client.generator.ts.TypeScriptContext;
+import org.babyfish.jimmer.client.java.service.HeaderService;
+import org.babyfish.jimmer.client.runtime.Metadata;
+import org.babyfish.jimmer.client.source.Source;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.util.Collections;
+
+public class HeaderServiceTest {
+
+    private static final Metadata METADATA =
+            Metadata
+                    .newBuilder()
+                    .setOperationParser(new OperationParserImpl())
+                    .setParameterParser(new ParameterParserImpl())
+                    .setGroups(Collections.singleton("headerService"))
+                    .setGenericSupported(true)
+                    .build();
+
+    @Test
+    public void testHyphenNullableHeader() {
+        Context ctx = new TypeScriptContext(METADATA);
+        Source source = ctx.getRootSource("services/" + HeaderService.class.getSimpleName());
+        StringWriter writer = new StringWriter();
+        ctx.render(source, writer);
+        String ts = writer.toString();
+        Assertions.assertTrue(ts.contains("_headers['Optional-Token'] = options.optionalToken\n"));
+        Assertions.assertFalse(ts.contains("_headers[''Optional-Token'']"));
+    }
+}
+


### PR DESCRIPTION
# Fixes #1305: Fix syntax error in TS client generation for nullable headers with hyphens

## Issue Description
When a `@RequestHeader` name contains a hyphen (e.g., `Access-Token`) and the parameter is nullable, the TypeScript client generator produces a syntax error with double single-quotes:

```typescript
// Incorrect
_headers[''Access-Token''] = ... 
```
## Root Cause
The generator logic for constructing the index access previously hardcoded the surrounding quotes (_headers[' and ']). However, the internal logic for the key name reused a function that also wraps strings in quotes if they contain special characters (like hyphens). This resulted in nested/duplicate quotes.

## Solution
### Zero dependencies, maintaining existing output style.

I have refactored the header key rendering responsibility to strictly separate object literal keys from index access keys:

1. Object Literal Keys (`tsObjectKey`):

    - If the key is a valid TypeScript identifier, it is output raw (e.g., Authorization).

    - Otherwise, it outputs a string literal (e.g., 'Content-Type'). This is now more generic and robust, handling more than just hyphens.

2. Index Access Keys:

    - Unified to use _headers[tsStringLiteral(header)].

    - Removed the hardcoded quotes from the outer string builder to prevent the ''xxx'' issue at the source.

## Regression Test
Added HeaderService and HeaderServiceTest to cover the "nullable + hyphenated header" scenario:

Asserts that the generated code contains: _headers['Optional-Token'] = options.optionalToken

Asserts that the generated code does not contain: _headers[''Optional-Token'']

## Impact
- `Scope`: Only affects the header key rendering in the TypeScript client generator.

- `Runtime`: No changes to Java runtime logic.

- `Dependencies`: No new dependencies added.

- `Style`: Preserves the existing single-quote preference.