### PR TITLE
Support @MapsId

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableProp.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableProp.java
@@ -117,6 +117,10 @@ public interface ImmutableProp {
 
     boolean isLogicalDeleted();
 
+    default boolean isMappedId() {
+        return getDeclaringType().isMappedIdProp(this);
+    }
+
     ImmutableType getTargetType();
 
     List<OrderedItem> getOrderedItems();

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
@@ -119,6 +119,9 @@ public interface ImmutableType {
     KeyMatcher getKeyMatcher();
 
     @NotNull
+    List<MappedId> getMappedIds();
+
+    @NotNull
     Map<String, ImmutableProp> getProps();
 
     @NotNull

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
@@ -121,6 +121,8 @@ public interface ImmutableType {
     @NotNull
     List<MappedId> getMappedIds();
 
+    boolean isMappedIdProp(ImmutableProp prop);
+
     @NotNull
     Map<String, ImmutableProp> getProps();
 

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/MappedId.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/MappedId.java
@@ -1,0 +1,376 @@
+package org.babyfish.jimmer.meta;
+
+import org.babyfish.jimmer.sql.MapsId;
+import org.babyfish.jimmer.sql.meta.ColumnDefinition;
+import org.babyfish.jimmer.sql.meta.EmbeddedColumns;
+import org.babyfish.jimmer.sql.meta.MetadataStrategy;
+import org.babyfish.jimmer.sql.meta.MultipleJoinColumns;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public final class MappedId {
+
+    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
+
+    private final ImmutableProp prop;
+
+    private final List<ImmutableProp> idPath;
+
+    private MappedId(ImmutableProp prop, List<ImmutableProp> idPath) {
+        this.prop = prop;
+        this.idPath = idPath;
+    }
+
+    @NotNull
+    public ImmutableProp getProp() {
+        return prop;
+    }
+
+    @NotNull
+    public ImmutableProp getIdProp() {
+        return prop.getDeclaringType().getIdProp();
+    }
+
+    @NotNull
+    public ImmutableProp getTargetIdProp() {
+        return prop.getTargetType().getIdProp();
+    }
+
+    @NotNull
+    public List<ImmutableProp> getIdPath() {
+        return idPath;
+    }
+
+    public boolean isFull() {
+        return idPath.isEmpty();
+    }
+
+    @NotNull
+    public List<Column> getColumns(MetadataStrategy strategy) {
+        ImmutableProp idProp = getIdProp();
+        ColumnDefinition sourceDefinition = sourceDefinition(strategy);
+        ColumnDefinition joinDefinition = prop.getStorage(strategy);
+        ColumnDefinition targetDefinition = getTargetIdProp().getStorage(strategy);
+        int size = joinDefinition.size();
+        if (sourceDefinition.size() != size) {
+            throw illegal(
+                    "the mapped id path \"" +
+                            pathText() +
+                            "\" has " +
+                            sourceDefinition.size() +
+                            " column(s), but the join columns have " +
+                            size +
+                            " column(s)"
+            );
+        }
+        if (targetDefinition.size() != size) {
+            throw illegal(
+                    "the target id property \"" +
+                            getTargetIdProp() +
+                            "\" has " +
+                            targetDefinition.size() +
+                            " column(s), but the join columns have " +
+                            size +
+                            " column(s)"
+            );
+        }
+        List<Column> columns = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            String targetColumnName = referencedColumnName(joinDefinition, i, targetDefinition);
+            int targetIndex = targetDefinition.index(targetColumnName);
+            if (targetIndex == -1) {
+                throw illegal(
+                        "the referenced column \"" +
+                                targetColumnName +
+                                "\" is not a column of the target id property \"" +
+                                getTargetIdProp() +
+                                "\""
+                );
+            }
+            String sourceColumnName = joinDefinition.name(i);
+            if (sourceDefinition.index(sourceColumnName) == -1) {
+                throw illegal(
+                        "the join column \"" +
+                                sourceColumnName +
+                                "\" is not a column of the mapped id path \"" +
+                                pathText() +
+                                "\""
+                );
+            }
+            columns.add(
+                    new Column(
+                            sourceColumnName,
+                            targetColumnName,
+                            idProp.getStorage(strategy),
+                            targetDefinition,
+                            sourceDefinition.index(sourceColumnName),
+                            targetIndex
+                    )
+            );
+        }
+        return Collections.unmodifiableList(columns);
+    }
+
+    private ColumnDefinition sourceDefinition(MetadataStrategy strategy) {
+        ColumnDefinition idDefinition = getIdProp().getStorage(strategy);
+        if (idPath.isEmpty()) {
+            return idDefinition;
+        }
+        if (!(idDefinition instanceof EmbeddedColumns)) {
+            throw illegal(
+                    "the non-empty value \"" +
+                            pathText() +
+                            "\" requires the id property \"" +
+                            getIdProp() +
+                            "\" to be embedded"
+            );
+        }
+        return ((EmbeddedColumns) idDefinition).partial(pathText());
+    }
+
+    private String pathText() {
+        if (idPath.isEmpty()) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (ImmutableProp prop : idPath) {
+            if (builder.length() != 0) {
+                builder.append('.');
+            }
+            builder.append(prop.getName());
+        }
+        return builder.toString();
+    }
+
+    private String referencedColumnName(
+            ColumnDefinition joinDefinition,
+            int index,
+            ColumnDefinition targetDefinition
+    ) {
+        if (joinDefinition instanceof MultipleJoinColumns) {
+            return ((MultipleJoinColumns) joinDefinition).referencedName(index);
+        }
+        return targetDefinition.name(index);
+    }
+
+    private ModelException illegal(String reason) {
+        return new ModelException(
+                "Illegal property \"" +
+                        prop +
+                        "\", it cannot be decorated by @" +
+                        MapsId.class.getName() +
+                        " because " +
+                        reason
+        );
+    }
+
+    public static List<MappedId> resolve(ImmutableType type) {
+        List<MappedId> mappedIds = new ArrayList<>();
+        for (ImmutableProp prop : type.getProps().values()) {
+            MapsId mapsId = prop.getAnnotation(MapsId.class);
+            if (mapsId != null) {
+                mappedIds.add(of(prop, mapsId));
+            }
+        }
+        if (mappedIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        validateNoPathOverlap(mappedIds);
+        return Collections.unmodifiableList(mappedIds);
+    }
+
+    private static MappedId of(ImmutableProp prop, MapsId mapsId) {
+        validateAssociation(prop);
+        ImmutableProp idProp = prop.getDeclaringType().getIdProp();
+        if (idProp == null) {
+            throw illegal(prop, "the declaring type has no id property");
+        }
+        ImmutableProp targetIdProp = prop.getTargetType().getIdProp();
+        if (targetIdProp == null) {
+            throw illegal(prop, "the target type has no id property");
+        }
+        List<ImmutableProp> path = resolvePath(idProp, mapsId.value());
+        Class<?> sourceType = path.isEmpty() ?
+                idProp.getReturnClass() :
+                path.get(path.size() - 1).getReturnClass();
+        if (sourceType != targetIdProp.getReturnClass()) {
+            throw illegal(
+                    prop,
+                    "the type of the mapped id path \"" +
+                            mapsId.value() +
+                            "\" is \"" +
+                            sourceType.getName() +
+                            "\", but the target id type is \"" +
+                            targetIdProp.getReturnClass().getName() +
+                            "\""
+            );
+        }
+        if (idProp.getAnnotation(org.babyfish.jimmer.sql.GeneratedValue.class) != null) {
+            throw illegal(prop, "the declaring id property \"" + idProp + "\" is generated");
+        }
+        return new MappedId(prop, path);
+    }
+
+    private static void validateAssociation(ImmutableProp prop) {
+        if (!prop.isReference(TargetLevel.ENTITY)) {
+            throw illegal(prop, "it is not a reference property");
+        }
+        Class<?> associationType = prop.getAssociationAnnotation().annotationType();
+        if (associationType != org.babyfish.jimmer.sql.OneToOne.class &&
+                associationType != org.babyfish.jimmer.sql.ManyToOne.class) {
+            throw illegal(prop, "it is neither one-to-one nor many-to-one");
+        }
+        if (prop.getMappedBy() != null) {
+            throw illegal(prop, "it is not an owning association");
+        }
+        if (!prop.isColumnDefinition()) {
+            throw illegal(prop, "it is not mapped by join columns");
+        }
+        if (prop.isRemote()) {
+            throw illegal(prop, "it is remote");
+        }
+    }
+
+    private static List<ImmutableProp> resolvePath(ImmutableProp idProp, String pathText) {
+        if (pathText.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (!idProp.isEmbedded(EmbeddedLevel.SCALAR)) {
+            throw illegal(
+                    idProp,
+                    "the non-empty maps-id path \"" +
+                            pathText +
+                            "\" requires embedded id"
+            );
+        }
+        ImmutableType type = idProp.getTargetType();
+        List<ImmutableProp> path = new ArrayList<>();
+        String[] names = DOT_PATTERN.split(pathText);
+        for (int i = 0; i < names.length; i++) {
+            String name = names[i];
+            ImmutableProp prop = type.getProps().get(name);
+            if (prop == null) {
+                throw illegal(
+                        idProp,
+                        "the maps-id path \"" +
+                                pathText +
+                                "\" cannot be resolved because there is no property \"" +
+                                name +
+                                "\" in \"" +
+                                type +
+                                "\""
+                );
+            }
+            path.add(prop);
+            type = prop.getTargetType();
+            if (type == null && i + 1 < names.length) {
+                throw illegal(
+                        idProp,
+                        "the maps-id path \"" +
+                                pathText +
+                                "\" cannot be resolved through the scalar property \"" +
+                                prop +
+                                "\""
+                );
+            }
+        }
+        return Collections.unmodifiableList(path);
+    }
+
+    private static void validateNoPathOverlap(List<MappedId> mappedIds) {
+        for (int i = 0; i < mappedIds.size(); i++) {
+            for (int ii = i + 1; ii < mappedIds.size(); ii++) {
+                MappedId a = mappedIds.get(i);
+                MappedId b = mappedIds.get(ii);
+                if (isPrefix(a.idPath, b.idPath) || isPrefix(b.idPath, a.idPath)) {
+                    throw illegal(
+                            b.prop,
+                            "its mapped id path overlaps with the path of \"" +
+                                    a.prop +
+                                    "\""
+                    );
+                }
+            }
+        }
+    }
+
+    private static boolean isPrefix(List<ImmutableProp> a, List<ImmutableProp> b) {
+        if (a.size() > b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (a.get(i) != b.get(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static ModelException illegal(ImmutableProp prop, String reason) {
+        return new ModelException(
+                "Illegal property \"" +
+                        prop +
+                        "\", it cannot be decorated by @" +
+                        MapsId.class.getName() +
+                        " because " +
+                        reason
+        );
+    }
+
+    public static final class Column {
+
+        private final String sourceName;
+
+        private final String targetName;
+
+        private final ColumnDefinition idDefinition;
+
+        private final ColumnDefinition targetIdDefinition;
+
+        private final int sourceIndex;
+
+        private final int targetIndex;
+
+        private Column(
+                String sourceName,
+                String targetName,
+                ColumnDefinition idDefinition,
+                ColumnDefinition targetIdDefinition,
+                int sourceIndex,
+                int targetIndex
+        ) {
+            this.sourceName = sourceName;
+            this.targetName = targetName;
+            this.idDefinition = idDefinition;
+            this.targetIdDefinition = targetIdDefinition;
+            this.sourceIndex = sourceIndex;
+            this.targetIndex = targetIndex;
+        }
+
+        public String getSourceName() {
+            return sourceName;
+        }
+
+        public String getTargetName() {
+            return targetName;
+        }
+
+        public ColumnDefinition getIdDefinition() {
+            return idDefinition;
+        }
+
+        public ColumnDefinition getTargetIdDefinition() {
+            return targetIdDefinition;
+        }
+
+        public int getSourceIndex() {
+            return sourceIndex;
+        }
+
+        public int getTargetIndex() {
+            return targetIndex;
+        }
+    }
+}

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
@@ -94,6 +94,8 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl {
 
     private List<MappedId> mappedIds;
 
+    private Set<ImmutableProp> mappedIdProps;
+
     private final String microServiceName;
 
     private final MetaCache<String> tableNameCache = new MetaCache<>(this::getTableName0);
@@ -288,6 +290,25 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl {
             this.mappedIds = mappedIds = MappedId.resolve(this);
         }
         return mappedIds;
+    }
+
+    @Override
+    public boolean isMappedIdProp(ImmutableProp prop) {
+        Set<ImmutableProp> mappedIdProps = this.mappedIdProps;
+        if (mappedIdProps == null) {
+            List<MappedId> mappedIds = getMappedIds();
+            if (mappedIds.isEmpty()) {
+                mappedIdProps = Collections.emptySet();
+            } else {
+                mappedIdProps = new HashSet<>(mappedIds.size());
+                for (MappedId mappedId : mappedIds) {
+                    mappedIdProps.add(mappedId.getProp());
+                }
+                mappedIdProps = Collections.unmodifiableSet(mappedIdProps);
+            }
+            this.mappedIdProps = mappedIdProps;
+        }
+        return mappedIdProps.contains(prop);
     }
 
     @NotNull

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
@@ -92,6 +92,8 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl {
 
     private KeyMatcher keyMatcher = KeyMatcher.EMPTY;
 
+    private List<MappedId> mappedIds;
+
     private final String microServiceName;
 
     private final MetaCache<String> tableNameCache = new MetaCache<>(this::getTableName0);
@@ -277,6 +279,15 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl {
     @Override
     public KeyMatcher getKeyMatcher() {
         return keyMatcher;
+    }
+
+    @Override
+    public List<MappedId> getMappedIds() {
+        List<MappedId> mappedIds = this.mappedIds;
+        if (mappedIds == null) {
+            this.mappedIds = mappedIds = MappedId.resolve(this);
+        }
+        return mappedIds;
     }
 
     @NotNull

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/PropDescriptor.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/PropDescriptor.java
@@ -573,8 +573,8 @@ public class PropDescriptor {
             families.put(Type.LOGICAL_DELETED, setOf(LogicalDeleted.class, Column.class, Default.class, ExcludeFromAllScalars.class));
             families.put(Type.FORMULA, setOf(Formula.class));
             families.put(Type.BASIC, setOf(Key.class, Column.class, PropOverrides.class, PropOverride.class, Scalar.class, Serialized.class, Default.class, ExcludeFromAllScalars.class));
-            families.put(Type.ONE_TO_ONE, setOf(Key.class, OnDissociate.class, JoinColumns.class, JoinColumn.class, JoinTable.class));
-            families.put(Type.MANY_TO_ONE, setOf(Key.class, OnDissociate.class, JoinColumns.class, JoinColumn.class, JoinTable.class));
+            families.put(Type.ONE_TO_ONE, setOf(Key.class, OnDissociate.class, JoinColumns.class, JoinColumn.class, JoinTable.class, MapsId.class));
+            families.put(Type.MANY_TO_ONE, setOf(Key.class, OnDissociate.class, JoinColumns.class, JoinColumn.class, JoinTable.class, MapsId.class));
             families.put(Type.ONE_TO_MANY, setOf());
             families.put(Type.MANY_TO_MANY, setOf(JoinTable.class, JoinSql.class));
             families.put(Type.ID_VIEW, setOf());

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/MapsId.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/MapsId.java
@@ -1,0 +1,19 @@
+package org.babyfish.jimmer.sql;
+
+import kotlin.annotation.AnnotationTarget;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks an owning reference whose target id is mapped into the id of the declaring entity.
+ *
+ * <p>If {@link #value()} is empty, the whole id of the declaring entity is mapped.
+ * Otherwise, the value is a dot-separated path inside the declaring id.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@kotlin.annotation.Target(allowedTargets = AnnotationTarget.PROPERTY)
+@Target(ElementType.METHOD)
+public @interface MapsId {
+
+    String value() default "";
+}

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/impl/PropChains.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/sql/meta/impl/PropChains.java
@@ -36,6 +36,7 @@ public class PropChains {
             MetadataStrategy strategy,
             Map<String, List<ImmutableProp>> outputMap
     ) {
+        ImmutableType declaringType = prop.getDeclaringType();
         Storage storage = prop.getStorage(strategy);
         if (prop.isEmbedded(EmbeddedLevel.BOTH)) {
             MultipleJoinColumns multipleJoinColumns = null;
@@ -72,9 +73,10 @@ public class PropChains {
                             String referencedName = multipleJoinColumns.referencedName(index);
                             if (DatabaseIdentifiers.comparableIdentifier(referencedName).equals(cmpName)) {
                                 addInto(
-                                        prop.getDeclaringType(),
+                                        declaringType,
                                         multipleJoinColumns.name(index),
                                         Collections.unmodifiableList(chain),
+                                        strategy,
                                         outputMap
                                 );
                                 break;
@@ -88,9 +90,10 @@ public class PropChains {
                         }
                     } else {
                         addInto(
-                                prop.getDeclaringType(),
+                                declaringType,
                                 cmpName,
                                 Collections.unmodifiableList(chain),
+                                strategy,
                                 outputMap
                         );
                     }
@@ -99,9 +102,10 @@ public class PropChains {
         } else if (storage instanceof SingleColumn) {
             String cmpName = DatabaseIdentifiers.comparableIdentifier(((SingleColumn)storage).getName());
             addInto(
-                    prop.getDeclaringType(),
+                    declaringType,
                     cmpName,
                     Collections.singletonList(prop),
+                    strategy,
                     outputMap
             );
         }
@@ -111,10 +115,19 @@ public class PropChains {
             ImmutableType type,
             String columnName,
             List<ImmutableProp> chain,
+            MetadataStrategy strategy,
             Map<String, List<ImmutableProp>> outputMap
     ) {
-        List<ImmutableProp> conflictChain = outputMap.put(columnName, chain);
+        List<ImmutableProp> conflictChain = outputMap.get(columnName);
         if (conflictChain == null) {
+            outputMap.put(columnName, chain);
+            return;
+        }
+        if (isMappedIdConflict(type, columnName, conflictChain, chain, strategy)) {
+            outputMap.put(columnName, chain);
+            return;
+        }
+        if (isMappedIdConflict(type, columnName, chain, conflictChain, strategy)) {
             return;
         }
         ImmutableProp targetIdProp = null;
@@ -154,6 +167,47 @@ public class PropChains {
                     "\"";
         }
         throw new ModelException(message);
+    }
+
+    private static boolean isMappedIdConflict(
+            ImmutableType type,
+            String columnName,
+            List<ImmutableProp> mappedIdChain,
+            List<ImmutableProp> idChain,
+            MetadataStrategy strategy
+    ) {
+        if (mappedIdChain.isEmpty() || idChain.isEmpty()) {
+            return false;
+        }
+        ImmutableProp mappedIdProp = mappedIdChain.get(0);
+        MappedId mappedId = null;
+        for (MappedId item : type.getMappedIds()) {
+            if (item.getProp() == mappedIdProp) {
+                mappedId = item;
+                break;
+            }
+        }
+        if (mappedId == null || idChain.get(0) != mappedId.getIdProp()) {
+            return false;
+        }
+        List<ImmutableProp> idPath = mappedId.getIdPath();
+        if (!idPath.isEmpty()) {
+            if (idChain.size() < idPath.size() + 1) {
+                return false;
+            }
+            for (int i = 0; i < idPath.size(); i++) {
+                if (idChain.get(i + 1) != idPath.get(i)) {
+                    return false;
+                }
+            }
+        }
+        String comparableColumnName = DatabaseIdentifiers.comparableIdentifier(columnName);
+        for (MappedId.Column column : mappedId.getColumns(strategy)) {
+            if (DatabaseIdentifiers.comparableIdentifier(column.getSourceName()).equals(comparableColumnName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String chainPath(List<ImmutableProp> chain) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/association/meta/AssociationType.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/association/meta/AssociationType.java
@@ -278,6 +278,11 @@ public class AssociationType extends AbstractImmutableTypeImpl {
     }
 
     @Override
+    public boolean isMappedIdProp(ImmutableProp prop) {
+        return false;
+    }
+
+    @Override
     public String getMicroServiceName() {
         return baseProp.getDeclaringType().getMicroServiceName();
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/association/meta/AssociationType.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/association/meta/AssociationType.java
@@ -271,6 +271,12 @@ public class AssociationType extends AbstractImmutableTypeImpl {
         return KeyMatcher.EMPTY;
     }
 
+    @NotNull
+    @Override
+    public List<MappedId> getMappedIds() {
+        return Collections.emptyList();
+    }
+
     @Override
     public String getMicroServiceName() {
         return baseProp.getDeclaringType().getMicroServiceName();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MappedIdResolver.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MappedIdResolver.java
@@ -1,0 +1,138 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.MappedId;
+import org.babyfish.jimmer.meta.PropId;
+import org.babyfish.jimmer.runtime.DraftSpi;
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+
+import java.util.List;
+import java.util.Objects;
+
+class MappedIdResolver {
+
+    private final SaveContext ctx;
+
+    MappedIdResolver(SaveContext ctx) {
+        this.ctx = ctx;
+    }
+
+    void resolve(List<DraftSpi> drafts) {
+        List<MappedId> mappedIds = ctx.path.getType().getMappedIds();
+        if (mappedIds.isEmpty()) {
+            return;
+        }
+        for (DraftSpi draft : drafts) {
+            for (MappedId mappedId : mappedIds) {
+                resolve(draft, mappedId);
+            }
+        }
+    }
+
+    private void resolve(DraftSpi draft, MappedId mappedId) {
+        ImmutableProp prop = mappedId.getProp();
+        PropId propId = prop.getId();
+        if (!draft.__isLoaded(propId)) {
+            return;
+        }
+        Object target = draft.__get(propId);
+        if (target == null) {
+            return;
+        }
+        ImmutableSpi targetSpi = (ImmutableSpi) target;
+        ImmutableProp targetIdProp = mappedId.getTargetIdProp();
+        PropId targetIdPropId = targetIdProp.getId();
+        if (!targetSpi.__isLoaded(targetIdPropId)) {
+            throw ctx.prop(prop).createInconsistentMappedId(
+                    mappedId,
+                    "the target id property \"" +
+                            targetIdProp +
+                            "\" is not loaded"
+            );
+        }
+        Object targetId = targetSpi.__get(targetIdPropId);
+        if (mappedId.isFull()) {
+            setFullId(draft, mappedId, targetId);
+        } else {
+            setPartialId(draft, mappedId, targetId);
+        }
+    }
+
+    private void setFullId(DraftSpi draft, MappedId mappedId, Object targetId) {
+        ImmutableProp idProp = mappedId.getIdProp();
+        PropId idPropId = idProp.getId();
+        if (draft.__isLoaded(idPropId)) {
+            Object id = draft.__get(idPropId);
+            if (id != null && !Objects.equals(id, targetId)) {
+                throw ctx.createInconsistentMappedId(
+                        mappedId,
+                        "the id value \"" +
+                                id +
+                                "\" does not match the target id value \"" +
+                                targetId +
+                                "\""
+                );
+            }
+        }
+        draft.__set(idPropId, targetId);
+    }
+
+    private void setPartialId(DraftSpi draft, MappedId mappedId, Object targetId) {
+        ImmutableProp idProp = mappedId.getIdProp();
+        PropId idPropId = idProp.getId();
+        DraftSpi idDraft;
+        if (draft.__isLoaded(idPropId)) {
+            Object id = draft.__get(idPropId);
+            idDraft = id != null ? toDraft(draft, id) : newDraft(draft, idProp.getTargetType());
+        } else {
+            idDraft = newDraft(draft, idProp.getTargetType());
+        }
+        setPath(idDraft, mappedId, targetId);
+        draft.__set(idPropId, idDraft);
+    }
+
+    private void setPath(DraftSpi parent, MappedId mappedId, Object targetId) {
+        List<ImmutableProp> path = mappedId.getIdPath();
+        for (int i = 0; i < path.size() - 1; i++) {
+            ImmutableProp prop = path.get(i);
+            PropId propId = prop.getId();
+            DraftSpi child;
+            if (parent.__isLoaded(propId)) {
+                Object value = parent.__get(propId);
+                child = value != null ? toDraft(parent, value) : newDraft(parent, prop.getTargetType());
+            } else {
+                child = newDraft(parent, prop.getTargetType());
+            }
+            parent.__set(propId, child);
+            parent = child;
+        }
+        ImmutableProp leafProp = path.get(path.size() - 1);
+        PropId leafPropId = leafProp.getId();
+        if (parent.__isLoaded(leafPropId)) {
+            Object value = parent.__get(leafPropId);
+            if (value != null && !Objects.equals(value, targetId)) {
+                throw ctx.createInconsistentMappedId(
+                        mappedId,
+                        "the id path value \"" +
+                                value +
+                                "\" does not match the target id value \"" +
+                                targetId +
+                                "\""
+                );
+            }
+        }
+        parent.__set(leafPropId, targetId);
+    }
+
+    private DraftSpi toDraft(DraftSpi owner, Object value) {
+        return owner.__draftContext().toDraftObject(value);
+    }
+
+    private DraftSpi newDraft(DraftSpi owner, ImmutableType type) {
+        return (DraftSpi) type.getDraftFactory().apply(
+                owner.__draftContext(),
+                null
+        );
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationContext.java
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.ast.impl.mutation;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.MappedId;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.*;
 import org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode;
@@ -248,6 +249,17 @@ class MutationContext {
                         "\" is illegal, the " +
                         catalog +
                         " is embeddable type but the its value is incomplete"
+        );
+    }
+
+    SaveException.InconsistentMappedId createInconsistentMappedId(MappedId mappedId, String reason) {
+        return new SaveException.InconsistentMappedId(
+                path,
+                "The property \"" +
+                        mappedId.getProp() +
+                        "\" decorated by @MapsId is inconsistent, " +
+                        reason,
+                mappedId.getProp()
         );
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -283,7 +283,7 @@ abstract class AbstractPreHandler implements PreHandler {
                     }
                 }
             }
-            if (ctx.backReferenceFrozen && !isMappedId(ctx.backReferenceProp)) {
+            if (ctx.backReferenceFrozen && !ctx.backReferenceProp.isMappedId()) {
                 fetcherImplementor = fetcherImplementor.add(ctx.backReferenceProp.getName(), IdOnlyFetchType.RAW);
             }
             this.originalFetcher = oldFetcher = fetcherImplementor;
@@ -295,7 +295,7 @@ abstract class AbstractPreHandler implements PreHandler {
         if (ctx.trigger != null) {
             return QueryReason.TRIGGER;
         }
-        if (ctx.backReferenceFrozen && !isMappedId(ctx.backReferenceProp)) {
+        if (ctx.backReferenceFrozen && !ctx.backReferenceProp.isMappedId()) {
             return QueryReason.TARGET_NOT_TRANSFERABLE;
         }
         if (interceptor != null) {
@@ -421,15 +421,6 @@ abstract class AbstractPreHandler implements PreHandler {
             return;
         }
         processor.beforeSave(draft);
-    }
-
-    private static boolean isMappedId(ImmutableProp prop) {
-        for (MappedId mappedId : prop.getDeclaringType().getMappedIds()) {
-            if (mappedId.getProp() == prop) {
-                return true;
-            }
-        }
-        return false;
     }
 
     final void callInterceptor(List<DraftInterceptor.Item<Object, DraftSpi>> items) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -283,7 +283,7 @@ abstract class AbstractPreHandler implements PreHandler {
                     }
                 }
             }
-            if (ctx.backReferenceFrozen) {
+            if (ctx.backReferenceFrozen && !isMappedId(ctx.backReferenceProp)) {
                 fetcherImplementor = fetcherImplementor.add(ctx.backReferenceProp.getName(), IdOnlyFetchType.RAW);
             }
             this.originalFetcher = oldFetcher = fetcherImplementor;
@@ -295,7 +295,7 @@ abstract class AbstractPreHandler implements PreHandler {
         if (ctx.trigger != null) {
             return QueryReason.TRIGGER;
         }
-        if (ctx.backReferenceFrozen) {
+        if (ctx.backReferenceFrozen && !isMappedId(ctx.backReferenceProp)) {
             return QueryReason.TARGET_NOT_TRANSFERABLE;
         }
         if (interceptor != null) {
@@ -421,6 +421,15 @@ abstract class AbstractPreHandler implements PreHandler {
             return;
         }
         processor.beforeSave(draft);
+    }
+
+    private static boolean isMappedId(ImmutableProp prop) {
+        for (MappedId mappedId : prop.getDeclaringType().getMappedIds()) {
+            if (mappedId.getProp() == prop) {
+                return true;
+            }
+        }
+        return false;
     }
 
     final void callInterceptor(List<DraftInterceptor.Item<Object, DraftSpi>> items) {
@@ -1059,4 +1068,3 @@ class NonIdempotentUpsertHandler extends UpsertPreHandler {
         return true;
     }
 }
-

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Saver.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Saver.java
@@ -132,6 +132,7 @@ public class Saver {
                 savePreAssociation(prop, drafts);
             }
         }
+        new MappedIdResolver(ctx).resolve(drafts);
 
         PreHandler preHandler = PreHandler.of(ctx);
         for (DraftSpi draft : drafts) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Shape.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Shape.java
@@ -34,13 +34,16 @@ class Shape {
     public static Shape of(JSqlClientImplementor sqlClient, ImmutableSpi spi, Predicate<ImmutableProp> propFilter) {
         return new Shape(
                 spi.__type(), 
-                PropertyGetter.entityGetters(sqlClient, spi.__type(), spi, propFilter)
+                PropertyGetter.entityGetters(sqlClient, spi.__type(), spi, withoutMappedIdProps(spi.__type(), propFilter))
         );
     }
 
     public static Shape fullOf(JSqlClientImplementor sqlClient, Class<?> type) {
         ImmutableType immutableType = ImmutableType.get(type);
-        return new Shape(immutableType, PropertyGetter.entityGetters(sqlClient, immutableType, null, null));
+        return new Shape(
+                immutableType,
+                PropertyGetter.entityGetters(sqlClient, immutableType, null, withoutMappedIdProps(immutableType, null))
+        );
     }
 
     @NotNull
@@ -190,5 +193,23 @@ class Shape {
         }
         builder.append(']');
         return builder.toString();
+    }
+
+    private static Predicate<ImmutableProp> withoutMappedIdProps(
+            ImmutableType type,
+            Predicate<ImmutableProp> propFilter
+    ) {
+        List<MappedId> mappedIds = type.getMappedIds();
+        if (mappedIds.isEmpty()) {
+            return propFilter;
+        }
+        Set<ImmutableProp> mappedIdProps = new HashSet<>(mappedIds.size());
+        for (MappedId mappedId : mappedIds) {
+            mappedIdProps.add(mappedId.getProp());
+        }
+        if (propFilter == null) {
+            return prop -> !mappedIdProps.contains(prop);
+        }
+        return prop -> !mappedIdProps.contains(prop) && propFilter.test(prop);
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
@@ -91,7 +91,20 @@ public abstract class TableUsageVisitor extends AstVisitor {
     protected final void use(RealTable table) {
         if (table != null) {
             useTable(table);
-            use(table.getParent());
+            useParent(table);
+        }
+    }
+
+    private void useParent(RealTable table) {
+        RealTable parent = table.getParent();
+        if (parent == null) {
+            return;
+        }
+        if (parent.isOptimizableBridgeTo(table, getAstContext())) {
+            useTableId(parent);
+            use(parent.getParent());
+        } else {
+            use(parent);
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
@@ -1,6 +1,7 @@
 package org.babyfish.jimmer.sql.ast.impl.query;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.TargetLevel;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
 import org.babyfish.jimmer.sql.ast.impl.AstVisitor;
@@ -41,7 +42,7 @@ public abstract class TableUsageVisitor extends AstVisitor {
                     rawId || TableUtils.isRawIdAllowed(tableImplementor, getAstContext().getSqlClient()))
             ) {
                 useTableId(table);
-                use(table.getParent());
+                useColumnSource(table.getParent());
             } else {
                 use(table);
             }
@@ -108,6 +109,18 @@ public abstract class TableUsageVisitor extends AstVisitor {
         }
     }
 
+    private void useColumnSource(RealTable table) {
+        if (table == null) {
+            return;
+        }
+        if (table.isMappedIdColumnSource(getAstContext())) {
+            useTableId(table);
+            useColumnSource(table.getParent());
+        } else {
+            use(table);
+        }
+    }
+
     private class UseJoinFetcherVisitor extends JoinFetchFieldVisitor {
 
         private final AstContext ctx;
@@ -125,7 +138,12 @@ public abstract class TableUsageVisitor extends AstVisitor {
             TableImplementor<?> oldTableImplementor = this.tableImplementor;
             TableImplementor<?> newTableImplementor =
                     oldTableImplementor.joinFetchImplementor(field.getProp(), oldTableImplementor.getBaseTableOwner());
-            useTable(newTableImplementor.realTable(ctx));
+            RealTable realTable = newTableImplementor.realTable(ctx);
+            if (isIdOnlyJoinFetch(field)) {
+                useTableId(realTable);
+            } else {
+                useTable(realTable);
+            }
             this.tableImplementor = newTableImplementor;
             return oldTableImplementor;
         }
@@ -133,6 +151,33 @@ public abstract class TableUsageVisitor extends AstVisitor {
         @Override
         protected void leave(Field field, Object enterValue) {
             this.tableImplementor = (TableImplementor<?>) enterValue;
+        }
+
+        private boolean isIdOnlyJoinFetch(Field field) {
+            if (field.getFilter() != null || field.getRecursionStrategy() != null) {
+                return false;
+            }
+            if (ctx.getSqlClient().getFilters().getTargetFilter(field.getProp()) != null) {
+                return false;
+            }
+            Fetcher<?> childFetcher = field.getChildFetcher();
+            return childFetcher != null && isIdOnlyFetcher(childFetcher);
+        }
+
+        private boolean isIdOnlyFetcher(Fetcher<?> fetcher) {
+            for (Field field : fetcher.getFieldMap().values()) {
+                ImmutableProp prop = field.getProp();
+                if (prop.isId()) {
+                    continue;
+                }
+                if (!prop.isMappedId() ||
+                        !prop.isAssociation(TargetLevel.PERSISTENT) ||
+                        prop.isReferenceList(TargetLevel.PERSISTENT) ||
+                        !isIdOnlyJoinFetch(field)) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/FetcherSelectionImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/FetcherSelectionImpl.java
@@ -213,7 +213,8 @@ public class FetcherSelectionImpl<T> implements FetcherSelection<T>, Ast {
                     if (storage instanceof EmbeddedColumns) {
                         renderEmbedded(null, (EmbeddedColumns) storage, field.getChildFetcher(), "", exportSelection, builder);
                     } else if (storage instanceof ColumnDefinition) {
-                        builder.separator().definition(table, (ColumnDefinition) storage, exportSelection);
+                        builder.separator();
+                        renderColumnDefinition(table, (ColumnDefinition) storage, exportSelection, builder);
                     } else if (template instanceof FormulaTemplate) {
                         builder.separator();
                         if (exportSelection != null) {
@@ -257,9 +258,7 @@ public class FetcherSelectionImpl<T> implements FetcherSelection<T>, Ast {
                                     .sql(".c")
                                     .sql(Integer.toString(exportSelection.columnIndex(realTable, columnName, false)));
                         } else {
-                            builder
-                                    .sql(builder.alias(realTable)).sql(".")
-                                    .sql(columnName);
+                            realTable.renderColumn(builder, columnName, false, null);
                         }
                     }
                 } else {
@@ -281,6 +280,21 @@ public class FetcherSelectionImpl<T> implements FetcherSelection<T>, Ast {
                 }
             }
         }.visit(fetcher);
+    }
+
+    private static void renderColumnDefinition(
+            RealTable table,
+            ColumnDefinition definition,
+            BaseQueryExportSelection exportSelection,
+            SqlBuilder builder
+    ) {
+        int size = definition.size();
+        for (int i = 0; i < size; i++) {
+            if (i != 0) {
+                builder.sql(", ");
+            }
+            table.renderColumn(builder, definition.name(i), false, exportSelection);
+        }
     }
 
     private ImmutableProp getEmbeddedRawReferenceProp(JSqlClientImplementor sqlClient) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTable.java
@@ -1,6 +1,7 @@
 package org.babyfish.jimmer.sql.ast.impl.table;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.sql.ast.impl.AstContext;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsageVisitor;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
@@ -21,6 +22,8 @@ public interface RealTable extends Iterable<RealTable> {
     TableAliasKey getAliasKey();
 
     RealTable child(Key key);
+
+    boolean isOptimizableBridgeTo(RealTable child, AstContext ctx);
 
     @Nullable
     BaseTableOwner getBaseTableOwner();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTable.java
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.ast.impl.table;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
+import org.babyfish.jimmer.sql.ast.impl.base.BaseQueryExportSelection;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsageVisitor;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
@@ -25,12 +26,21 @@ public interface RealTable extends Iterable<RealTable> {
 
     boolean isOptimizableBridgeTo(RealTable child, AstContext ctx);
 
+    boolean isMappedIdColumnSource(AstContext ctx);
+
     @Nullable
     BaseTableOwner getBaseTableOwner();
 
     void use(TableUsageVisitor visitor);
 
     void renderTo(@NotNull AbstractSqlBuilder<?> builder, boolean cte);
+
+    void renderColumn(
+            AbstractSqlBuilder<?> builder,
+            String columnName,
+            boolean foreignKeyInBaseQuery,
+            BaseQueryExportSelection exportSelection
+    );
 
     void renderJoinAsFrom(SqlBuilder builder, TableImplementor.RenderMode mode);
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
@@ -164,6 +164,29 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
     }
 
     @Override
+    public boolean isOptimizableBridgeTo(RealTable child, AstContext ctx) {
+        if (parent == null ||
+                !(owner instanceof TableImplementor<?>) ||
+                !(child.getTableLikeImplementor() instanceof TableImplementor<?>)) {
+            return false;
+        }
+        TableImplementor<?> bridgeImplementor = (TableImplementor<?>) owner;
+        TableImplementor<?> childImplementor = (TableImplementor<?>) child.getTableLikeImplementor();
+        ImmutableProp bridgeProp = bridgeImplementor.getJoinProp();
+        ImmutableProp childProp = childImplementor.getJoinProp();
+        return bridgeImplementor.getWeakJoinHandle() == null &&
+                childImplementor.getWeakJoinHandle() == null &&
+                !bridgeImplementor.isInverse() &&
+                childImplementor.isInverse() &&
+                bridgeImplementor.getJoinType() == JoinType.INNER &&
+                childImplementor.getJoinType() == JoinType.INNER &&
+                bridgeProp != null &&
+                bridgeProp.isMappedId() &&
+                childProp == bridgeProp &&
+                bridgeImplementor.getStatement().getFilterPredicate(bridgeImplementor, ctx) == null;
+    }
+
+    @Override
     public TableAliasKey getAliasKey() {
         return aliasKey;
     }
@@ -483,6 +506,20 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                         TableImplementor.RenderMode.NORMAL
                 );
             }
+        } else if (isMappedIdBridgeJoin(builder)) {
+            RealTableImpl bridge = parent;
+            TableImpl<?> bridgeOwner = (TableImpl<?>) bridge.owner;
+            renderJoinImpl(
+                    builder,
+                    joinType,
+                    builder.alias(bridge.parent),
+                    bridge.parent,
+                    bridgeOwner.joinProp.getStorage(strategy),
+                    immutableType.getTableName(strategy),
+                    builder.alias(this),
+                    joinProp.getStorage(strategy),
+                    mode
+            );
         } else { // One-to-many join cannot be optimized by "used"
             renderJoinImpl(
                     builder,
@@ -496,6 +533,16 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                     mode
             );
         }
+    }
+
+    private boolean isMappedIdBridgeJoin(SqlBuilder builder) {
+        if (parent == null || parent.parent == null) {
+            return false;
+        }
+        if (builder.getAstContext().getTableUsedState(parent) != TableUsedState.ID_ONLY) {
+            return false;
+        }
+        return parent.isOptimizableBridgeTo(this, builder.getAstContext());
     }
 
     private void renderJoinBySql(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
@@ -187,6 +187,22 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
     }
 
     @Override
+    public boolean isMappedIdColumnSource(AstContext ctx) {
+        if (parent == null || !(owner instanceof TableImpl<?>)) {
+            return false;
+        }
+        TableImpl<?> tableOwner = (TableImpl<?>) owner;
+        ImmutableProp joinProp = tableOwner.joinProp;
+        return joinProp != null &&
+                joinProp.isMappedId() &&
+                !tableOwner.isInverse &&
+                tableOwner.weakJoinHandle == null &&
+                !joinProp.isMiddleTableDefinition() &&
+                !(joinProp.getSqlTemplate() instanceof JoinTemplate) &&
+                tableOwner.getStatement().getFilterPredicate(tableOwner, ctx) == null;
+    }
+
+    @Override
     public TableAliasKey getAliasKey() {
         return aliasKey;
     }
@@ -749,10 +765,12 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
             }
             if (!isInverse) {
                 if (optionalDefinition == null) {
-                    builder.definition(
-                            withPrefix ? parent : null,
+                    renderDefinition(
+                            builder,
+                            (RealTableImpl) parent,
                             joinProp.getStorage(strategy),
                             true,
+                            withPrefix,
                             asBlock,
                             exportSelection
                     );
@@ -766,10 +784,7 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                         }
                         int index = fullDefinition.index(optionalDefinition.name(i));
                         String parentColumnName = parentDefinition.name(index);
-                        if (withPrefix) {
-                            builder.sql(builder.assertSimple().alias(parent)).sql(".");
-                        }
-                        builder.sql(parentColumnName);
+                        renderColumn(builder, (RealTableImpl) parent, parentColumnName, true, withPrefix, exportSelection);
                         if (asBlock != null) {
                             builder.sql(" ").sql(asBlock.apply(i));
                         }
@@ -788,13 +803,116 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
             ColumnDefinition definition = optionalDefinition != null ?
                     optionalDefinition :
                     prop.getStorage(strategy);
-            builder.definition(
-                    withPrefix ? this : null,
+            renderDefinition(
+                    builder,
+                    this,
                     definition,
                     false,
+                    withPrefix,
                     asBlock,
                     exportSelection
             );
+        }
+    }
+
+    @Override
+    public void renderColumn(
+            AbstractSqlBuilder<?> builder,
+            String columnName,
+            boolean foreignKeyInBaseQuery,
+            BaseQueryExportSelection exportSelection
+    ) {
+        renderColumn(builder, this, columnName, foreignKeyInBaseQuery, true, exportSelection);
+    }
+
+    private void renderDefinition(
+            AbstractSqlBuilder<?> builder,
+            RealTableImpl table,
+            ColumnDefinition definition,
+            boolean foreignKeyInBaseQuery,
+            boolean withPrefix,
+            Function<Integer, String> asBlock,
+            BaseQueryExportSelection exportSelection
+    ) {
+        int size = definition.size();
+        for (int i = 0; i < size; i++) {
+            if (i != 0) {
+                builder.sql(", ");
+            }
+            renderColumn(builder, table, definition.name(i), foreignKeyInBaseQuery, withPrefix, exportSelection);
+            if (asBlock != null) {
+                builder.sql(" ").sql(asBlock.apply(i));
+            }
+        }
+    }
+
+    private void renderColumn(
+            AbstractSqlBuilder<?> builder,
+            RealTableImpl table,
+            String columnName,
+            boolean foreignKeyInBaseQuery,
+            boolean withPrefix,
+            BaseQueryExportSelection exportSelection
+    ) {
+        ColumnMapping mapping = mappedIdParentColumn(builder, table, columnName);
+        if (mapping != null) {
+            renderColumn(
+                    builder,
+                    mapping.table,
+                    mapping.columnName,
+                    foreignKeyInBaseQuery,
+                    withPrefix,
+                    exportSelection
+            );
+            return;
+        }
+        if (withPrefix && exportSelection != null) {
+            int index = exportSelection.columnIndex(table, columnName, foreignKeyInBaseQuery);
+            builder
+                    .sql(exportSelection.getAlias(builder.assertSimple()))
+                    .sql(".c")
+                    .sql(Integer.toString(index));
+        } else {
+            if (withPrefix) {
+                builder.sql(builder.assertSimple().alias(table)).sql(".");
+            }
+            builder.sql(columnName);
+        }
+    }
+
+    @Nullable
+    private ColumnMapping mappedIdParentColumn(
+            AbstractSqlBuilder<?> builder,
+            RealTableImpl table,
+            String columnName
+    ) {
+        if (table == null ||
+                table.parent == null ||
+                builder.getAstContext().getTableUsedState(table) == TableUsedState.USED ||
+                !table.isMappedIdColumnSource(builder.getAstContext())) {
+            return null;
+        }
+        TableImpl<?> tableOwner = (TableImpl<?>) table.owner;
+        ImmutableProp joinProp = tableOwner.joinProp;
+        MetadataStrategy strategy = builder.sqlClient().getMetadataStrategy();
+        ColumnDefinition idDefinition = tableOwner.immutableType.getIdProp().getStorage(strategy);
+        int index = idDefinition.index(columnName);
+        if (index == -1) {
+            return null;
+        }
+        ColumnDefinition parentDefinition = joinProp.getStorage(strategy);
+        return new ColumnMapping((RealTableImpl) table.parent, parentDefinition.name(index));
+    }
+
+    private static class ColumnMapping {
+
+        final RealTableImpl table;
+
+        final String columnName;
+
+        ColumnMapping(RealTableImpl table, String columnName) {
+            this.table = table;
+            this.columnName = columnName;
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/SimpleValueGetter.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/SimpleValueGetter.java
@@ -96,15 +96,15 @@ class SimpleValueGetter extends AbstractValueGetter {
                 RealTable realTable = tableImplementor.realTableForRender(builder);
                 String middleTableAlias = sqlBuilder.middleTableAlias(realTable);
                 if (middleTableAlias != null) {
-                    builder.sql(middleTableAlias);
+                    builder.sql(middleTableAlias).sql(".").sql(columnName);
                 } else {
                     TableImplementor<?> parent = tableImplementor.getParent();
-                    sqlBuilder.sqlAlias(parent.realTableForRender(builder));
+                    parent.realTableForRender(builder).renderColumn(builder, columnName, true, null);
                 }
             } else {
-                sqlBuilder.sqlAlias(tableImplementor.realTableForRender(builder));
+                tableImplementor.realTableForRender(builder).renderColumn(builder, columnName, false, null);
             }
-            builder.sql(".");
+            return;
         }
         builder.sql(columnName);
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/exception/SaveErrorCode.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/exception/SaveErrorCode.java
@@ -55,6 +55,9 @@ public enum SaveErrorCode {
 
     INCOMPLETE_PROPERTY,
 
+    @ErrorField(name = "prop", type = String.class)
+    INCONSISTENT_MAPPED_ID,
+
     @ErrorField(name = "props", type = String.class, list = true)
     @ErrorField(name = "values", type = Object.class, list = true)
     NOT_UNIQUE,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/exception/SaveException.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/exception/SaveException.java
@@ -38,6 +38,7 @@ import java.util.*;
                 SaveException.UnstructuredAssociation.class,
                 SaveException.TargetIsNotTransferable.class,
                 SaveException.IncompleteProperty.class,
+                SaveException.InconsistentMappedId.class,
                 SaveException.NotUnique.class,
                 SaveException.IllegalTargetId.class,
                 SaveException.UnloadedFrozenBackReference.class
@@ -404,6 +405,33 @@ public abstract class SaveException extends CodeBasedRuntimeException {
         @Override
         public SaveErrorCode getSaveErrorCode() {
             return SaveErrorCode.INCOMPLETE_PROPERTY;
+        }
+    }
+
+    @ClientException(code = "INCONSISTENT_MAPPED_ID")
+    public static class InconsistentMappedId extends SaveException {
+
+        private final ImmutableProp prop;
+
+        public InconsistentMappedId(@NotNull MutationPath path, String message, ImmutableProp prop) {
+            super(path, message);
+            this.prop = prop;
+        }
+
+        public InconsistentMappedId(@NotNull ExportedSavePath path, String message, ImmutableProp prop) {
+            super(path, message);
+            this.prop = prop;
+        }
+
+        @Override
+        public SaveErrorCode getSaveErrorCode() {
+            return SaveErrorCode.INCONSISTENT_MAPPED_ID;
+        }
+
+        @ApiIgnore
+        @NotNull
+        public ImmutableProp getProp() {
+            return prop;
         }
     }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/ShapeTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/ShapeTest.java
@@ -7,6 +7,7 @@ import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.model.embedded.OrderItemDraft;
 import org.babyfish.jimmer.sql.model.embedded.TransformDraft;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChildDraft;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDraft;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
@@ -155,6 +156,35 @@ public class ShapeTest extends AbstractQueryTest {
         );
         Assertions.assertEquals(
                 "[TENANT_ID, DOCUMENT_ID, NAME]",
+                shape.getColumnDefinitionGetters().stream()
+                        .map(it -> it.metadata().getColumnName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+
+    @Test
+    public void testMultiplePartialMappedIdReferencesAreNotWritableShape() {
+        ImmutableSpi child = (ImmutableSpi) DualParentChildDraft.$.produce(draft -> {
+            draft.applyId(id -> id.setLeftId(1L).setRightId(2L).setLocalId(3L));
+            draft.setName("Child");
+            draft.applyLeft(left -> {
+                left.setId(1L);
+                left.setName("Left");
+            });
+            draft.applyRight(right -> {
+                right.setId(2L);
+                right.setName("Right");
+            });
+        });
+        Shape shape = Shape.of((JSqlClientImplementor) getSqlClient(), child, ImmutableProp::isColumnDefinition);
+
+        Assertions.assertEquals(
+                "[id.leftId, id.rightId, id.localId, name]",
+                shape.toString()
+        );
+        Assertions.assertEquals(
+                "[LEFT_ID, RIGHT_ID, LOCAL_ID, NAME]",
                 shape.getColumnDefinitionGetters().stream()
                         .map(it -> it.metadata().getColumnName())
                         .collect(Collectors.toList())

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/ShapeTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/ShapeTest.java
@@ -7,9 +7,13 @@ import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.model.embedded.OrderItemDraft;
 import org.babyfish.jimmer.sql.model.embedded.TransformDraft;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDraft;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
 
 public class ShapeTest extends AbstractQueryTest {
 
@@ -106,5 +110,55 @@ public class ShapeTest extends AbstractQueryTest {
         Assertions.assertEquals("id.c", shape.getGetters().get(2).toString());
         Assertions.assertEquals("order.id.x", shape.getGetters().get(3).toString());
         Assertions.assertEquals("order.id.y", shape.getGetters().get(4).toString());
+    }
+
+    @Test
+    public void testMappedIdReferenceIsNotWritableShape() {
+        ImmutableSpi profile = (ImmutableSpi) MapsIdProfileDraft.$.produce(draft -> {
+            draft.applyId(id -> id.setA(1L).setB(2L));
+            draft.setNickname("Alex");
+            draft.applyPrincipal(principal -> {
+                principal.applyId(id -> id.setA(1L).setB(2L));
+                principal.setName("Root");
+            });
+        });
+        Shape shape = Shape.of((JSqlClientImplementor) getSqlClient(), profile, ImmutableProp::isColumnDefinition);
+
+        Assertions.assertEquals(
+                "[id.a, id.b, nickname]",
+                shape.toString()
+        );
+        Assertions.assertEquals(
+                "[A, B, NICKNAME]",
+                shape.getColumnDefinitionGetters().stream()
+                        .map(it -> it.metadata().getColumnName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+
+    @Test
+    public void testPartialMappedIdReferenceIsNotWritableShape() {
+        ImmutableSpi document = (ImmutableSpi) TenantDocumentDraft.$.produce(draft -> {
+            draft.applyId(id -> id.setTenantId(1L).setDocumentId(2L));
+            draft.setName("Doc");
+            draft.applyTenant(tenant -> {
+                tenant.setId(1L);
+                tenant.setName("Tenant");
+            });
+        });
+        Shape shape = Shape.of((JSqlClientImplementor) getSqlClient(), document, ImmutableProp::isColumnDefinition);
+
+        Assertions.assertEquals(
+                "[id.tenantId, id.documentId, name]",
+                shape.toString()
+        );
+        Assertions.assertEquals(
+                "[TENANT_ID, DOCUMENT_ID, NAME]",
+                shape.getColumnDefinitionGetters().stream()
+                        .map(it -> it.metadata().getColumnName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/DualParentChild.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/DualParentChild.java
@@ -1,0 +1,25 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.*;
+
+@Entity
+public interface DualParentChild {
+
+    @Id
+    @PropOverride(prop = "leftId", columnName = "LEFT_ID")
+    @PropOverride(prop = "rightId", columnName = "RIGHT_ID")
+    @PropOverride(prop = "localId", columnName = "LOCAL_ID")
+    DualParentChildId id();
+
+    String name();
+
+    @ManyToOne
+    @MapsId("leftId")
+    @JoinColumn(name = "LEFT_ID", referencedColumnName = "ID")
+    Tenant left();
+
+    @ManyToOne
+    @MapsId("rightId")
+    @JoinColumn(name = "RIGHT_ID", referencedColumnName = "ID")
+    Tenant right();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/DualParentChildId.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/DualParentChildId.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Embeddable;
+
+@Embeddable
+public interface DualParentChildId {
+
+    long leftId();
+
+    long rightId();
+
+    long localId();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdPrincipal.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdPrincipal.java
@@ -1,0 +1,14 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.*;
+
+@Entity
+public interface MapsIdPrincipal {
+
+    @Id
+    @PropOverride(prop = "a", columnName = "A")
+    @PropOverride(prop = "b", columnName = "B")
+    SharedId id();
+
+    String name();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdProfile.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdProfile.java
@@ -1,0 +1,20 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.*;
+
+@Entity
+public interface MapsIdProfile {
+
+    @Id
+    @PropOverride(prop = "a", columnName = "A")
+    @PropOverride(prop = "b", columnName = "B")
+    SharedId id();
+
+    String nickname();
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "A", referencedColumnName = "A")
+    @JoinColumn(name = "B", referencedColumnName = "B")
+    MapsIdPrincipal principal();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/SharedId.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/SharedId.java
@@ -1,0 +1,11 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Embeddable;
+
+@Embeddable
+public interface SharedId {
+
+    long a();
+
+    long b();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/Tenant.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/Tenant.java
@@ -2,6 +2,9 @@ package org.babyfish.jimmer.sql.model.mapsid;
 
 import org.babyfish.jimmer.sql.Entity;
 import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.OneToMany;
+
+import java.util.List;
 
 @Entity
 public interface Tenant {
@@ -10,4 +13,7 @@ public interface Tenant {
     long id();
 
     String name();
+
+    @OneToMany(mappedBy = "tenant")
+    List<TenantDocument> documents();
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/Tenant.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/Tenant.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+
+@Entity
+public interface Tenant {
+
+    @Id
+    long id();
+
+    String name();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocument.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocument.java
@@ -1,0 +1,19 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.*;
+
+@Entity
+public interface TenantDocument {
+
+    @Id
+    @PropOverride(prop = "tenantId", columnName = "TENANT_ID")
+    @PropOverride(prop = "documentId", columnName = "DOCUMENT_ID")
+    TenantDocumentId id();
+
+    String name();
+
+    @ManyToOne
+    @MapsId("tenantId")
+    @JoinColumn(name = "TENANT_ID", referencedColumnName = "ID")
+    Tenant tenant();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocumentDetail.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocumentDetail.java
@@ -1,0 +1,20 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.*;
+
+@Entity
+public interface TenantDocumentDetail {
+
+    @Id
+    @PropOverride(prop = "tenantId", columnName = "TENANT_ID")
+    @PropOverride(prop = "documentId", columnName = "DOCUMENT_ID")
+    TenantDocumentId id();
+
+    String description();
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "TENANT_ID", referencedColumnName = "TENANT_ID")
+    @JoinColumn(name = "DOCUMENT_ID", referencedColumnName = "DOCUMENT_ID")
+    TenantDocument document();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocumentId.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/TenantDocumentId.java
@@ -1,0 +1,11 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Embeddable;
+
+@Embeddable
+public interface TenantDocumentId {
+
+    long tenantId();
+
+    long documentId();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -13,6 +13,8 @@ import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDraft;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 public class MapsIdMutationTest extends AbstractMutationTest {
 
     @Test
@@ -88,6 +90,63 @@ public class MapsIdMutationTest extends AbstractMutationTest {
                                     "--->\"id\":{\"tenantId\":3,\"documentId\":10}," +
                                     "--->\"name\":\"Spec\"," +
                                     "--->\"tenant\":{\"id\":3,\"name\":\"Tenant\"}" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testBatchSaveFullMappedId() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveEntitiesCommand(
+                                Arrays.asList(
+                                        MapsIdProfileDraft.$.produce(profile -> {
+                                            profile.setNickname("Alex");
+                                            profile.applyPrincipal(principal -> {
+                                                principal.applyId(id -> id.setA(1L).setB(2L));
+                                                principal.setName("Root");
+                                            });
+                                        }),
+                                        MapsIdProfileDraft.$.produce(profile -> {
+                                            profile.setNickname("Bob");
+                                            profile.applyPrincipal(principal -> {
+                                                principal.applyId(id -> id.setA(3L).setB(4L));
+                                                principal.setName("Branch");
+                                            });
+                                        })
+                                )
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_PRINCIPAL(A, B, NAME) values(?, ?, ?)");
+                        it.batchVariables(0, 1L, 2L, "Root");
+                        it.batchVariables(1, 3L, 4L, "Branch");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_PROFILE(A, B, NICKNAME) values(?, ?, ?)");
+                        it.batchVariables(0, 1L, 2L, "Alex");
+                        it.batchVariables(1, 3L, 4L, "Bob");
+                    });
+                    ctx.totalRowCount(4);
+                    ctx.rowCount(AffectedTable.of(MapsIdPrincipal.class), 2);
+                    ctx.rowCount(AffectedTable.of(MapsIdProfile.class), 2);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":{\"a\":1,\"b\":2}," +
+                                    "--->\"nickname\":\"Alex\"," +
+                                    "--->\"principal\":{\"id\":{\"a\":1,\"b\":2},\"name\":\"Root\"}" +
+                                    "}"
+                    ));
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":{\"a\":3,\"b\":4}," +
+                                    "--->\"nickname\":\"Bob\"," +
+                                    "--->\"principal\":{\"id\":{\"a\":3,\"b\":4},\"name\":\"Branch\"}" +
                                     "}"
                     ));
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -100,6 +100,52 @@ public class MapsIdMutationTest extends AbstractMutationTest {
     }
 
     @Test
+    public void testSavePartialMappedIdFromInverseSide() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                TenantDraft.$.produce(tenant -> {
+                                    tenant.setId(4L);
+                                    tenant.setName("Tenant");
+                                    tenant.addIntoDocuments(document -> {
+                                        document.applyId(id -> id.setDocumentId(11L));
+                                        document.setName("Spec");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT(ID, NAME) values(?, ?)");
+                        it.variables(4L, "Tenant");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT_DOCUMENT(TENANT_ID, DOCUMENT_ID, NAME) values(?, ?, ?)");
+                        it.variables(4L, 11L, "Spec");
+                    });
+                    ctx.totalRowCount(2);
+                    ctx.rowCount(AffectedTable.of(Tenant.class), 1);
+                    ctx.rowCount(AffectedTable.of(TenantDocument.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":4," +
+                                    "--->\"name\":\"Tenant\"," +
+                                    "--->\"documents\":[" +
+                                    "--->--->{" +
+                                    "--->--->--->\"id\":{\"tenantId\":4,\"documentId\":11}," +
+                                    "--->--->--->\"name\":\"Spec\"," +
+                                    "--->--->--->\"tenant\":{\"id\":4}" +
+                                    "--->--->}" +
+                                    "--->]" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
     public void testBatchSaveFullMappedId() {
         executeAndExpectResult(
                 getSqlClient()

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -1,0 +1,123 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.ast.mutation.AffectedTable;
+import org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode;
+import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.exception.SaveException;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdPrincipal;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
+import org.babyfish.jimmer.sql.model.mapsid.Tenant;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDraft;
+import org.junit.jupiter.api.Test;
+
+public class MapsIdMutationTest extends AbstractMutationTest {
+
+    @Test
+    public void testSaveFullMappedId() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                MapsIdProfileDraft.$.produce(profile -> {
+                                    profile.setNickname("Alex");
+                                    profile.applyPrincipal(principal -> {
+                                        principal.applyId(id -> id.setA(1L).setB(2L));
+                                        principal.setName("Root");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_PRINCIPAL(A, B, NAME) values(?, ?, ?)");
+                        it.variables(1L, 2L, "Root");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_PROFILE(A, B, NICKNAME) values(?, ?, ?)");
+                        it.variables(1L, 2L, "Alex");
+                    });
+                    ctx.totalRowCount(2);
+                    ctx.rowCount(AffectedTable.of(MapsIdPrincipal.class), 1);
+                    ctx.rowCount(AffectedTable.of(MapsIdProfile.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":{\"a\":1,\"b\":2}," +
+                                    "--->\"nickname\":\"Alex\"," +
+                                    "--->\"principal\":{\"id\":{\"a\":1,\"b\":2},\"name\":\"Root\"}" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testSavePartialMappedId() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                TenantDocumentDraft.$.produce(document -> {
+                                    document.applyId(id -> id.setDocumentId(10L));
+                                    document.setName("Spec");
+                                    document.applyTenant(tenant -> {
+                                        tenant.setId(3L);
+                                        tenant.setName("Tenant");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT(ID, NAME) values(?, ?)");
+                        it.variables(3L, "Tenant");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT_DOCUMENT(TENANT_ID, DOCUMENT_ID, NAME) values(?, ?, ?)");
+                        it.variables(3L, 10L, "Spec");
+                    });
+                    ctx.totalRowCount(2);
+                    ctx.rowCount(AffectedTable.of(Tenant.class), 1);
+                    ctx.rowCount(AffectedTable.of(TenantDocument.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":{\"tenantId\":3,\"documentId\":10}," +
+                                    "--->\"name\":\"Spec\"," +
+                                    "--->\"tenant\":{\"id\":3,\"name\":\"Tenant\"}" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testConflictingMappedId() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                MapsIdProfileDraft.$.produce(profile -> {
+                                    profile.applyId(id -> id.setA(9L).setB(9L));
+                                    profile.setNickname("Alex");
+                                    profile.applyPrincipal(principal -> {
+                                        principal.applyId(id -> id.setA(1L).setB(2L));
+                                        principal.setName("Root");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_PRINCIPAL(A, B, NAME) values(?, ?, ?)");
+                        it.variables(1L, 2L, "Root");
+                    });
+                    ctx.throwable(it -> it.type(SaveException.InconsistentMappedId.class));
+                }
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -11,6 +11,7 @@ import org.babyfish.jimmer.sql.model.mapsid.MapsIdPrincipal;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
 import org.babyfish.jimmer.sql.model.mapsid.Tenant;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDraft;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDraft;
 import org.junit.jupiter.api.Test;
@@ -225,6 +226,59 @@ public class MapsIdMutationTest extends AbstractMutationTest {
                                     "--->\"name\":\"Child\"," +
                                     "--->\"left\":{\"id\":10,\"name\":\"Left\"}," +
                                     "--->\"right\":{\"id\":20,\"name\":\"Right\"}" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testMappedIdBackReferenceDoesNotRequireTransferCheckSelect() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                TenantDraft.$.produce(tenant -> {
+                                    tenant.setId(10L);
+                                    tenant.setName("Tenant");
+                                    tenant.addIntoDocuments(document -> {
+                                        document.applyId(id -> id.setDocumentId(30L));
+                                        document.setName("Spec");
+                                    });
+                                })
+                        ),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("merge into TENANT(ID, NAME) key(ID) values(?, ?)");
+                        it.variables(10L, "Tenant");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("merge into TENANT_DOCUMENT(TENANT_ID, DOCUMENT_ID, NAME) key(TENANT_ID, DOCUMENT_ID) values(?, ?, ?)");
+                        it.variables(10L, 30L, "Spec");
+                    });
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID " +
+                                        "from TENANT_DOCUMENT tb_1_ " +
+                                        "where tb_1_.TENANT_ID = ? and " +
+                                        "(tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID) <> (?, ?) limit ?"
+                        );
+                        it.variables(10L, 10L, 30L, 1);
+                    });
+                    ctx.totalRowCount(2);
+                    ctx.rowCount(AffectedTable.of(Tenant.class), 1);
+                    ctx.rowCount(AffectedTable.of(TenantDocument.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":10," +
+                                    "--->\"name\":\"Tenant\"," +
+                                    "--->\"documents\":[" +
+                                    "--->--->{" +
+                                    "--->--->--->\"id\":{\"tenantId\":10,\"documentId\":30}," +
+                                    "--->--->--->\"name\":\"Spec\"," +
+                                    "--->--->--->\"tenant\":{\"id\":10}" +
+                                    "--->--->}" +
+                                    "--->]" +
                                     "}"
                     ));
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -5,6 +5,8 @@ import org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode;
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.exception.SaveException;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChild;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChildDraft;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdPrincipal;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
@@ -176,6 +178,55 @@ public class MapsIdMutationTest extends AbstractMutationTest {
                         it.variables(1L, 2L, "Root");
                     });
                     ctx.throwable(it -> it.type(SaveException.InconsistentMappedId.class));
+                }
+        );
+    }
+
+    @Test
+    public void testSaveMultiplePartialMappedIds() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                DualParentChildDraft.$.produce(child -> {
+                                    child.applyId(id -> id.setLocalId(30L));
+                                    child.setName("Child");
+                                    child.applyLeft(left -> {
+                                        left.setId(10L);
+                                        left.setName("Left");
+                                    });
+                                    child.applyRight(right -> {
+                                        right.setId(20L);
+                                        right.setName("Right");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT(ID, NAME) values(?, ?)");
+                        it.variables(10L, "Left");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into TENANT(ID, NAME) values(?, ?)");
+                        it.variables(20L, "Right");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into DUAL_PARENT_CHILD(LEFT_ID, RIGHT_ID, LOCAL_ID, NAME) values(?, ?, ?, ?)");
+                        it.variables(10L, 20L, 30L, "Child");
+                    });
+                    ctx.totalRowCount(3);
+                    ctx.rowCount(AffectedTable.of(Tenant.class), 2);
+                    ctx.rowCount(AffectedTable.of(DualParentChild.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"id\":{\"leftId\":10,\"rightId\":20,\"localId\":30}," +
+                                    "--->\"name\":\"Child\"," +
+                                    "--->\"left\":{\"id\":10,\"name\":\"Left\"}," +
+                                    "--->\"right\":{\"id\":20,\"name\":\"Right\"}" +
+                                    "}"
+                    ));
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
@@ -65,4 +65,26 @@ public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
                 }
         );
     }
+
+    @Test
+    public void testMappedIdAssociationIdUsagesDoNotJoinTargetTable() {
+        executeAndExpect(
+                getLambdaClient().createQuery(TenantDocumentTable.class, (q, document) -> {
+                    q.where(document.asTableEx().tenant().id().eq(1L));
+                    q.groupBy(document.asTableEx().tenant().id());
+                    q.orderBy(document.asTableEx().tenant().id().asc());
+                    return q.select(document.asTableEx().tenant().id());
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.TENANT_ID " +
+                                    "from TENANT_DOCUMENT tb_1_ " +
+                                    "where tb_1_.TENANT_ID = ? " +
+                                    "group by tb_1_.TENANT_ID " +
+                                    "order by tb_1_.TENANT_ID asc"
+                    );
+                    ctx.variables(1L);
+                }
+        );
+    }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
@@ -2,6 +2,8 @@ package org.babyfish.jimmer.sql.query;
 
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChildFetcher;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChildTable;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentFetcher;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentTable;
 import org.babyfish.jimmer.sql.model.mapsid.TenantFetcher;
@@ -106,6 +108,52 @@ public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
                 ctx -> ctx.sql(
                         "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID, tb_1_.NAME, tb_1_.TENANT_ID " +
                                 "from TENANT_DOCUMENT tb_1_"
+                )
+        );
+    }
+
+    @Test
+    public void testMultiplePartialMappedIdAssociationIdUsagesDoNotJoinTargetTables() {
+        executeAndExpect(
+                getLambdaClient().createQuery(DualParentChildTable.class, (q, child) -> {
+                    q.where(child.asTableEx().left().id().eq(10L));
+                    q.where(child.asTableEx().right().id().eq(20L));
+                    q.orderBy(child.asTableEx().left().id().asc());
+                    return q.select(
+                            child.asTableEx().left().id(),
+                            child.asTableEx().right().id(),
+                            child.id().localId()
+                    );
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.LEFT_ID, tb_1_.RIGHT_ID, tb_1_.LOCAL_ID " +
+                                    "from DUAL_PARENT_CHILD tb_1_ " +
+                                    "where tb_1_.LEFT_ID = ? and tb_1_.RIGHT_ID = ? " +
+                                    "order by tb_1_.LEFT_ID asc"
+                    );
+                    ctx.variables(10L, 20L);
+                }
+        );
+    }
+
+    @Test
+    public void testMultiplePartialMappedIdAssociationIdOnlyJoinFetcherDoesNotJoinTargetTables() {
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(DualParentChildTable.$)
+                        .select(
+                                DualParentChildTable.$.fetch(
+                                        DualParentChildFetcher.$
+                                                .name()
+                                                .left(ReferenceFetchType.JOIN_ALWAYS, TenantFetcher.$)
+                                                .right(ReferenceFetchType.JOIN_ALWAYS, TenantFetcher.$)
+                                )
+                        ),
+                ctx -> ctx.sql(
+                        "select tb_1_.LEFT_ID, tb_1_.RIGHT_ID, tb_1_.LOCAL_ID, " +
+                                "tb_1_.NAME, tb_1_.LEFT_ID, tb_1_.RIGHT_ID " +
+                                "from DUAL_PARENT_CHILD tb_1_"
                 )
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
@@ -1,0 +1,68 @@
+package org.babyfish.jimmer.sql.query;
+
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentTable;
+import org.junit.jupiter.api.Test;
+
+public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
+
+    @Test
+    public void testMappedIdIntermediateJoin() {
+        executeAndExpect(
+                getLambdaClient().createQuery(TenantDocumentTable.class, (q, document) -> {
+                    q.where(
+                            document
+                                    .asTableEx()
+                                    .tenant()
+                                    .documents()
+                                    .name()
+                                    .eq("Spec")
+                    );
+                    return q.select(document.id());
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID " +
+                                    "from TENANT_DOCUMENT tb_1_ " +
+                                    "inner join TENANT_DOCUMENT tb_2_ on tb_1_.TENANT_ID = tb_2_.TENANT_ID " +
+                                    "where tb_2_.NAME = ?"
+                    );
+                    ctx.variables("Spec");
+                }
+        );
+    }
+
+    @Test
+    public void testMappedIdIntermediateJoinCannotBeOptimizedWhenBridgeFieldIsUsed() {
+        executeAndExpect(
+                getLambdaClient().createQuery(TenantDocumentTable.class, (q, document) -> {
+                    q.where(
+                            document
+                                    .asTableEx()
+                                    .tenant()
+                                    .name()
+                                    .eq("Tenant")
+                    );
+                    q.where(
+                            document
+                                    .asTableEx()
+                                    .tenant()
+                                    .documents()
+                                    .name()
+                                    .eq("Spec")
+                    );
+                    return q.select(document.id());
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID " +
+                                    "from TENANT_DOCUMENT tb_1_ " +
+                                    "inner join TENANT tb_2_ on tb_1_.TENANT_ID = tb_2_.ID " +
+                                    "inner join TENANT_DOCUMENT tb_3_ on tb_2_.ID = tb_3_.TENANT_ID " +
+                                    "where tb_2_.NAME = ? and tb_3_.NAME = ?"
+                    );
+                    ctx.variables("Tenant", "Spec");
+                }
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
@@ -1,7 +1,10 @@
 package org.babyfish.jimmer.sql.query;
 
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentFetcher;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentTable;
+import org.babyfish.jimmer.sql.model.mapsid.TenantFetcher;
 import org.junit.jupiter.api.Test;
 
 public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
@@ -85,6 +88,25 @@ public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
                     );
                     ctx.variables(1L);
                 }
+        );
+    }
+
+    @Test
+    public void testMappedIdAssociationIdOnlyJoinFetcherDoesNotJoinTargetTable() {
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(TenantDocumentTable.$)
+                        .select(
+                                TenantDocumentTable.$.fetch(
+                                        TenantDocumentFetcher.$
+                                                .name()
+                                                .tenant(ReferenceFetchType.JOIN_ALWAYS, TenantFetcher.$)
+                                )
+                        ),
+                ctx -> ctx.sql(
+                        "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID, tb_1_.NAME, tb_1_.TENANT_ID " +
+                                "from TENANT_DOCUMENT tb_1_"
+                )
         );
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/MapsIdJoinOptimizationTest.java
@@ -4,6 +4,8 @@ import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
 import org.babyfish.jimmer.sql.model.mapsid.DualParentChildFetcher;
 import org.babyfish.jimmer.sql.model.mapsid.DualParentChildTable;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDetailFetcher;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentDetailTable;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentFetcher;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocumentTable;
 import org.babyfish.jimmer.sql.model.mapsid.TenantFetcher;
@@ -154,6 +156,55 @@ public class MapsIdJoinOptimizationTest extends AbstractQueryTest {
                         "select tb_1_.LEFT_ID, tb_1_.RIGHT_ID, tb_1_.LOCAL_ID, " +
                                 "tb_1_.NAME, tb_1_.LEFT_ID, tb_1_.RIGHT_ID " +
                                 "from DUAL_PARENT_CHILD tb_1_"
+                )
+        );
+    }
+
+    @Test
+    public void testMappedIdAssociationIdChainDoesNotJoinIntermediateTargetTables() {
+        executeAndExpect(
+                getLambdaClient().createQuery(TenantDocumentDetailTable.class, (q, detail) -> {
+                    q.where(detail.asTableEx().document().tenant().id().eq(10L));
+                    q.orderBy(detail.asTableEx().document().tenant().id().asc());
+                    return q.select(
+                            detail.asTableEx().document().id(),
+                            detail.asTableEx().document().tenant().id()
+                    );
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID, tb_1_.TENANT_ID " +
+                                    "from TENANT_DOCUMENT_DETAIL tb_1_ " +
+                                    "where tb_1_.TENANT_ID = ? " +
+                                    "order by tb_1_.TENANT_ID asc"
+                    );
+                    ctx.variables(10L);
+                }
+        );
+    }
+
+    @Test
+    public void testMappedIdAssociationIdOnlyJoinFetcherChainDoesNotJoinIntermediateTargetTables() {
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(TenantDocumentDetailTable.$)
+                        .select(
+                                TenantDocumentDetailTable.$.fetch(
+                                        TenantDocumentDetailFetcher.$
+                                                .description()
+                                                .document(
+                                                        ReferenceFetchType.JOIN_ALWAYS,
+                                                        TenantDocumentFetcher.$.tenant(
+                                                                ReferenceFetchType.JOIN_ALWAYS,
+                                                                TenantFetcher.$
+                                                        )
+                                                )
+                                )
+                        ),
+                ctx -> ctx.sql(
+                        "select tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID, tb_1_.DESCRIPTION, " +
+                                "tb_1_.TENANT_ID, tb_1_.DOCUMENT_ID, tb_1_.TENANT_ID " +
+                                "from TENANT_DOCUMENT_DETAIL tb_1_"
                 )
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
@@ -4,13 +4,14 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.MappedId;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.model.mapsid.DualParentChild;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -52,6 +53,54 @@ public class MapsIdMetadataTest extends AbstractQueryTest {
         assertEquals(
                 "[TENANT_ID->ID]",
                 mappedId.getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
+                        .stream()
+                        .map(it -> it.getSourceName() + "->" + it.getTargetName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+
+    @Test
+    public void testMultiplePartialEmbeddedIdMappings() {
+        ImmutableType type = ImmutableType.get(DualParentChild.class);
+        List<MappedId> mappedIds = type.getMappedIds();
+
+        assertEquals(2, mappedIds.size());
+        Map<String, MappedId> mappedIdMap = mappedIds
+                .stream()
+                .collect(Collectors.toMap(it -> it.getProp().getName(), it -> it));
+        assertEquals("[left, right]", mappedIds.stream().map(it -> it.getProp().getName()).collect(Collectors.toList()).toString());
+        assertEquals(
+                "[leftId]",
+                mappedIdMap.get("left")
+                        .getIdPath()
+                        .stream()
+                        .map(ImmutableProp::getName)
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+        assertEquals(
+                "[rightId]",
+                mappedIdMap.get("right")
+                        .getIdPath()
+                        .stream()
+                        .map(ImmutableProp::getName)
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+        assertEquals(
+                "[LEFT_ID->ID]",
+                mappedIdMap.get("left")
+                        .getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
+                        .stream()
+                        .map(it -> it.getSourceName() + "->" + it.getTargetName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+        assertEquals(
+                "[RIGHT_ID->ID]",
+                mappedIdMap.get("right")
+                        .getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
                         .stream()
                         .map(it -> it.getSourceName() + "->" + it.getTargetName())
                         .collect(Collectors.toList())

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
@@ -1,0 +1,61 @@
+package org.babyfish.jimmer.sql.util;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.MappedId;
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
+import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MapsIdMetadataTest extends AbstractQueryTest {
+
+    @Test
+    public void testWholeEmbeddedIdMapping() {
+        ImmutableType type = ImmutableType.get(MapsIdProfile.class);
+        List<MappedId> mappedIds = type.getMappedIds();
+
+        assertEquals(1, mappedIds.size());
+        MappedId mappedId = mappedIds.get(0);
+        assertEquals("principal", mappedId.getProp().getName());
+        assertTrue(mappedId.isFull());
+        assertEquals(
+                "[A->A, B->B]",
+                mappedId.getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
+                        .stream()
+                        .map(it -> it.getSourceName() + "->" + it.getTargetName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+
+    @Test
+    public void testPartialEmbeddedIdMapping() {
+        ImmutableType type = ImmutableType.get(TenantDocument.class);
+        List<MappedId> mappedIds = type.getMappedIds();
+
+        assertEquals(1, mappedIds.size());
+        MappedId mappedId = mappedIds.get(0);
+        assertEquals("tenant", mappedId.getProp().getName());
+        assertFalse(mappedId.isFull());
+        assertEquals(
+                "[tenantId]",
+                mappedId.getIdPath().stream().map(ImmutableProp::getName).collect(Collectors.toList()).toString()
+        );
+        assertEquals(
+                "[TENANT_ID->ID]",
+                mappedId.getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
+                        .stream()
+                        .map(it -> it.getSourceName() + "->" + it.getTargetName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -8,6 +8,7 @@ drop table issue1125_mp_role_perm if exists;
 drop table issue1125_sys_role if exists;
 drop table issue1125_sys_perm if exists;
 drop table dual_parent_child if exists;
+drop table tenant_document_detail if exists;
 drop table tenant_document if exists;
 drop table tenant if exists;
 drop table maps_id_profile if exists;
@@ -1605,6 +1606,16 @@ create table tenant_document(
     constraint fk_tenant_document__tenant
         foreign key(tenant_id)
             references tenant(id)
+);
+
+create table tenant_document_detail(
+    tenant_id bigint not null,
+    document_id bigint not null,
+    description varchar(50) not null,
+    constraint pk_tenant_document_detail primary key(tenant_id, document_id),
+    constraint fk_tenant_document_detail__document
+        foreign key(tenant_id, document_id)
+            references tenant_document(tenant_id, document_id)
 );
 
 create table dual_parent_child(

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -7,6 +7,7 @@ create schema if not exists D;
 drop table issue1125_mp_role_perm if exists;
 drop table issue1125_sys_role if exists;
 drop table issue1125_sys_perm if exists;
+drop table dual_parent_child if exists;
 drop table tenant_document if exists;
 drop table tenant if exists;
 drop table maps_id_profile if exists;
@@ -1603,5 +1604,19 @@ create table tenant_document(
     constraint pk_tenant_document primary key(tenant_id, document_id),
     constraint fk_tenant_document__tenant
         foreign key(tenant_id)
+            references tenant(id)
+);
+
+create table dual_parent_child(
+    left_id bigint not null,
+    right_id bigint not null,
+    local_id bigint not null,
+    name varchar(50) not null,
+    constraint pk_dual_parent_child primary key(left_id, right_id, local_id),
+    constraint fk_dual_parent_child__left
+        foreign key(left_id)
+            references tenant(id),
+    constraint fk_dual_parent_child__right
+        foreign key(right_id)
             references tenant(id)
 );

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -7,6 +7,10 @@ create schema if not exists D;
 drop table issue1125_mp_role_perm if exists;
 drop table issue1125_sys_role if exists;
 drop table issue1125_sys_perm if exists;
+drop table tenant_document if exists;
+drop table tenant if exists;
+drop table maps_id_profile if exists;
+drop table maps_id_principal if exists;
 drop table time_row if exists;
 drop table issue888_item if exists;
 drop table issue888_structure if exists;
@@ -1567,4 +1571,37 @@ create table issue1125_sys_role (
   id bigint generated always as identity(start with 1 increment by 1) not null,
   deleted_at timestamp(0),
   constraint sys_role_pkey primary key (id)
+);
+
+create table maps_id_principal(
+    a bigint not null,
+    b bigint not null,
+    name varchar(50) not null,
+    constraint pk_maps_id_principal primary key(a, b)
+);
+
+create table maps_id_profile(
+    a bigint not null,
+    b bigint not null,
+    nickname varchar(50) not null,
+    constraint pk_maps_id_profile primary key(a, b),
+    constraint fk_maps_id_profile__principal
+        foreign key(a, b)
+            references maps_id_principal(a, b)
+);
+
+create table tenant(
+    id bigint not null,
+    name varchar(50) not null,
+    constraint pk_tenant primary key(id)
+);
+
+create table tenant_document(
+    tenant_id bigint not null,
+    document_id bigint not null,
+    name varchar(50) not null,
+    constraint pk_tenant_document primary key(tenant_id, document_id),
+    constraint fk_tenant_document__tenant
+        foreign key(tenant_id)
+            references tenant(id)
 );


### PR DESCRIPTION
# Usage
The annotation belongs to owning `@OneToOne` and `@ManyToOne` references.
Empty `@MapsId` maps the whole declaring id; non-empty values map a path inside an embedded declaring id.
Mutation `Shape` excludes mapped-id associations from writable column sources so shared PK/FK columns are represented only through the id path.

# Optimizations
- Query analysis can treat an id-only mapped-id association table as an optimizable bridge and join directly from its parent to the inverse child table. The bridge must still be rendered normally as soon as one of its fields or filters is required.
- Id-only fetchers over mapped-id associations reuse owner id columns as well. A join fetch request may still avoid a physical target-table join when the target object can be materialized from mapped-id columns alone.
- Mapped-id column reuse is recursive across chains. Query predicates, ordering, selections, value getters, and fetcher field rendering all go through the same real-table column renderer so an absent id-only intermediate table cannot leak its alias into SQL.