### PR TITLE
fix(client): Schemas#isAllowed method logic

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/client/meta/impl/Schemas.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/client/meta/impl/Schemas.java
@@ -57,10 +57,10 @@ public class Schemas {
     }
 
     private static boolean isAllowed(Collection<String> elementGroups, Set<String> allowedGroups) {
-        if (elementGroups == null) {
+        if (elementGroups == null || elementGroups.isEmpty()) {
             return true;
         }
-        if (allowedGroups == null) {
+        if (allowedGroups == null || allowedGroups.isEmpty()) {
             return true;
         }
         for (String elementGroup : elementGroups) {


### PR DESCRIPTION
### Reason

https://github.com/babyfish-ct/jimmer/blob/943124f44cc216271b16ac72120b064381df69f0/project/jimmer-core/src/main/java/org/babyfish/jimmer/client/meta/impl/Schemas.java#L63

访问在线 openapi 文档时，会首先使用 OpenApiUiController#hasMetadata 方法进行一些前置检查，检查时不关心 api 分组，只要项目内存在 api 接口即可判断通过

在使用 @Api 注解为 api 分组的项目中，该检查会因为项目中存在 api 分组而最终导致以上引用的代码处接收到一个空集，而判断时只检查了 null ，使得 isAllowed 方法最终返回 false

最终导致访问 openapi 文档网页时返回 "Cannot view API because there is no metadata."

### Reproduction steps

在 jimmer-examples 项目中的 java/jimmer-sql/service 模块内的控制器上添加 @Api 注解后访问 openapi.html 即可复现此问题

### Existing solutions

在 isAllowed 方法的 if 语句中添加 isEmpty 判断即可解决此问题