### PR TITLE
fix(sql-dialect): correct MySQL `for update` clause from `no wait` to `nowait`

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlDialect.java
@@ -103,7 +103,7 @@ public class MySqlDialect extends MySql5Dialect {
         }
         LockWait wait = forUpdate.getLockWait();
         if (wait == LockWait.NO_WAIT) {
-            builder.sql(" no wait");
+            builder.sql(" nowait");
         } else if (wait == LockWait.SKIP_LOCKED) {
             if (forUpdate.getLockMode().isShared()) {
                 throw new IllegalArgumentException(


### PR DESCRIPTION
According to the [official documentation (8.4)](https://dev.mysql.com/doc/refman/8.4/en/innodb-locking-reads.html), MySQL's NO_WAIT should be `NOWAIT`, without a space in between