### PR TITLE
 This PR fixes several logical-delete related mutation/query issues.

### DIFF
--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/JoinFetchTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/JoinFetchTest.kt
@@ -272,7 +272,8 @@ class JoinFetchTest : AbstractQueryTest() {
             sql(
                 """select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME 
                     |from ADMINISTRATOR tb_1_ 
-                    |left join ADMINISTRATOR_METADATA tb_2_ on tb_1_.ID = tb_2_.ADMINISTRATOR_ID 
+                    |left join ADMINISTRATOR_METADATA tb_2_ 
+                    |on tb_1_.ID = tb_2_.ADMINISTRATOR_ID and tb_2_.DELETED <> ? 
                     |where tb_1_.DELETED <> ?""".trimMargin()
             )
             rows(
@@ -302,6 +303,7 @@ class JoinFetchTest : AbstractQueryTest() {
                 """select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME 
                     |from EMPLOYEE tb_1_ 
                     |left join DEPARTMENT tb_2_ on tb_1_.DEPARTMENT_ID = tb_2_.ID 
+                    |and tb_2_.DELETED_TIME is null 
                     |where tb_1_.DELETED_UUID is null""".trimMargin()
             )
             rows(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
@@ -20,6 +20,9 @@ import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 import org.babyfish.jimmer.sql.filter.Filter;
 import org.babyfish.jimmer.sql.filter.impl.FilterArgsImpl;
 import org.babyfish.jimmer.sql.filter.impl.FilterManager;
+import org.babyfish.jimmer.sql.fetcher.Fetcher;
+import org.babyfish.jimmer.sql.fetcher.Field;
+import org.babyfish.jimmer.sql.fetcher.impl.JoinFetchFieldVisitor;
 import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.jetbrains.annotations.NotNull;
@@ -486,6 +489,17 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
             }
         }
 
+        @Override
+        public void visitTableFetcher(RealTable table, Fetcher<?> fetcher) {
+            TableLikeImplementor<?> implementor = table.getTableLikeImplementor();
+            if (implementor instanceof TableImplementor<?>) {
+                new ApplyJoinFetcherFilterVisitor(
+                        getAstContext().getSqlClient(),
+                        (TableImplementor<?>) implementor
+                ).visit(fetcher);
+            }
+        }
+
         public boolean isApplied(AbstractMutableStatementImpl statement, Selection<?> selection) {
             return appliedSet.has(statement, selection);
         }
@@ -508,6 +522,36 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
 
         public void apply(AbstractMutableStatementImpl statement, Order order) {
             appliedSet.add(statement, order);
+        }
+
+        private class ApplyJoinFetcherFilterVisitor extends JoinFetchFieldVisitor {
+
+            private TableImplementor<?> tableImplementor;
+
+            ApplyJoinFetcherFilterVisitor(JSqlClientImplementor sqlClient, TableImplementor<?> tableImplementor) {
+                super(sqlClient);
+                this.tableImplementor = tableImplementor;
+            }
+
+            @Override
+            protected Object enter(Field field) {
+                TableImplementor<?> oldTableImplementor = tableImplementor;
+                TableImplementor<?> newTableImplementor =
+                        oldTableImplementor.joinFetchImplementor(
+                                field.getProp(),
+                                oldTableImplementor.getBaseTableOwner()
+                        );
+                newTableImplementor
+                        .getStatement()
+                        .applyGlobalFilerImpl(ApplyFilterVisitor.this, newTableImplementor);
+                tableImplementor = newTableImplementor;
+                return oldTableImplementor;
+            }
+
+            @Override
+            protected void leave(Field field, Object enterValue) {
+                tableImplementor = (TableImplementor<?>) enterValue;
+            }
         }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -1054,6 +1054,10 @@ class Operator {
                                 .variable(getter);
                     }
                 }
