### PR TITLE
Fix issue reverse sort

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KConfigurableRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KConfigurableRootQueryImpl.kt
@@ -92,6 +92,7 @@ internal class KConfigurableRootQueryImpl<P: KPropsLike, R>(
         val reversedQuery = this
             .takeIf { offset + pageSize / 2 > total / 2 }
             ?.reverseSorting()
+            ?.takeIf { (it as KConfigurableRootQueryImpl<*, *>).javaQuery !== javaQuery }
 
         val entities: List<R> =
             if (reversedQuery != null) {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/PagingTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/PagingTest.kt
@@ -216,7 +216,7 @@ class PagingTest : AbstractQueryTest() {
                 """select tb_1_.ID, tb_1_.NAME 
                     |from BOOK tb_1_ 
                     |order by tb_1_.NAME asc, tb_1_.EDITION desc 
-                    |limit ?""".trimMargin()
+                    |limit ? offset ?""".trimMargin()
             )
         }
     }


### PR DESCRIPTION
解决bug：反排序优化功能导致分页混乱。
bug描述：3页内容，第三页和第1页数据相同，顺序相反