### PR TITLE
fix: DTO生成器中关联属性转换器forList参数逻辑错误

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -14,7 +14,6 @@ import org.babyfish.jimmer.client.ApiIgnore;
 import org.babyfish.jimmer.client.meta.Doc;
 import org.babyfish.jimmer.dto.compiler.*;
 import org.babyfish.jimmer.impl.util.StringUtil;
-import org.babyfish.jimmer.meta.impl.Utils;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.Id;
 import org.jspecify.annotations.NonNull;
@@ -1410,7 +1409,7 @@ public class DtoGenerator {
                     baseTypeName,
                     getPropTypeName(prop).box(),
                     baseProp.isAssociation(true) ?
-                            "getAssociatedIdConverter(true)" :
+                            "getAssociatedIdConverter(" + (prop.isFunc("associatedIdIn", "associatedIdNotIn") ? "true" : "false") + ")" :
                             "getConverter(" + (prop.isFunc("valueIn", "valueNotIn") ? "true" : "") + ")"
             );
         }

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -1469,7 +1469,11 @@ class DtoGenerator private constructor(
                                 if (baseProp.isAssociation(true)) "getAssociatedIdConverter" else "getConverter",
                                 baseTypeName,
                                 propTypeName(prop).copy(nullable = false),
-                                if (baseProp.isAssociation(true) || prop.isFunc("valueIn", "valueNotIn")) "true" else ""
+                                if (baseProp.isAssociation(true)) {
+                                    if (prop.isFunc("associatedIdIn", "associatedIdNotIn")) "true" else "false"
+                                } else {
+                                    if (prop.isFunc("valueIn", "valueNotIn")) "true" else ""
+                                }
                             )
                         }
                     }


### PR DESCRIPTION
之前所有关联属性都错误地使用getAssociatedIdConverter(true)，
导致非列表形式的关联查询(如associatedIdEq)也使用了列表模式的转换器。

修复后：
- associatedIdIn / associatedIdNotIn -> getAssociatedIdConverter(true)
- 其他关联查询(如associatedIdEq) -> getAssociatedIdConverter(false)

close #1372