+                LogicalDeletedInfo logicalDeletedInfo = shape.getType().getLogicalDeletedInfo();
+                if (logicalDeletedInfo != null) {
+                    builder.separator().logicalDeleteFilter(logicalDeletedInfo, null);
+                }
             } else {
                 for (PropertyGetter getter : shape.getIdGetters()) {
                     builder.separator()

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -172,7 +172,8 @@ public class H2Dialect extends DefaultDialect {
 
         ctx.enter(AbstractSqlBuilder.ScopeType.AND);
         for (ValueGetter getter : ctx.getConflictGetters()) {
-            ctx.separator().sql("tb_1_.").sql(getter).sql(" = tb_2_.").sql(getter);
+            ctx.separator().sql("tb_1_.").sql(getter).sql(" = ");
+            appendConflictValueFromSource(ctx, getter);
         }
         ctx.leave();
         if (!ctx.isUpdateIgnored() && (ctx.hasGeneratedId()) || ctx.hasUpdatedColumns()) {
@@ -204,6 +205,20 @@ public class H2Dialect extends DefaultDialect {
                 .appendInsertedColumns("tb_2_.")
                 .leave()
                 .leave();
+    }
+
+    private void appendConflictValueFromSource(UpsertContext ctx, ValueGetter getter) {
+        ctx.sql("tb_2_.").sql(getter);
+        if (Classes.boxTypeOf(getter.metadata().getSqlType()) != Boolean.class) {
+            return;
+        }
+        String sqlTypeName = getter.metadata().getSqlTypeName();
+        if (sqlTypeName == null) {
+            sqlTypeName = sqlType(Classes.primitiveTypeOf(getter.metadata().getSqlType()));
+        }
+        if (sqlTypeName != null) {
+            ctx.sql("::").sql(sqlTypeName);
+        }
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -239,6 +239,11 @@ public class DefaultExecutor implements Executor {
             Reader<?> idReader = sqlClient.getReader(generatedIdProp);
             try (ResultSet rs = statement.getGeneratedKeys()) {
                 while (rs.next()) {
+                    if (index == batchCount) {
+                        throw new ExecutionException(
+                                "Too many generated ids for batch SQL statement: " + sql
+                        );
+                    }
                     Object id = idReader.read(rs, new Reader.Context(null, sqlClient));
                     ids[index++] = id;
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
@@ -402,7 +402,9 @@ public class JoinFetchTest extends AbstractQueryTest {
                             "select tb_1_.ID, tb_1_.NAME, " +
                                     "tb_2_.ID, tb_2_.NAME " +
                                     "from ADMINISTRATOR tb_1_ " +
-                                    "left join ADMINISTRATOR_METADATA tb_2_ on tb_1_.ID = tb_2_.ADMINISTRATOR_ID " +
+                                    "left join ADMINISTRATOR_METADATA tb_2_ " +
+                                    "--->on tb_1_.ID = tb_2_.ADMINISTRATOR_ID " +
+                                    "--->and tb_2_.DELETED <> ? " +
                                     "where tb_1_.DELETED <> ?"
                     );
                     ctx.rows(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/GetIdTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/GetIdTest.java
@@ -145,11 +145,11 @@ public class GetIdTest extends AbstractMutationTest {
                         .setMode(SaveMode.UPDATE_ONLY),
                 ctx -> {
                     ctx.statement(it -> {
-                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ?");
-                        it.batchVariables(0, 1L, "Jacob");
-                        it.batchVariables(1, 1L, "Jessica");
-                        it.batchVariables(2, 1L, "Raines");
-                        it.batchVariables(3, 1L, "Sam");
+                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, 1L, "Jacob", 0L);
+                        it.batchVariables(1, 1L, "Jessica", 0L);
+                        it.batchVariables(2, 1L, "Raines", 0L);
+                        it.batchVariables(3, 1L, "Sam", 0L);
                     });
                     ctx.entity(it -> {
                         it.modified(
@@ -169,6 +169,64 @@ public class GetIdTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.modified(
                                 "{\"id\":\"1\",\"name\":\"Sam\",\"department\":{\"id\":\"1\"}}"
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateByKeyDoesNotAffectLogicalDeletedRowsFromH2() {
+        jdbc(con -> {
+            try (Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("delete from employee");
+                stmt.executeUpdate("delete from department");
+                stmt.executeUpdate("insert into department(id, name) values(1, 'Market')");
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(1, 'Sam', 'M', 1, 0)"
+                );
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(2, 'Jessica', 'F', 1, 0)"
+                );
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(3, 'Sam', 'M', 1, 9)"
+                );
+            }
+        });
+
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new H2Dialect()));
+        Employee employee1 = EmployeeDraft.$.produce(draft -> {
+            draft.setName("Sam");
+            draft.setGender(Gender.FEMALE);
+        });
+        Employee employee2 = EmployeeDraft.$.produce(draft -> {
+            draft.setName("Jessica");
+            draft.setGender(Gender.MALE);
+        });
+        executeAndExpectResult(
+                sqlClient
+                        .getEntities()
+                        .saveEntitiesCommand(
+                                Arrays.asList(employee1, employee2)
+                        )
+                        .setMode(SaveMode.UPDATE_ONLY),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("update EMPLOYEE set GENDER = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, "F", "Sam", 0L);
+                        it.batchVariables(1, "M", "Jessica", 0L);
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{\"id\":\"1\",\"name\":\"Sam\",\"gender\":\"FEMALE\"}"
+                        );
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{\"id\":\"2\",\"name\":\"Jessica\",\"gender\":\"MALE\"}"
                         );
                     });
                 }
@@ -787,9 +845,9 @@ public class GetIdTest extends AbstractMutationTest {
                         it.queryReason(QueryReason.GET_ID_FOR_KEY_BASE_UPDATE);
                     });
                     ctx.statement(it -> {
-                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ?");
-                        it.batchVariables(0, 1L, "Jessica");
-                        it.batchVariables(1, 1L, "Sam");
+                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, 1L, "Jessica", 0L);
+                        it.batchVariables(1, 1L, "Sam", 0L);
                     });
                     ctx.entity(it -> {
                         it.modified(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
@@ -17,12 +17,15 @@ import org.babyfish.jimmer.sql.model.Gender;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.hr.Department;
 import org.babyfish.jimmer.sql.model.hr.DepartmentDraft;
+import org.babyfish.jimmer.sql.model.inheritance.Administrator;
+import org.babyfish.jimmer.sql.model.inheritance.AdministratorDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -972,7 +975,7 @@ public class IdentityTest extends AbstractMutationTest {
                         it.batchVariables(1, "Sales", 0L);
                     });
                     ctx.entity(it -> it.modified("{\"id\":\"1\",\"name\":\"Market\"}"));
-                    ctx.entity(it -> it.modified("{\"id\":\"101\",\"name\":\"Sales\"}"));
+                    ctx.entity(it -> it.modified("{\"id\":\"100\",\"name\":\"Sales\"}"));
                 }
         );
     }
@@ -1077,6 +1080,49 @@ public class IdentityTest extends AbstractMutationTest {
                     });
                     ctx.entity(it -> it.modified("{\"id\":\"1\",\"name\":\"Market\"}"));
                     ctx.entity(it -> it.modified("{\"id\":\"101\",\"name\":\"Sales\"}"));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertIfAbsentWithBooleanLogicalDeletedByH2() {
+
+        resetIdentity(null);
+
+        LocalDateTime time = LocalDateTime.of(2024, 6, 6, 22, 13);
+        Administrator administrator = AdministratorDraft.$.produce(draft -> {
+            draft.setName("a_5");
+            draft.setCreatedTime(time);
+            draft.setModifiedTime(time);
+        });
+        executeAndExpectResult(
+                getSqlClient(it -> it.setDialect(new H2Dialect()))
+                        .getEntities()
+                        .saveCommand(administrator)
+                        .setMode(SaveMode.INSERT_IF_ABSENT),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "merge into ADMINISTRATOR tb_1_ " +
+                                        "using(values(?, ?, ?, ?)) " +
+                                        "tb_2_(NAME, CREATED_TIME, MODIFIED_TIME, DELETED) " +
+                                        "on tb_1_.NAME = tb_2_.NAME and tb_1_.DELETED = tb_2_.DELETED::boolean " +
+                                        "when not matched then " +
+                                        "insert(NAME, CREATED_TIME, MODIFIED_TIME, DELETED) " +
+                                        "values(tb_2_.NAME, tb_2_.CREATED_TIME, tb_2_.MODIFIED_TIME, tb_2_.DELETED)"
+                        );
+                        it.variables("a_5", Timestamp.valueOf(time), Timestamp.valueOf(time), false);
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{" +
+                                        "--->\"name\":\"a_5\"," +
+                                        "--->\"createdTime\":\"2024-06-06 22:13:00\"," +
+                                        "--->\"modifiedTime\":\"2024-06-06 22:13:00\"," +
+                                        "--->\"id\":100" +
+                                        "}"
+                        );
+                    });
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/GlobalFilterTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/GlobalFilterTest.java
@@ -2,8 +2,12 @@ package org.babyfish.jimmer.sql.query;
 
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
 import org.babyfish.jimmer.sql.filter.Filter;
 import org.babyfish.jimmer.sql.filter.FilterArgs;
+import org.babyfish.jimmer.sql.model.hr.DepartmentFetcher;
+import org.babyfish.jimmer.sql.model.hr.EmployeeFetcher;
+import org.babyfish.jimmer.sql.model.hr.EmployeeTable;
 import org.babyfish.jimmer.sql.model.inheritance.*;
 import org.babyfish.jimmer.sql.runtime.LogicalDeletedBehavior;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +27,46 @@ public class GlobalFilterTest extends AbstractQueryTest {
         });
         lambdaClient = new LambdaClient(sqlClient);
         lambdaClientForDeletedData = new LambdaClient(sqlClientForDeletedData);
+    }
+
+    @Test
+    public void testJoinFetchAppliesLogicalDeletedFilterToJoinedReference() {
+        EmployeeTable table = EmployeeTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(1L))
+                        .select(
+                                table.fetch(
+                                        EmployeeFetcher.$
+                                                .name()
+                                                .department(
+                                                        ReferenceFetchType.JOIN_ALWAYS,
+                                                        DepartmentFetcher.$.name()
+                                                )
+                                )
+                        ),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME " +
+                                    "from EMPLOYEE tb_1_ " +
+                                    "left join DEPARTMENT tb_2_ " +
+                                    "--->on tb_1_.DEPARTMENT_ID = tb_2_.ID " +
+                                    "--->and tb_2_.DELETED_MILLIS = ? " +
+                                    "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?"
+                    );
+                    ctx.variables(0L, 1L, 0L);
+                    ctx.rows(
+                            "[" +
+                                    "--->{" +
+                                    "--->--->\"id\":\"1\"," +
+                                    "--->--->\"name\":\"Sam\"," +
+                                    "--->--->\"department\":{\"id\":\"1\",\"name\":\"Market\"}" +
+                                    "--->}" +
+                                    "]"
+                    );
+                }
+        );
     }
 
     @Test


