### PR TITLE
fix(validation): support jakarta.validation.Constraint in addition to javax.validation.Constraint

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/validation/Validator.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/validation/Validator.java
@@ -30,7 +30,7 @@ public class Validator<T> {
 
     private final List<ConstraintValidator<?, T>> javaxConstraintValidators;
 
-    private final List<JakartaValidatorDelegate<T>> jakartaConstraintValidators;
+    private final List<JakartaConstraintValidatorDelegate<T>> jakartaConstraintValidators;
 
     @SuppressWarnings("unchecked")
     public Validator(
@@ -129,7 +129,7 @@ public class Validator<T> {
                     Method initialize =
                             findInitializeMethod(validatorType, annotation.annotationType());
                     initialize.invoke(constraintValidator, annotation);
-                    jakartaConstraintValidators.add(new JakartaValidatorDelegate<>(constraintValidator));
+                    jakartaConstraintValidators.add(new JakartaConstraintValidatorDelegate<>(constraintValidator));
                 }
             } catch (InvocationTargetException ex) {
                 Throwable cause = ex.getTargetException();
@@ -169,7 +169,7 @@ public class Validator<T> {
                 throw new ValidationException(message);
             }
         }
-        for (JakartaValidatorDelegate<T> delegate : jakartaConstraintValidators) {
+        for (JakartaConstraintValidatorDelegate<T> delegate : jakartaConstraintValidators) {
             try {
                 if (!delegate.isValid(value)) {
                     throwJakartaValidationException(message);
@@ -201,13 +201,13 @@ public class Validator<T> {
         }
     }
 
-    private static final class JakartaValidatorDelegate<T> {
+    private static final class JakartaConstraintValidatorDelegate<T> {
 
         private final Object delegate;
 
         private final Method isValidMethod;
 
-        JakartaValidatorDelegate(Object delegate) throws ReflectiveOperationException {
+        JakartaConstraintValidatorDelegate(Object delegate) throws ReflectiveOperationException {
             this.delegate = delegate;
             Class<?> ctxClass = Class.forName("jakarta.validation.ConstraintValidatorContext");
             this.isValidMethod = delegate.getClass().getMethod("isValid", Object.class, ctxClass);

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/validation/Validator.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/validation/Validator.java
@@ -10,6 +10,7 @@ import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.ValidationException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -18,13 +19,18 @@ import java.util.regex.Pattern;
 
 public class Validator<T> {
 
+    public static final String JAKARTA_CONSTRAINT_FULL_NAME = "jakarta.validation.Constraint";
+    public static final String JAKARTA_VALIDATION_EXCEPTION_CLASS_NAME = "jakarta.validation.ValidationException";
+
     private static final Pattern I18N_PATTERN = Pattern.compile("\\{[^}]+}");
 
     private static ResourceBundle BUNDLE;
 
     private final String message;
 
-    private final List<ConstraintValidator<?, T>> constraintValidators;
+    private final List<ConstraintValidator<?, T>> javaxConstraintValidators;
+
+    private final List<JakartaValidatorDelegate<T>> jakartaConstraintValidators;
 
     @SuppressWarnings("unchecked")
     public Validator(
@@ -61,43 +67,154 @@ public class Validator<T> {
                             type.getName() +
                             "' does not match the validation rule of @" + annotationType.getName();
         }
-        Constraint constraint = annotationType.getAnnotation(Constraint.class);
-        List<ConstraintValidator<?, T>> constraintValidators = new ArrayList<>();
-        for (Class<? extends ConstraintValidator<?, ?>> validatorType :
-                new LinkedHashSet<>(Arrays.asList(constraint.validatedBy()))) {
-            ConstraintValidator<?, T> constraintValidator;
+
+        Constraint javaxConstraint = annotationType.getAnnotation(Constraint.class);
+        if (javaxConstraint != null) {
+            this.javaxConstraintValidators = new ArrayList<>();
+            this.jakartaConstraintValidators = Collections.emptyList();
+            for (Class<? extends ConstraintValidator<?, ?>> validatorType :
+                    new LinkedHashSet<>(Arrays.asList(javaxConstraint.validatedBy()))) {
+                ConstraintValidator<?, T> constraintValidator;
+                try {
+                    constraintValidator = (ConstraintValidator<?, T>) validatorType.getConstructor().newInstance();
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException ex) {
+                    throw new IllegalArgumentException(
+                            "Cannot create constraint validator instance of \"" +
+                                    validatorType.getName() +
+                                    "\" declared by the annotation \"@" +
+                                    annotationType.getName() +
+                                    "\"",
+                            ex
+                    );
+                } catch (InvocationTargetException ex) {
+                    throw new IllegalArgumentException(
+                            "Cannot create constraint validator instance of \"" +
+                                    validatorType.getName() +
+                                    "\" declared by the annotation \"@" +
+                                    annotationType.getName() +
+                                    "\"",
+                            ex.getTargetException()
+                    );
+                }
+                ((ConstraintValidator<Annotation, ?>) constraintValidator).initialize(annotation);
+                javaxConstraintValidators.add(constraintValidator);
+            }
+        } else {
+            final Class<? extends Annotation> jakartaConstraintClass;
             try {
-                constraintValidator = (ConstraintValidator<?, T>) validatorType.getConstructor().newInstance();
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException ex) {
-                throw new IllegalArgumentException(
-                        "Cannot create constraint validator instance of \"" +
-                                validatorType.getName() +
-                                "\" declared by the annotation \"@" +
-                                annotationType.getName() +
-                                "\"",
+                jakartaConstraintClass =
+                        Class.forName(JAKARTA_CONSTRAINT_FULL_NAME).asSubclass(Annotation.class);
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalStateException(
+                        "jakarta.validation API is required at runtime for Jakarta Bean Validation constraints. " +
+                                "Add jakarta.validation:jakarta.validation-api (and an implementation such as " +
+                                "Hibernate Validator) to the classpath.",
                         ex
                 );
+            }
+            Annotation jakartaConstraintMeta = annotationType.getAnnotation(jakartaConstraintClass);
+            Objects.requireNonNull(
+                    jakartaConstraintMeta,
+                    "Annotation type \""+annotationType.getName()+"\" must be meta-annotated with " +
+                            "javax.validation.Constraint or jakarta.validation.Constraint"
+            );
+            this.javaxConstraintValidators = Collections.emptyList();
+            this.jakartaConstraintValidators = new ArrayList<>();
+            try {
+                Method validatedByMethod = jakartaConstraintClass.getMethod("validatedBy");
+                Class<?>[] validatedBy = (Class<?>[]) validatedByMethod.invoke(jakartaConstraintMeta);
+
+                for (Class<?> validatorType : new LinkedHashSet<>(Arrays.asList(validatedBy))) {
+                    Object constraintValidator = validatorType.getConstructor().newInstance();
+                    Method initialize =
+                            findInitializeMethod(validatorType, annotation.annotationType());
+                    initialize.invoke(constraintValidator, annotation);
+                    jakartaConstraintValidators.add(new JakartaValidatorDelegate<>(constraintValidator));
+                }
             } catch (InvocationTargetException ex) {
-                throw new IllegalArgumentException(
-                        "Cannot create constraint validator instance of \"" +
-                                validatorType.getName() +
-                                "\" declared by the annotation \"@" +
-                                annotationType.getName() +
-                                "\"",
-                        ex.getTargetException()
+                Throwable cause = ex.getTargetException();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException(
+                        "jakarta.validation API is required at runtime for Jakarta Bean Validation constraints. " +
+                                "Add jakarta.validation:jakarta.validation-api (and an implementation such as " +
+                                "Hibernate Validator) to the classpath.",
+                        ex
                 );
             }
-            ((ConstraintValidator<Annotation, ?>)constraintValidator).initialize(annotation);
-            constraintValidators.add(constraintValidator);
         }
-        this.constraintValidators = constraintValidators;
+    }
+
+    private static Method findInitializeMethod(Class<?> validatorType, Class<? extends Annotation> annotationClass)
+            throws NoSuchMethodException {
+        for (Method method : validatorType.getMethods()) {
+            if (!"initialize".equals(method.getName()) || method.getParameterCount() != 1) {
+                continue;
+            }
+            Class<?> param = method.getParameterTypes()[0];
+            if (param.isAssignableFrom(annotationClass)) {
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(
+                "No initialize(" + annotationClass.getName() + ") on " + validatorType.getName()
+        );
     }
 
     public void validate(T value) {
-        for (ConstraintValidator<?, T> constraintValidator : constraintValidators) {
+        for (ConstraintValidator<?, T> constraintValidator : javaxConstraintValidators) {
             if (!constraintValidator.isValid(value, null)) {
                 throw new ValidationException(message);
             }
+        }
+        for (JakartaValidatorDelegate<T> delegate : jakartaConstraintValidators) {
+            try {
+                if (!delegate.isValid(value)) {
+                    throwJakartaValidationException(message);
+                }
+            } catch (InvocationTargetException ex) {
+                Throwable cause = ex.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new IllegalStateException(cause);
+            } catch (IllegalAccessException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+
+    private static void throwJakartaValidationException(String message) {
+        try {
+            Class<?> exClass = Class.forName(JAKARTA_VALIDATION_EXCEPTION_CLASS_NAME);
+            Constructor<?> ctor = exClass.getConstructor(String.class);
+            throw (RuntimeException) ctor.newInstance(message);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "jakarta.validation API is required at runtime for Jakarta Bean Validation constraints.",
+                    e
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class JakartaValidatorDelegate<T> {
+
+        private final Object delegate;
+
+        private final Method isValidMethod;
+
+        JakartaValidatorDelegate(Object delegate) throws ReflectiveOperationException {
+            this.delegate = delegate;
+            Class<?> ctxClass = Class.forName("jakarta.validation.ConstraintValidatorContext");
+            this.isValidMethod = delegate.getClass().getMethod("isValid", Object.class, ctxClass);
+        }
+
+        boolean isValid(T value) throws InvocationTargetException, IllegalAccessException {
+            return (Boolean) isValidMethod.invoke(delegate, value, null);
         }
     }
 


### PR DESCRIPTION
Improved Validator so that when javax.validation.Constraint is not present on the annotation type, it also resolves jakarta.validation.Constraint (e.g. via Class.forName / reflection so jimmer-core can stay compile-time dependent on javax.validation-api only).

Instantiate and invoke Jakarta ConstraintValidator instances through reflection where needed, and throw jakarta.validation.ValidationException on failure when that API is available.

Fail fast with clear IllegalStateException / NullPointerException messages when jakarta.validation-api is missing at runtime but a Jakarta constraint is required, or when the annotation is not a valid @Constraint.