### PR TITLE
fix(sql): Fix base table count and union pagination rendering

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.ast.impl.query.ConfigurableBaseQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.MergedBaseQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.TypedBaseQueryImplementor;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableStatementImplementor;
+import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderMode;
 import org.babyfish.jimmer.sql.ast.impl.table.*;
 import org.babyfish.jimmer.sql.ast.impl.util.AbstractDataManager;
 import org.babyfish.jimmer.sql.ast.impl.util.AbstractIdentityDataManager;
@@ -33,12 +34,19 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     private BaseTableRenderFrame baseTableRenderFrame;
 
+    private final QueryRenderMode queryRenderMode;
+
     private int modCount;
 
     private Set<MergedBaseQueryImpl<?>> visitingRecursiveMergedQueries;
 
     public AstContext(JSqlClientImplementor sqlClient) {
+        this(sqlClient, QueryRenderMode.NORMAL);
+    }
+
+    public AstContext(JSqlClientImplementor sqlClient, QueryRenderMode queryRenderMode) {
         this.sqlClient = sqlClient;
+        this.queryRenderMode = queryRenderMode;
     }
 
     public JSqlClientImplementor getSqlClient() {
@@ -80,6 +88,12 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     public void popRenderedBaseTable() {
         this.baseTableRenderFrame = baseTableRenderFrame.parent;
+    }
+
+    public boolean isQueryWithoutSortingAndPaging() {
+        return queryRenderMode == QueryRenderMode.WITHOUT_SORTING_AND_PAGING ||
+                queryRenderMode == QueryRenderMode.WITHOUT_NESTED_BASE_TABLE_SORTING_AND_PAGING &&
+                        baseTableRenderFrame != null;
     }
 
     @SuppressWarnings("unchecked")

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
@@ -121,7 +121,8 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
         AstContext astContext = builder.getAstContext();
         astContext.pushStatement(getMutableQuery());
         try {
-            if (data.withoutSortingAndPaging || (data.offset == 0 && data.limit == Integer.MAX_VALUE)) {
+            if (data.withoutSortingAndPaging || astContext.isQueryWithoutSortingAndPaging() ||
+                    (data.offset == 0 && data.limit == Integer.MAX_VALUE)) {
                 renderWithoutPaging(builder, null, render);
             } else {
                 PropExpressionImplementor<?> idPropExpr = idOnlyPropExprByOffset();
@@ -257,7 +258,11 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
             fakeRenderExportedForeignKeys(mutableQuery.getTableLikeImplementor(),builder);
         }
         builder.leave();
-        mutableQuery.renderTo(builder, data.withoutSortingAndPaging, data.reverseSorting);
+        mutableQuery.renderTo(
+                builder,
+                data.withoutSortingAndPaging || builder.getAstContext().isQueryWithoutSortingAndPaging(),
+                data.reverseSorting
+        );
     }
 
     private void renderSelections(SqlBuilder builder) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
@@ -333,9 +333,19 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
     }
 
     private long simpleCount(Connection con) {
+        return getMutableQuery()
+                .getSqlClient()
+                .getSlaveConnectionManager(getData().forUpdate != null)
+                .execute(con, this::simpleCountImpl);
+    }
+
+    private long simpleCountImpl(Connection con) {
         TypedQueryData data = getData();
         JSqlClientImplementor sqlClient = getMutableQuery().getSqlClient();
-        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(new SqlBuilder(new AstContext(sqlClient)));
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(
+                sqlClient,
+                QueryRenderMode.WITHOUT_SORTING_AND_PAGING
+        );
         List<Object> rows = Selectors.select(
                 sqlClient,
                 con,
@@ -350,9 +360,19 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
     }
 
     private boolean simpleExists(Connection con) {
+        return getMutableQuery()
+                .getSqlClient()
+                .getSlaveConnectionManager(getData().forUpdate != null)
+                .execute(con, this::simpleExistsImpl);
+    }
+
+    private boolean simpleExistsImpl(Connection con) {
         TypedQueryData data = getData();
         JSqlClientImplementor sqlClient = getMutableQuery().getSqlClient();
-        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(new SqlBuilder(new AstContext(sqlClient)));
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(
+                sqlClient,
+                QueryRenderMode.WITHOUT_NESTED_BASE_TABLE_SORTING_AND_PAGING
+        );
         List<Object> rows = Selectors.select(
                 sqlClient,
                 con,
@@ -372,7 +392,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
             return Collections.emptyList();
         }
         JSqlClientImplementor sqlClient = getMutableQuery().getSqlClient();
-        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(new SqlBuilder(new AstContext(sqlClient)));
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(sqlClient);
         return Selectors.select(
                 sqlClient,
                 con,
@@ -418,7 +438,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
 
     private void forEachImpl(Connection con, int batchSize, Consumer<R> consumer) {
         JSqlClientImplementor sqlClient = getMutableQuery().getSqlClient();
-        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(new SqlBuilder(new AstContext(sqlClient)));
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(sqlClient);
         Selectors.forEach(
                 sqlClient,
                 con,
@@ -433,15 +453,24 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
         );
     }
 
-    private Tuple3<String, List<Object>, List<Integer>> preExecute(SqlBuilder builder) {
+    private Tuple3<String, List<Object>, List<Integer>> preExecute(JSqlClientImplementor sqlClient) {
+        return preExecute(sqlClient, QueryRenderMode.NORMAL);
+    }
+
+    private Tuple3<String, List<Object>, List<Integer>> preExecute(
+            JSqlClientImplementor sqlClient,
+            QueryRenderMode mode
+    ) {
+        AstContext astContext = new AstContext(sqlClient, mode);
+        SqlBuilder builder = new SqlBuilder(astContext);
         if (!getMutableQuery().isFrozen()) {
-            getMutableQuery().applyVirtualPredicates(builder.getAstContext());
-            getMutableQuery().applyGlobalFilters(builder.getAstContext(), getMutableQuery().getContext().getFilterLevel(), getData().selections);
+            getMutableQuery().applyVirtualPredicates(astContext);
+            getMutableQuery().applyGlobalFilters(astContext, getMutableQuery().getContext().getFilterLevel(), getData().selections);
         }
-        UseTableVisitor visitor = new UseTableVisitor(builder.getAstContext());
+        UseTableVisitor visitor = new UseTableVisitor(astContext);
         accept(visitor);
         visitor.allocateAliases();
-        renderTo(builder);
+        renderTo(builder, null);
         return builder.build();
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedBaseQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedBaseQueryImpl.java
@@ -194,9 +194,38 @@ public class MergedBaseQueryImpl<T extends BaseTable> implements TypedBaseQuery<
         builder.enter('?' + operator + '?');
         for (TypedQueryImplementor query : getQueries()) {
             builder.separator();
+            boolean wrap = requiresSubQuery(query, builder);
+            if (wrap) {
+                builder.enter(AbstractSqlBuilder.ScopeType.SUB_QUERY);
+            }
             query.renderTo(builder);
+            if (wrap) {
+                builder.leave();
+            }
         }
         builder.leave();
+    }
+
+    private static boolean requiresSubQuery(TypedQueryImplementor query, AbstractSqlBuilder<?> builder) {
+        if (query instanceof MergedBaseQueryImpl<?>) {
+            for (TypedQueryImplementor childQuery : ((MergedBaseQueryImpl<?>) query).getQueries()) {
+                if (requiresSubQuery(childQuery, builder)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (!(query instanceof AbstractConfigurableTypedQueryImpl)) {
+            return false;
+        }
+        AbstractConfigurableTypedQueryImpl configurableQuery = (AbstractConfigurableTypedQueryImpl) query;
+        TypedQueryData data = configurableQuery.getData();
+        if (data.limit != Integer.MAX_VALUE || data.offset != 0) {
+            return true;
+        }
+        return !data.withoutSortingAndPaging &&
+                !builder.assertSimple().getAstContext().isQueryWithoutSortingAndPaging() &&
+                !configurableQuery.getMutableQuery().getOrders().isEmpty();
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/QueryRenderMode.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/QueryRenderMode.java
@@ -1,0 +1,10 @@
+package org.babyfish.jimmer.sql.ast.impl.query;
+
+public enum QueryRenderMode {
+
+    NORMAL,
+
+    WITHOUT_SORTING_AND_PAGING,
+
+    WITHOUT_NESTED_BASE_TABLE_SORTING_AND_PAGING
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/IssueTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/IssueTest.java
@@ -1,5 +1,7 @@
 package org.babyfish.jimmer.sql.base;
 
+import org.babyfish.jimmer.Page;
+import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.ast.Expression;
 import org.babyfish.jimmer.sql.ast.NumericExpression;
 import org.babyfish.jimmer.sql.ast.query.TypedBaseQuery;
@@ -12,12 +14,89 @@ import org.babyfish.jimmer.sql.model.*;
 import org.babyfish.jimmer.sql.model.embedded.OrderIdDraft;
 import org.babyfish.jimmer.sql.model.embedded.OrderItemTable;
 import org.babyfish.jimmer.sql.model.embedded.OrderTable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 public class IssueTest extends AbstractQueryTest {
+
+    @Test
+    public void testBaseTableFetchPageWithoutConnection() {
+        BookTable table = BookTable.$;
+        JSqlClient sqlClient = getSqlClient(it -> it.setConnectionManager(testConnectionManager()));
+        BaseTable1<BookTable> existsBaseTable = sqlClient
+                .createBaseQuery(table)
+                .where(table.store().id().eq(Constants.manningId))
+                .orderBy(table.edition().desc())
+                .addSelect(table)
+                .asBaseTable();
+
+        connectAndExpect(
+                con -> sqlClient
+                        .createQuery(existsBaseTable)
+                        .select(existsBaseTable.get_1())
+                        .exists(),
+                ctx -> {
+                    ctx.sql(
+                            "select 1 from (" +
+                                    "select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_1_.c5 " +
+                                    "from (" +
+                                    "select tb_2_.ID c1, tb_2_.NAME c2, tb_2_.EDITION c3, tb_2_.PRICE c4, tb_2_.STORE_ID c5 " +
+                                    "from BOOK tb_2_ " +
+                                    "where tb_2_.STORE_ID = ?" +
+                                    ") tb_1_ " +
+                                    "limit ?" +
+                                    ") tb_simple_exists__"
+                    );
+                    ctx.rows("[true]");
+                }
+        );
+
+        BaseTable1<BookTable> pageBaseTable = sqlClient
+                .createBaseQuery(table)
+                .where(table.store().id().eq(Constants.manningId))
+                .orderBy(table.edition().desc())
+                .addSelect(table)
+                .asBaseTable();
+
+        connectAndExpect(
+                con -> sqlClient
+                        .createQuery(pageBaseTable)
+                        .orderBy(pageBaseTable.get_1().edition().desc())
+                        .select(pageBaseTable.get_1())
+                        .fetchPage(0, 2),
+                ctx -> {
+                    ctx.sql(
+                            "select count(1) from (" +
+                                    "select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_1_.c5 " +
+                                    "from (" +
+                                    "select tb_2_.ID c1, tb_2_.NAME c2, tb_2_.EDITION c3, tb_2_.PRICE c4, tb_2_.STORE_ID c5 " +
+                                    "from BOOK tb_2_ " +
+                                    "where tb_2_.STORE_ID = ?" +
+                                    ") tb_1_" +
+                                    ") tb_simple_count__"
+                    );
+                    ctx.statement(1).sql(
+                            "select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_1_.c5 " +
+                                    "from (" +
+                                    "select tb_2_.ID c1, tb_2_.NAME c2, tb_2_.EDITION c3, tb_2_.PRICE c4, tb_2_.STORE_ID c5 " +
+                                    "from BOOK tb_2_ " +
+                                    "where tb_2_.STORE_ID = ? " +
+                                    "order by tb_2_.EDITION desc" +
+                                    ") tb_1_ " +
+                                    "order by tb_1_.c3 desc " +
+                                    "limit ?"
+                    );
+                    ctx.rows(it -> {
+                        Page<Book> page = (Page<Book>) it.get(0);
+                        Assertions.assertEquals(2, page.getRows().size());
+                        Assertions.assertEquals(3, page.getTotalRowCount());
+                    });
+                }
+        );
+    }
 
     @Test
     public void testIssue1238() {


### PR DESCRIPTION
# Fix base table count and union pagination rendering

## Summary

Fix SQL rendering for base-table queries used by `exists()` and `fetchPage(...)`.

This fixes two cases:

- `fetchPage(...)` count / `exists()` over `asBaseTable()` should not render invalid nested sorting or paging.
- `union all` base-query operands with branch-local `order by`, `limit`, or `offset` must be wrapped as subqueries.

## Failure

A downstream Kotlin query shaped like this failed on Jimmer `0.10.7`:

```kotlin
sql.createQuery(baseTableSymbol {
    sql.createBaseQuery(Relation::class) {
        where(table.leftId eq ownerId)
        orderBy(table.createdAt.desc())
        selections.add(table.right).add(table.createdAt)
    } unionAll sql.createBaseQuery(Relation::class) {
        where(table.rightId eq ownerId)
        orderBy(table.createdAt.desc())
        selections.add(table.left).add(table.createdAt)
    }
}) {
    orderBy(table._2.desc())
    select(table._1.fetch(TargetView::class))
}.fetchPage(page, size)
```

Real stacktrace excerpt:

```text
Unhandled exception
java.lang.NullPointerException: Cannot invoke "java.sql.Connection.prepareStatement(String)" because "args.con" is null
    at org.babyfish.jimmer.sql.runtime.DefaultExecutor.execute(DefaultExecutor.java:57)
    at ru.meenity.jimmer.executor.CompactSqlExecutor.execute(CompactSqlExecutor.kt:54)
    at org.babyfish.jimmer.sql.runtime.Selectors.select(Selectors.java:32)
    at org.babyfish.jimmer.sql.ast.impl.query.ConfigurableRootQueryImpl.simpleCount(ConfigurableRootQueryImpl.java:339)
    at org.babyfish.jimmer.sql.ast.impl.query.ConfigurableRootQueryImpl.fetchUnlimitedCount(ConfigurableRootQueryImpl.java:50)
    at org.babyfish.jimmer.sql.ast.query.ConfigurableRootQuery.fetchUnlimitedCount(ConfigurableRootQuery.java:29)
```

## Cause

Base-table rendering did not distinguish normal rendering from count/exists rendering.

Also, merged base queries rendered ordered union operands directly, producing invalid SQL once the count path was fixed.

## Fix

- Add internal `QueryRenderMode` for render-pass-specific sorting/paging suppression.
- Store render mode in `AstContext` for current render pass.
- Use the mode in `simpleCount` and `simpleExists`.
- Read render mode at query-render point instead of passing boolean flags through private methods.
- Wrap merged base-query operands when a child has branch-local sorting or paging.

## Verification

Added `IssueTest.testBaseTableFetchPageWithoutConnection` covering `exists()` and `fetchPage(...)` over sorted base tables.

The downstream endpoint-level query using `baseTableSymbol + unionAll + fetchPage(...)` passes with this fix.
