### PR TITLE
feat(sql): introduce `TypedTransientResolver` for advanced property resolution with contextual entity access

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ExperimentalTypedTransientResolver.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ExperimentalTypedTransientResolver.kt
@@ -1,0 +1,10 @@
+package org.babyfish.jimmer.sql.kt
+
+/**
+ * [org.babyfish.jimmer.sql.TypedTransientResolver] is experimental and may change in future releases
+ *
+ * @since 0.9.121
+ */
+@RequiresOptIn(message = "TypedTransientResolver is experimental and may change in future releases")
+@Target(AnnotationTarget.CLASS)
+annotation class ExperimentalTypedTransientResolver

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KTypedTransientResolver.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KTypedTransientResolver.kt
@@ -1,0 +1,44 @@
+package org.babyfish.jimmer.sql.kt
+
+import org.babyfish.jimmer.sql.TypedTransientResolver
+
+/**
+ * A specialized variant of [KTransientResolver]. When conditions are appropriate, it will use
+ * [resolve(Collection, Context)][resolve] to provide an extra [Context][TypedTransientResolver.Context] parameter,
+ * which supplies the collection of entities currently being calculated, allowing access to other properties
+ * during calculation.
+ *
+ * You need to implement both abstract `resolve` functions to ensure that when the [Context][TypedTransientResolver.Context]
+ * generation conditions are not met, it can fall back to the same behavior as [KTransientResolver].
+ *
+ * [Context][TypedTransientResolver.Context] may not be generated in scenarios where caching is configured.
+ *
+ * This type is only for Kotlin. If you use Java, see [TypedTransientResolver][org.babyfish.jimmer.sql.TypedTransientResolver].
+ *
+ * NOTE: This type is experimental and may undergo major changes or be removed in future versions.
+ *
+ * @since 0.9.121
+ * @param [E] The current entity type
+ * @param [ID] The id type of current entity
+ * @param [V] The calculated type, there are three possibilities
+ * - If the calculated property is NOT association,
+ * `V` should be the property type
+ * - If the calculated property is associated reference,
+ * `V`should be the associated-id type
+ * - If the calculated property is associated list,
+ * `V` should be the type of list whose elements
+ * are associated ids
+ */
+@ExperimentalTypedTransientResolver
+interface KTypedTransientResolver<E : Any, ID: Any, V> : KTransientResolver<ID, V>, TypedTransientResolver<E, ID, V> {
+    /**
+     * When the conditions for generating [TypedTransientResolver.Context] are met, this method will be used
+     * instead of [resolve(Collection)][resolve] to perform complex property calculations.
+     *
+     * @param ids     A batch of ids of the current objects that are resolving calculated property,
+     *                it is not null and not empty
+     * @param context The context of current entities being resolved
+     * @return A map contains resolved values
+     */
+    override fun resolve(ids: Collection<ID>, context: TypedTransientResolver.Context<E>): Map<ID, V>
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/calc/BookStoreNameWithVersionResolver.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/calc/BookStoreNameWithVersionResolver.kt
@@ -1,0 +1,43 @@
+package org.babyfish.jimmer.sql.kt.model.calc
+
+import org.babyfish.jimmer.sql.TypedTransientResolver
+import org.babyfish.jimmer.sql.kt.ExperimentalTypedTransientResolver
+import org.babyfish.jimmer.sql.kt.KSqlClient
+import org.babyfish.jimmer.sql.kt.KTransientResolver
+import org.babyfish.jimmer.sql.kt.KTypedTransientResolver
+import org.babyfish.jimmer.sql.kt.ast.expression.valueIn
+import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
+import org.babyfish.jimmer.sql.kt.model.classic.store.id
+import org.babyfish.jimmer.sql.kt.model.classic.store.name
+import org.babyfish.jimmer.sql.kt.model.classic.store.version
+
+@OptIn(ExperimentalTypedTransientResolver::class)
+class BookStoreNameWithVersionResolver(
+    private val sqlClient: KSqlClient
+) : KTypedTransientResolver<BookStore, Long, String> {
+
+    override fun resolve(ids: Collection<Long>): Map<Long, String> =
+        sqlClient.createQuery(BookStore::class) {
+            where(table.id valueIn ids)
+            select(
+                table.id,
+                table.name,
+                table.version
+            )
+        }.execute(KTransientResolver.currentConnection)
+            .associateBy({ it._1 }) {
+                "${it._2}#${it._3}"
+            }
+
+    override fun resolve(
+        ids: Collection<Long>,
+        context: TypedTransientResolver.Context<BookStore>
+    ): Map<Long, String> {
+        val idSet = ids.toHashSet()
+        return context.content
+            .filter { it.id in idSet }
+            .associateBy({ it.id }) {
+                "${it.name}#${it.version}"
+            }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/classic/store/BookStore.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/classic/store/BookStore.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.kt.model.classic.store
 
 import org.babyfish.jimmer.sql.*
 import org.babyfish.jimmer.sql.kt.model.calc.BookStoreAvgPriceResolver
+import org.babyfish.jimmer.sql.kt.model.calc.BookStoreNameWithVersionResolver
 import org.babyfish.jimmer.sql.kt.model.calc.BookStoreNewestBooksResolver
 import org.babyfish.jimmer.sql.kt.model.classic.book.Book
 import java.math.BigDecimal
@@ -38,6 +39,9 @@ interface BookStore {
      */
     @Transient(BookStoreAvgPriceResolver::class)
     val avgPrice: BigDecimal
+
+    @Transient(BookStoreNameWithVersionResolver::class)
+    val nameWithVersion: String
 
     /**
      * The website property

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/TypedTransientResolverTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/TypedTransientResolverTest.kt
@@ -1,0 +1,81 @@
+package org.babyfish.jimmer.sql.kt.query
+
+import org.babyfish.jimmer.meta.ImmutableProp
+import org.babyfish.jimmer.sql.cache.Cache
+import org.babyfish.jimmer.sql.kt.cache.KCacheFactory
+import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
+import org.babyfish.jimmer.sql.kt.common.createCache
+import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
+import org.babyfish.jimmer.sql.kt.model.classic.store.fetchBy
+import org.junit.Test
+
+class TypedTransientResolverTest : AbstractQueryTest() {
+
+    @Test
+    fun testTypedNameWithVersion() {
+        executeAndExpect(
+            sqlClient.createQuery(BookStore::class) {
+                select(
+                    table.fetchBy {
+                        allScalarFields()
+                        nameWithVersion()
+                    }
+                )
+            }
+        ) {
+            sql(
+                "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION, tb_1_.WEBSITE " +
+                    "from BOOK_STORE tb_1_"
+            )
+            rows(
+                "[" +
+                    "--->{\"id\":1,\"name\":\"O'REILLY\",\"version\":0,\"website\":null,\"nameWithVersion\":\"O'REILLY#0\"}," +
+                    "--->{\"id\":2,\"name\":\"MANNING\",\"version\":0,\"website\":null,\"nameWithVersion\":\"MANNING#0\"}" +
+                    "]"
+            )
+        }
+    }
+
+    @Test
+    fun testTypedNameWithVersionCacheFallback() {
+        val cachedSqlClient = sqlClient {
+            setCacheFactory(
+                object : KCacheFactory {
+                    override fun createResolverCache(prop: ImmutableProp): Cache<*, *> =
+                        createCache<Any, Any>(prop)
+                }
+            )
+        }
+        for (i in 0..1) {
+            val useSql = i == 0
+            executeAndExpect(
+                cachedSqlClient.createQuery(BookStore::class) {
+                    select(
+                        table.fetchBy {
+                            allScalarFields()
+                            nameWithVersion()
+                        }
+                    )
+                }
+            ) {
+                sql(
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION, tb_1_.WEBSITE " +
+                        "from BOOK_STORE tb_1_"
+                )
+                if (useSql) {
+                    statement(1).sql(
+                        "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ " +
+                            "where tb_1_.ID in (?, ?)"
+                    )
+                }
+                rows(
+                    "[" +
+                        "--->{\"id\":1,\"name\":\"O'REILLY\",\"version\":0,\"website\":null,\"nameWithVersion\":\"O'REILLY#0\"}," +
+                        "--->{\"id\":2,\"name\":\"MANNING\",\"version\":0,\"website\":null,\"nameWithVersion\":\"MANNING#0\"}" +
+                        "]"
+                )
+            }
+        }
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/TypedTransientResolver.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/TypedTransientResolver.java
@@ -1,0 +1,63 @@
+package org.babyfish.jimmer.sql;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A specialized variant of {@link TransientResolver}. When conditions are appropriate, it will use
+ * {@link #resolve(Collection, Context)} to provide an extra {@link Context} parameter, which supplies
+ * the collection of entities currently being calculated, allowing access to other properties during calculation.
+ * <p>
+ * You need to implement both abstract {@code resolve} methods to ensure that when the {@link Context}
+ * generation conditions are not met, it can fall back to the same behavior as {@link TransientResolver}.
+ * <p>
+ * {@link Context} may not be generated in scenarios where caching is configured.
+ * <p>
+ * This type is only for Java. If you use Kotlin, see {@code KTypedTransientResolver}.
+ * <p>
+ * NOTE: This type is experimental and may undergo major changes or be removed in future versions.
+ *
+ * @param <E>  The entity type
+ * @param <ID> The id type of current entity
+ * @param <V>  The calculated type, there are three possibilities
+ *             <ul>
+ *                <li>If the calculated property is NOT association,
+ *                {@code V} should be the property type</li>
+ *                <li>If the calculated property is associated reference,
+ *                {@code V} should be the associated-id type</li>
+ *                <li>If the calculated property is associated list,
+ *                {@code V} should be the type of list whose elements
+ *                are associated ids.</li>
+ *             </ul>
+ * @author Forte Scarlet
+ * @see TransientResolver
+ * @since 0.9.121
+ */
+@ApiStatus.Experimental
+public interface TypedTransientResolver<E, ID, V> extends TransientResolver<ID, V> {
+    /**
+     * When the conditions for generating {@link Context} are met, this method will be used 
+     * instead of {@link #resolve(Collection)} to perform complex property calculations.
+     *
+     * @param ids     A batch of ids of the current objects that are resolving calculated property,
+     *                it is not null and not empty
+     * @param context The context of current entities being resolved
+     * @return A map contains resolved values
+     */
+    Map<ID, V> resolve(Collection<ID> ids, Context<E> context);
+
+    /**
+     * Represents a context providing additional data related to the current entities being processed within a resolver.
+     * <p>
+     * NOTE: This interface is experimental and subject to potential breaking changes or removal in future versions.
+     *
+     * @param <E> The type of entities contained within the context
+     * @since 0.9.121
+     */
+    @ApiStatus.Experimental
+    interface Context<E> {
+        Collection<? extends E> getContent();
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/TransientResolverTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/TransientResolverTest.java
@@ -112,6 +112,44 @@ public class TransientResolverTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testTypedNameWithVersion() {
+        executeAndExpect(
+                getLambdaClient().createQuery(BookStoreTable.class, (q, store) -> {
+                    return q.select(
+                            store.fetch(
+                                    BookStoreFetcher.$
+                                            .allScalarFields()
+                                            .nameWithVersion()
+                            )
+                    );
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                                    "from BOOK_STORE tb_1_"
+                    );
+                    ctx.rows(
+                            "[" +
+                                    "--->{" +
+                                    "--->--->\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
+                                    "--->--->\"name\":\"O'REILLY\"," +
+                                    "--->--->\"website\":null," +
+                                    "--->--->\"version\":0," +
+                                    "--->--->\"nameWithVersion\":\"O'REILLY#0\"" +
+                                    "--->},{" +
+                                    "--->--->\"id\":\"2fa3955e-3e83-49b9-902e-0465c109c779\"," +
+                                    "--->--->\"name\":\"MANNING\"," +
+                                    "--->--->\"website\":null," +
+                                    "--->--->\"version\":0," +
+                                    "--->--->\"nameWithVersion\":\"MANNING#0\"" +
+                                    "--->}" +
+                                    "]"
+                    );
+                }
+        );
+    }
+
+    @Test
     public void testMostPopularAuthorWithDeepFetcher() {
         executeAndExpect(
                 getLambdaClient().createQuery(BookStoreTable.class, (q, store) -> {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/loader/TypedTransientWithCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/loader/TypedTransientWithCacheTest.java
@@ -1,0 +1,47 @@
+package org.babyfish.jimmer.sql.loader;
+
+import org.babyfish.jimmer.sql.fetcher.Fetcher;
+import org.babyfish.jimmer.sql.fetcher.impl.DataLoader;
+import org.babyfish.jimmer.sql.model.BookStore;
+import org.babyfish.jimmer.sql.model.BookStoreFetcher;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TypedTransientWithCacheTest extends AbstractCachedLoaderTest {
+
+    @Test
+    public void testTypedResolverCacheFallback() {
+        Fetcher<BookStore> fetcher = BookStoreFetcher.$.nameWithVersion();
+        for (int i = 0; i < 2; i++) {
+            boolean useSql = i == 0;
+            connectAndExpect(
+                    con -> new DataLoader(
+                            (JSqlClientImplementor) getCachedSqlClient(),
+                            con,
+                            null,
+                            fetcher.getFieldMap().get("nameWithVersion")
+                    ).load(Entities.BOOK_STORES),
+                    ctx -> {
+                        if (useSql) {
+                            ctx.sql(
+                                    "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                                            "from BOOK_STORE tb_1_ " +
+                                            "where tb_1_.ID in (?, ?)"
+                            );
+                        }
+                        ctx.row(0, map -> {
+                            Assertions.assertEquals(
+                                    "O'REILLY#0",
+                                    map.get(Entities.BOOK_STORES.get(0))
+                            );
+                            Assertions.assertEquals(
+                                    "MANNING#0",
+                                    map.get(Entities.BOOK_STORES.get(1))
+                            );
+                        });
+                    }
+            );
+        }
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/BookStore.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/BookStore.java
@@ -6,6 +6,7 @@ import org.babyfish.jimmer.sql.meta.UUIDIdGenerator;
 
 import org.babyfish.jimmer.sql.*;
 import org.babyfish.jimmer.sql.model.calc.BookStoreAvgPriceResolver;
+import org.babyfish.jimmer.sql.model.calc.BookStoreNameWithVersionResolver;
 import org.babyfish.jimmer.sql.model.calc.BookStoreNewestBooksResolver;
 import org.jspecify.annotations.Nullable;
 
@@ -39,6 +40,9 @@ public interface BookStore {
 
     @Transient(BookStoreAvgPriceResolver.class)
     BigDecimal avgPrice();
+
+    @Transient(BookStoreNameWithVersionResolver.class)
+    String nameWithVersion();
 
     @Nullable
     @Transient(ref = "bookStoreMostPopularAuthorResolver")

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/calc/BookStoreNameWithVersionResolver.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/calc/BookStoreNameWithVersionResolver.java
@@ -1,0 +1,53 @@
+package org.babyfish.jimmer.sql.model.calc;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.TransientResolver;
+import org.babyfish.jimmer.sql.TypedTransientResolver;
+import org.babyfish.jimmer.sql.ast.tuple.Tuple3;
+import org.babyfish.jimmer.sql.model.BookStore;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class BookStoreNameWithVersionResolver implements TypedTransientResolver<BookStore, UUID, String> {
+
+    private static final BookStoreTable table = BookStoreTable.$;
+
+    private final JSqlClient sqlClient;
+
+    public BookStoreNameWithVersionResolver(JSqlClient sqlClient) {
+        this.sqlClient = sqlClient;
+    }
+
+    @Override
+    public Map<UUID, String> resolve(Collection<UUID> ids) {
+        List<Tuple3<UUID, String, Integer>> tuples = sqlClient
+                .createQuery(table)
+                .where(table.id().in(ids))
+                .select(
+                        table.id(),
+                        table.name(),
+                        table.version()
+                )
+                .execute(TransientResolver.currentConnection());
+        Map<UUID, String> map = new LinkedHashMap<>((tuples.size() * 4 + 2) / 3);
+        for (Tuple3<UUID, String, Integer> tuple : tuples) {
+            map.put(tuple.get_1(), tuple.get_2() + "#" + tuple.get_3());
+        }
+        return map;
+    }
+
+    @Override
+    public Map<UUID, String> resolve(Collection<UUID> ids, Context<BookStore> context) {
+        Collection<? extends BookStore> stores = context.getContent();
+        Map<UUID, String> map = new LinkedHashMap<>((stores.size() * 4 + 2) / 3);
+        for (BookStore store : stores) {
+            map.put(store.id(), store.name() + "#" + store.version());
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
Hi! This PR introduces a specialized TransientResolver subtype, `TypedTransientResolver`,
which allows resolvers to access the current entity list during calculation.

Fixes #693

```java
public class BookStoreNameWithVersionResolver
        implements TypedTransientResolver<BookStore, UUID, String> {
    @Override
    public Map<UUID, String> resolve(Collection<UUID> ids, Context<BookStore> ctx) {
        return ctx.getContent().stream().collect(toMap(
            BookStore::id,
            it -> it.name() + "#" + it.version()
        ));
    }

    @Override
    public Map<UUID, String> resolve(Collection<UUID> ids) {
        // Fallback when context is unavailable
        return queryByIds(ids);
    }
}
```

## Experimental Notes and Limitations
- `TypedTransientResolver` is experimental (`@ApiStatus.Experimental`); Kotlin requires `@ExperimentalTypedTransientResolver` and `@OptIn`.
- Context is provided only when the loader has source entities and caching is not used; with cache enabled it falls back to `resolve(ids)`.
- Implement both `resolve` overloads to support both paths.
- Experimental APIs may be adjusted, changed, or removed before they stabilize.

Using `interface Context<E>` keeps the contract open for future extension (for example, exposing more metadata such as `Table<E>` later).

Please feel free to review this PR at any time and leave any suggestions or comments :)