### PR DESCRIPTION
# Changes

## Key-based updates now ignore logically deleted rows

When an entity is updated by key, the generated `where` predicate now includes the logical-delete active-row condition. This preserves the intended model where logical delete participates in the physical unique constraint, but save/update operations still work only with non-hidden rows.

This prevents key-based updates from touching logically deleted records that share the same business key with active records.

## Batch generated-id handling is guarded

Generated-id collection for batch mutation results now validates that the requested generated-id index exists for the batch result shape. This avoids misleading low-level index errors when a mutation path does not actually provide generated ids in the expected layout.

## Logical-delete filters are applied to join-fetch tables

Logical-delete filtering is now applied not only to ordinary joined tables, but also to join-fetch tables. This ensures fetched associations do not accidentally include logically deleted target rows.

## H2 `merge using(values)` handles boolean logical-delete conflict columns

H2 can infer `values(?)` source columns as string-like values inside `merge ... using(values ...)`, which breaks comparisons such as:

```sql
tb_1_.DELETED = tb_2_.DELETED
```

for boolean logical-delete columns.

The H2 dialect now renders a cast on the source side of the merge ON predicate for boolean conflict columns:

```sql
  tb_1_.DELETED = tb_2_.DELETED::boolean
```

The workaround is localized in H2Dialect, because the affected SQL shape is H2-specific.

# Fixed issues

#1337 