### PR TITLE
fix(cache): support default schema for JIMMER_TRANS_CACHE_OPERATOR table

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/DatabaseSchemaStrategy.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/DatabaseSchemaStrategy.java
@@ -13,4 +13,9 @@ public interface DatabaseSchemaStrategy {
 
     @Nullable
     String middleTableSchema(ImmutableProp prop);
+
+    @Nullable
+    default String systemTableSchema() {
+        return null;
+    }
 }

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/DefaultDatabaseSchemaStrategy.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/DefaultDatabaseSchemaStrategy.java
@@ -29,6 +29,12 @@ public class DefaultDatabaseSchemaStrategy implements DatabaseSchemaStrategy {
     }
 
     @Override
+    @Nullable
+    public String systemTableSchema() {
+        return schema;
+    }
+
+    @Override
     public String toString() {
         return "DefaultDatabaseSchemaStrategy{schema='" + schema + "'}";
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/TransactionCacheOperator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/TransactionCacheOperator.java
@@ -31,50 +31,7 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
 
     private static final String REASON = "REASON";
 
-    private static final String INSERT =
-            "insert into " +
-                    TABLE_NAME + "(" +
-                    IMMUTABLE_TYPE +
-                    ", " +
-                    IMMUTABLE_PROP +
-                    ", " +
-                    CACHE_KEY +
-                    ", " +
-                    REASON +
-                    ") values(?, ?, ?, ?)";
-
-    private static final String SELECT_ID_PREFIX =
-            "select " +
-                    ID +
-                    " from " +
-                    TABLE_NAME +
-                    " order by " +
-                    ID +
-                    " limit ";
-
-    private static final String SELECT_PREFIX =
-            "select " +
-                    ID +
-                    ", " +
-                    IMMUTABLE_TYPE +
-                    ", " +
-                    IMMUTABLE_PROP +
-                    ", " +
-                    CACHE_KEY +
-                    ", " +
-                    REASON +
-                    " from " +
-                    TABLE_NAME +
-                    " where " +
-                    ID +
-                    " in";
-
-    private static final String DELETE_PREFIX =
-            "delete from " +
-                    TABLE_NAME +
-                    " where " +
-                    ID +
-                    " in";
+    private Sql sql;
 
     private final JsonCodec<?> jsonCodec;
 
@@ -102,6 +59,12 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
 
     @Override
     protected void onInitialize(JSqlClientImplementor sqlClient) {
+        String schema = sqlClient.getMetadataStrategy().getSchemaStrategy().systemTableSchema();
+        String qualifiedTableName = schema == null || schema.isEmpty()
+                ? TABLE_NAME
+                : schema + "." + TABLE_NAME;
+        sql = new Sql(qualifiedTableName);
+
         ConnectionManager connectionManager = sqlClient.getConnectionManager();
         if (connectionManager == null) {
             throw new IllegalArgumentException("The `sqlClient` must support connection manager");
@@ -110,8 +73,8 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
             try {
                 try (ResultSet rs = con.getMetaData().getTables(
                         con.getCatalog(),
-                        con.getSchema(),
-                        "JIMMER_TRANS_CACHE_OPERATOR",
+                        schema == null || schema.isEmpty() ? con.getSchema() : schema,
+                        TABLE_NAME,
                         null
                 )) {
                     if (rs.next()) {
@@ -120,8 +83,8 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
                 }
                 try (ResultSet rs = con.getMetaData().getTables(
                         null,
-                        null,
-                        "jimmer_trans_cache_operator",
+                        schema == null || schema.isEmpty() ? null : schema.toLowerCase(),
+                        TABLE_NAME.toLowerCase(),
                         null
                 )) {
                     if (rs.next()) {
@@ -129,18 +92,26 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
                     }
                 }
                 try (Statement statement = con.createStatement()) {
-                    statement.execute(sqlClient.getDialect().transCacheOperatorTableDDL());
+                    String ddl = sqlClient.getDialect().transCacheOperatorTableDDL()
+                            .replace(TABLE_NAME, qualifiedTableName);
+                    statement.execute(ddl);
                 }
                 return null;
             } catch (SQLException ex) {
                 throw new ExecutionException(
-                        "Cannot create table `" +
-                                TransactionCacheOperator.TABLE_NAME +
-                                "`",
+                        "Cannot create table `" + qualifiedTableName + "`",
                         ex
                 );
             }
         });
+    }
+
+    private Sql sql() {
+        Sql s = sql;
+        if (s == null) {
+            throw new IllegalStateException("The current cache operator has not been initialized");
+        }
+        return s;
     }
 
     @Override
@@ -174,7 +145,7 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
     ) {
         sqlClient().getConnectionManager().execute(con -> {
             try {
-                try (PreparedStatement stmt = con.prepareStatement(INSERT)) {
+                try (PreparedStatement stmt = con.prepareStatement(sql().insert)) {
                     for (Object key : keys) {
                         stmt.setString(1, type != null ? type.toString() : null);
                         stmt.setString(2, prop != null ? prop.toString() : null);
@@ -216,7 +187,7 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
     }
 
     private List<Long> selectOperationIds(Connection con) {
-        String sql = SELECT_ID_PREFIX + batchSize;
+        String sql = sql().selectIdPrefix + batchSize;
         List<Long> ids = new ArrayList<>();
         try (PreparedStatement stmt = con.prepareStatement(sql)) {
             try (ResultSet rs = stmt.executeQuery()) {
@@ -233,7 +204,7 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
     @SuppressWarnings("unchecked")
     private Map<MergedKey, Set<Object>> getAndLockOperationKeyMap(Collection<Long> ids, Connection con) {
         StringBuilder builder = new StringBuilder();
-        builder.append(SELECT_PREFIX).append('(');
+        builder.append(sql().selectPrefix).append('(');
         for (int i = ids.size(); i > 0; --i) {
             builder.append('?');
             if (i > 1) {
@@ -289,7 +260,7 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
 
     private void deleteOperations(Collection<Long> ids, Connection con) {
         StringBuilder builder = new StringBuilder();
-        builder.append(DELETE_PREFIX).append('(');
+        builder.append(sql().deletePrefix).append('(');
         for (int i = ids.size(); i > 0; --i) {
             builder.append('?');
             if (i > 1) {
@@ -330,6 +301,60 @@ public class TransactionCacheOperator extends AbstractCacheOperator {
         }
         return typeFromString(propPath.substring(0, lastDotIndex))
                 .getProp(propPath.substring(lastDotIndex + 1));
+    }
+
+    private static class Sql {
+
+        final String insert;
+
+        final String selectIdPrefix;
+
+        final String selectPrefix;
+
+        final String deletePrefix;
+
+        Sql(String qualifiedTableName) {
+            insert = "insert into " +
+                    qualifiedTableName + "(" +
+                    IMMUTABLE_TYPE +
+                    ", " +
+                    IMMUTABLE_PROP +
+                    ", " +
+                    CACHE_KEY +
+                    ", " +
+                    REASON +
+                    ") values(?, ?, ?, ?)";
+
+            selectIdPrefix = "select " +
+                    ID +
+                    " from " +
+                    qualifiedTableName +
+                    " order by " +
+                    ID +
+                    " limit ";
+
+            selectPrefix = "select " +
+                    ID +
+                    ", " +
+                    IMMUTABLE_TYPE +
+                    ", " +
+                    IMMUTABLE_PROP +
+                    ", " +
+                    CACHE_KEY +
+                    ", " +
+                    REASON +
+                    " from " +
+                    qualifiedTableName +
+                    " where " +
+                    ID +
+                    " in";
+
+            deletePrefix = "delete from " +
+                    qualifiedTableName +
+                    " where " +
+                    ID +
+                    " in";
+        }
     }
 
     private static class MergedKey {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/AbstractTransactionCacheOperatorTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/AbstractTransactionCacheOperatorTest.java
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.cache.Cache;
 import org.babyfish.jimmer.sql.cache.CacheEnvironment;
 import org.babyfish.jimmer.sql.cache.CacheFactory;
 import org.babyfish.jimmer.sql.cache.TransactionCacheOperator;
+import org.babyfish.jimmer.sql.meta.DatabaseSchemaStrategy;
 import org.babyfish.jimmer.sql.common.AbstractTest;
 import org.babyfish.jimmer.sql.dialect.Dialect;
 import org.babyfish.jimmer.sql.event.TriggerType;
@@ -51,6 +52,10 @@ public abstract class AbstractTransactionCacheOperatorTest extends AbstractTest 
             cfg.setDialect(dialect());
             cfg.setTriggerType(TriggerType.TRANSACTION_ONLY);
             cfg.setCacheOperator(new TransactionCacheOperator());
+            DatabaseSchemaStrategy schemaStrategy = databaseSchemaStrategy();
+            if (schemaStrategy != null) {
+                cfg.setDatabaseSchemaStrategy(schemaStrategy);
+            }
             cfg.setCacheFactory(new CacheFactory() {
                 @Override
                 public Cache<?, ?> createObjectCache(@NotNull ImmutableType type) {
@@ -96,6 +101,10 @@ public abstract class AbstractTransactionCacheOperatorTest extends AbstractTest 
     protected abstract DataSource dataSource();
 
     protected abstract Dialect dialect();
+
+    protected DatabaseSchemaStrategy databaseSchemaStrategy() {
+        return null;
+    }
 
     private void assertDeletedKeys(Class<?> type, Object ... keys) {
         List<?> list = typeKeyMap.get(ImmutableType.get(type));

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/H2TransactionCacheOperatorTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/H2TransactionCacheOperatorTest.java
@@ -19,11 +19,15 @@ public class H2TransactionCacheOperatorTest extends AbstractTransactionCacheOper
 
     private Connection _con;
 
-    private Connection connection() throws SQLException {
+    protected String databaseUrl() {
+        return "jdbc:h2:mem:trans-cache-operator";
+    }
+
+    protected Connection connection() throws SQLException {
         if (_con != null) {
             return _con;
         }
-        return _con = new Driver().connect("jdbc:h2:mem:trans-cache-operator", null);
+        return _con = new Driver().connect(databaseUrl(), null);
     }
 
     @AfterEach

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/H2TransactionCacheOperatorWithSchemaTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/transaction/H2TransactionCacheOperatorWithSchemaTest.java
@@ -1,0 +1,32 @@
+package org.babyfish.jimmer.sql.cache.transaction;
+
+import org.babyfish.jimmer.sql.meta.DatabaseSchemaStrategy;
+import org.babyfish.jimmer.sql.meta.DefaultDatabaseSchemaStrategy;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class H2TransactionCacheOperatorWithSchemaTest extends H2TransactionCacheOperatorTest {
+
+    private static final String SCHEMA = "MYSCHEMA";
+
+    @Override
+    protected String databaseUrl() {
+        return "jdbc:h2:mem:trans-cache-operator-schema";
+    }
+
+    @Override
+    protected void assume() {
+        // connection() keeps _con open — H2 in-memory database persists only while a connection is alive
+        try (Statement stmt = connection().createStatement()) {
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS " + SCHEMA);
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected DatabaseSchemaStrategy databaseSchemaStrategy() {
+        return new DefaultDatabaseSchemaStrategy(SCHEMA);
+    }
+}


### PR DESCRIPTION
#1369 

TransactionCacheOperator referenced JIMMER_TRANS_CACHE_OPERATOR without any schema qualifier in DDL, metadata checks, and all DML statements, ignoring the DatabaseSchemaStrategy configured on the SqlClient.

Add systemTableSchema() default method to DatabaseSchemaStrategy, overridden in DefaultDatabaseSchemaStrategy to return the configured schema. TransactionCacheOperator now resolves the qualified table name during onInitialize() and uses it for all SQL and DDL.