### PR TITLE
fix(ts): prevent FetchedTypeRender infinite recursion

### DIFF
--- a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/generator/ts/FetchedTypeRender.java
+++ b/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/generator/ts/FetchedTypeRender.java
@@ -61,10 +61,10 @@ public class FetchedTypeRender implements Render {
             if (targetType instanceof ObjectType) {
                 ObjectType targetObjectType = (ObjectType) targetType;
                 if (targetObjectType.isRecursiveFetchedType() && !objectType.hasMultipleRecursiveProps()) {
-                    collectRecursiveTypeNames((ObjectType) targetType);
-                } else {
+                    collectRecursiveTypeNames(targetObjectType);
+                } else if (!(type.getJavaType().equals(targetObjectType.getJavaType()) && paths.contains(property.getName()))) {
                     paths.push(property.getName());
-                    collectRecursiveTypeNames((ObjectType) targetType);
+                    collectRecursiveTypeNames(targetObjectType);
                     paths.pop();
                 }
             }


### PR DESCRIPTION
### Reason

https://github.com/babyfish-ct/jimmer/blob/28947eb71f380fcf720ca9956b060f869131ff4a/project/jimmer-client/src/main/java/org/babyfish/jimmer/client/generator/ts/FetchedTypeRender.java#L63

处理递归结构的类时，对于引用自身类型的字段，在以上条件判断时会无限递归进入 else 分支，最终导致 StackOverflowError

这个条件判断中调用的 isRecursiveFetchedType 和 hasMultipleRecursiveProps 方法只在 FetchedTypeImpl 中有实际的逻辑处理，其他几类实现都只是固定返回 false

### Description

我的项目中引入的第三方依赖里有一个类型存在递归结构，导致 Jimmer 生成客户端对接代码时无限递归
出现问题的类大概是这样的：

```java
public class Parameter {
    protected String name;
    protected List<Parameter> children;

    ......
}
```

其中 children 字段导致 Jimmer 生成客户端API相关的 FetchedTypeRender#collectRecursiveTypeNames 方法内出现无限递归

### Existing solutions

有碰到过几次这个问题，导致一些需要使用的类型在前端代码中没有对应的 typescript 声明

我试了一下最简单的方式是为 else 分支添加条件，不重复处理**同一个类型**中的**同一个字段**

希望能够合并或使用其他方式修复此问题

🤝