### PR TITLE
fix(immutable): NullException when @JsonConverter auto apply to @IdView

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableProp.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableProp.java
@@ -519,8 +519,11 @@ public class ImmutableProp implements BaseProp {
         if (jsonConverter == null) {
             final ImmutableProp idViewBaseProp = getIdViewBaseProp();
             if (idViewBaseProp != null) {
-                autoApply = true;
-                jsonConverter = RecursiveAnnotations.of(idViewBaseProp.declaringType.getIdProp().executableElement, JsonConverter.class.getName());
+                ImmutableProp idProp = idViewBaseProp.declaringType.getIdProp();
+                if (idProp != null) {
+                    autoApply = true;
+                    jsonConverter = RecursiveAnnotations.of(idProp.executableElement, JsonConverter.class.getName());
+                }
             }
         }
 


### PR DESCRIPTION
# Fix NPE in @JsonConverter auto-apply to @IdView on @MappedSuperclass

## Reason
提交 `e65a621f8` 引入了 `@JsonConverter` 自动应用到 `@IdView` 的功能，`@IdView` 属性可自动从基类属性声明类型的 `@Id` 上继承转换器，无需手动标注。

代码实现中**错误假设** `idViewBaseProp.declaringType.getIdProp()` 永远不为空；
当 `@IdView` 声明在 `@MappedSuperclass` 上时，映射超类本身不包含 `@Id` 属性，`getIdProp()` 会返回 `null`，后续访问 `.executableElement` 字段触发**空指针异常**。

异常堆栈：
```
java.lang.NullPointerException: Cannot read field "executableElement"
because the return value of "ImmutableType.getIdProp()" is null
```

## Reproduction steps
定义一个标注 `@MappedSuperclass` 的接口，在其中声明 `@IdView` 属性（属性关联的字段无 `@Id` 注解），即可触发该问题：
```java
@MappedSuperclass
public interface TenantAware {
    @ManyToOne
    Tenant tenant();

    @IdView("tenant")  // tenant() 定义在当前超类，无 @Id → 触发 NPE
    String tenantId();
}
```

## Existing solutions
在调用 `getIdProp()` 前增加**非空校验**：如果声明类型没有 `@Id` 属性，则跳过自动应用逻辑（无可用继承的转换器）。

### 代码修改
```diff
- autoApply = true;
- jsonConverter = RecursiveAnnotations.of(idViewBaseProp.declaringType.getIdProp().executableElement, ...);

+ ImmutableProp idProp = idViewBaseProp.declaringType.getIdProp();
+ if (idProp != null) {
+     autoApply = true;
+     jsonConverter = RecursiveAnnotations.of(idProp.executableElement, ...);
+ }
```