### PR TITLE
Allow @MapsId scalar ids to use association-id property names

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableType.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableType.java
@@ -672,6 +672,9 @@ public class ImmutableType implements BaseType {
                 String expectedPropName = prop.getName() + "Id";
                 ImmutableProp expectedProp = getProps().get(expectedPropName);
                 if (expectedProp != null) {
+                    if (isExplicitMappedIdProp(prop, expectedProp)) {
+                        continue;
+                    }
                     throw new MetaException(
                             expectedProp.toElement(),
                             "It looks like @IdView of association \"" +
@@ -684,6 +687,26 @@ public class ImmutableType implements BaseType {
             this.idPropNameMap = map;
         }
         return map;
+    }
+
+    private boolean isExplicitMappedIdProp(ImmutableProp associationProp, ImmutableProp expectedProp) {
+        MapsId mapsId = associationProp.getAnnotation(MapsId.class);
+        if (mapsId == null || !mapsId.value().isEmpty()) {
+            return false;
+        }
+        if (associationProp.isReverse() || associationProp.isTransient()) {
+            return false;
+        }
+        if (expectedProp != idProp || !expectedProp.isId()) {
+            return false;
+        }
+        ImmutableType targetType = associationProp.getTargetType();
+        if (targetType == null || targetType.getIdProp() == null) {
+            return false;
+        }
+        return expectedProp.getElementTypeName().box().equals(
+                targetType.getIdProp().getElementTypeName().box()
+        );
     }
 
     public List<ImmutableProp> getPropsOrderById() {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/JoinFetchTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/JoinFetchTest.kt
@@ -272,7 +272,8 @@ class JoinFetchTest : AbstractQueryTest() {
             sql(
                 """select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME 
                     |from ADMINISTRATOR tb_1_ 
-                    |left join ADMINISTRATOR_METADATA tb_2_ on tb_1_.ID = tb_2_.ADMINISTRATOR_ID 
+                    |left join ADMINISTRATOR_METADATA tb_2_ 
+                    |on tb_1_.ID = tb_2_.ADMINISTRATOR_ID and tb_2_.DELETED <> ? 
                     |where tb_1_.DELETED <> ?""".trimMargin()
             )
             rows(
@@ -302,6 +303,7 @@ class JoinFetchTest : AbstractQueryTest() {
                 """select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME 
                     |from EMPLOYEE tb_1_ 
                     |left join DEPARTMENT tb_2_ on tb_1_.DEPARTMENT_ID = tb_2_.ID 
+                    |and tb_2_.DELETED_TIME is null 
                     |where tb_1_.DELETED_UUID is null""".trimMargin()
             )
             rows(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
@@ -20,6 +20,9 @@ import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 import org.babyfish.jimmer.sql.filter.Filter;
 import org.babyfish.jimmer.sql.filter.impl.FilterArgsImpl;
 import org.babyfish.jimmer.sql.filter.impl.FilterManager;
+import org.babyfish.jimmer.sql.fetcher.Fetcher;
+import org.babyfish.jimmer.sql.fetcher.Field;
+import org.babyfish.jimmer.sql.fetcher.impl.JoinFetchFieldVisitor;
 import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.jetbrains.annotations.NotNull;
@@ -486,6 +489,17 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
             }
         }
 
+        @Override
+        public void visitTableFetcher(RealTable table, Fetcher<?> fetcher) {
+            TableLikeImplementor<?> implementor = table.getTableLikeImplementor();
+            if (implementor instanceof TableImplementor<?>) {
+                new ApplyJoinFetcherFilterVisitor(
+                        getAstContext().getSqlClient(),
+                        (TableImplementor<?>) implementor
+                ).visit(fetcher);
+            }
+        }
+
         public boolean isApplied(AbstractMutableStatementImpl statement, Selection<?> selection) {
             return appliedSet.has(statement, selection);
         }
@@ -508,6 +522,36 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
 
         public void apply(AbstractMutableStatementImpl statement, Order order) {
             appliedSet.add(statement, order);
+        }
+
+        private class ApplyJoinFetcherFilterVisitor extends JoinFetchFieldVisitor {
+
+            private TableImplementor<?> tableImplementor;
+
+            ApplyJoinFetcherFilterVisitor(JSqlClientImplementor sqlClient, TableImplementor<?> tableImplementor) {
+                super(sqlClient);
+                this.tableImplementor = tableImplementor;
+            }
+
+            @Override
+            protected Object enter(Field field) {
+                TableImplementor<?> oldTableImplementor = tableImplementor;
+                TableImplementor<?> newTableImplementor =
+                        oldTableImplementor.joinFetchImplementor(
+                                field.getProp(),
+                                oldTableImplementor.getBaseTableOwner()
+                        );
+                newTableImplementor
+                        .getStatement()
+                        .applyGlobalFilerImpl(ApplyFilterVisitor.this, newTableImplementor);
+                tableImplementor = newTableImplementor;
+                return oldTableImplementor;
+            }
+
+            @Override
+            protected void leave(Field field, Object enterValue) {
+                tableImplementor = (TableImplementor<?>) enterValue;
+            }
         }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -1054,6 +1054,10 @@ class Operator {
                                 .variable(getter);
                     }
                 }
+                LogicalDeletedInfo logicalDeletedInfo = shape.getType().getLogicalDeletedInfo();
+                if (logicalDeletedInfo != null) {
+                    builder.separator().logicalDeleteFilter(logicalDeletedInfo, null);
+                }
             } else {
                 for (PropertyGetter getter : shape.getIdGetters()) {
                     builder.separator()

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -172,7 +172,8 @@ public class H2Dialect extends DefaultDialect {
 
         ctx.enter(AbstractSqlBuilder.ScopeType.AND);
         for (ValueGetter getter : ctx.getConflictGetters()) {
-            ctx.separator().sql("tb_1_.").sql(getter).sql(" = tb_2_.").sql(getter);
+            ctx.separator().sql("tb_1_.").sql(getter).sql(" = ");
+            appendConflictValueFromSource(ctx, getter);
         }
         ctx.leave();
         if (!ctx.isUpdateIgnored() && (ctx.hasGeneratedId()) || ctx.hasUpdatedColumns()) {
@@ -204,6 +205,20 @@ public class H2Dialect extends DefaultDialect {
                 .appendInsertedColumns("tb_2_.")
                 .leave()
                 .leave();
+    }
+
+    private void appendConflictValueFromSource(UpsertContext ctx, ValueGetter getter) {
+        ctx.sql("tb_2_.").sql(getter);
+        if (Classes.boxTypeOf(getter.metadata().getSqlType()) != Boolean.class) {
+            return;
+        }
+        String sqlTypeName = getter.metadata().getSqlTypeName();
+        if (sqlTypeName == null) {
+            sqlTypeName = sqlType(Classes.primitiveTypeOf(getter.metadata().getSqlType()));
+        }
+        if (sqlTypeName != null) {
+            ctx.sql("::").sql(sqlTypeName);
+        }
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/event/binlog/BinLog.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/event/binlog/BinLog.java
@@ -2,9 +2,45 @@ package org.babyfish.jimmer.sql.event.binlog;
 
 import org.babyfish.jimmer.jackson.codec.Node;
 
+/**
+ * Accepts row-change events from an external CDC/binlog/message-queue integration
+ * and converts them into Jimmer trigger events.
+ */
 public interface BinLog {
 
+    /**
+     * Accept a row-change event without a custom reason.
+     *
+     * @param tableName The changed table name. See
+     * {@link #accept(String, Node, Node, String)} for the name resolution contract.
+     * @param oldData The old row data, or {@code null} for insert events
+     * @param newData The new row data, or {@code null} for delete events
+     */
     void accept(String tableName, Node oldData, Node newData);
 
+    /**
+     * Accept a row-change event.
+     *
+     * <p>The {@code tableName} can be either unqualified, such as {@code BOOK}, or
+     * database/schema-qualified, such as {@code PUBLIC.BOOK}. Qualified names are
+     * resolved exactly first. If no exact managed table is found, Jimmer falls back
+     * to suffix lookup, so {@code PUBLIC.BOOK} can still match an entity mapped to
+     * {@code BOOK}.</p>
+     *
+     * <p>For CDC streams that include several databases/schemas with the same table
+     * names, pass the database/schema-qualified table name and map the corresponding
+     * entities to qualified table names as well. Otherwise an unqualified fallback
+     * cannot distinguish which physical table produced the event.</p>
+     *
+     * <ul>
+     *     <li>For MySQL, use the database name as the qualifying prefix.</li>
+     *     <li>For PostgreSQL, use the schema name as the qualifying prefix.</li>
+     * </ul>
+     *
+     * @param tableName The changed table name
+     * @param oldData The old row data, or {@code null} for insert events
+     * @param newData The new row data, or {@code null} for delete events
+     * @param reason Optional reason propagated to trigger events
+     */
     void accept(String tableName, Node oldData, Node newData, String reason);
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -239,6 +239,11 @@ public class DefaultExecutor implements Executor {
             Reader<?> idReader = sqlClient.getReader(generatedIdProp);
             try (ResultSet rs = statement.getGeneratedKeys()) {
                 while (rs.next()) {
+                    if (index == batchCount) {
+                        throw new ExecutionException(
+                                "Too many generated ids for batch SQL statement: " + sql
+                        );
+                    }
                     Object id = idReader.read(rs, new Reader.Context(null, sqlClient));
                     ids[index++] = id;
                 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
@@ -622,7 +622,6 @@ public class EntityManager {
             return typeMapCache.get(strategy);
         }
 
-        @SuppressWarnings("unchecked")
         private Map<Key, Map<List<Object>, ImmutableType>> createTypeMap(MetadataStrategy strategy) {
             Map<Key, Map<List<Object>, ImmutableType>> typeMap = createRawTypeMap(strategy);
             for (Map.Entry<Key, Map<List<Object>, ImmutableType>> e : typeMap.entrySet()) {
@@ -674,23 +673,7 @@ public class EntityManager {
                 }
             }
 
-            Set<Key> rawKeys = new HashSet<>(typeMap.keySet());
-            Set<Key> ambiguousAliasKeys = new HashSet<>();
-            for (ImmutableType type : map.keySet()) {
-                if (!type.isEntity()) {
-                    continue;
-                }
-                String tableName = DatabaseIdentifiers.comparableIdentifier(type.getTableName(strategy));
-                extendRawTypeMap(type.getMicroServiceName(), tableName, typeMap, rawKeys, ambiguousAliasKeys);
-                for (ImmutableProp prop : type.getProps().values()) {
-                    if (prop.isMiddleTableDefinition()) {
-                        String middleTableName = DatabaseIdentifiers.comparableIdentifier(
-                                prop.<MiddleTable>getStorage(strategy).getTableName()
-                        );
-                        extendRawTypeMap(type.getMicroServiceName(), middleTableName, typeMap, rawKeys, ambiguousAliasKeys);
-                    }
-                }
-            }
+            typeMap.putAll(createAliasTypeMap(typeMap));
             return typeMap;
         }
 
@@ -842,34 +825,40 @@ public class EntityManager {
         }
     }
 
-    private static void extendRawTypeMap(
-            String microServiceName,
-            String tableName,
-            Map<Key, Map<List<Object>, ImmutableType>> map,
-            Set<Key> rawKeys,
+    private static Map<Key, Map<List<Object>, ImmutableType>> createAliasTypeMap(
+            Map<Key, Map<List<Object>, ImmutableType>> rawTypeMap
+    ) {
+        Map<Key, Map<List<Object>, ImmutableType>> aliasTypeMap = new LinkedHashMap<>();
+        Set<Key> ambiguousAliasKeys = new HashSet<>();
+        for (Map.Entry<Key, Map<List<Object>, ImmutableType>> e : rawTypeMap.entrySet()) {
+            addAliasTypeMap(e.getKey(), e.getValue(), rawTypeMap, aliasTypeMap, ambiguousAliasKeys);
+        }
+        return aliasTypeMap;
+    }
+
+    private static void addAliasTypeMap(
+            Key rawKey,
+            Map<List<Object>, ImmutableType> subMap,
+            Map<Key, Map<List<Object>, ImmutableType>> rawTypeMap,
+            Map<Key, Map<List<Object>, ImmutableType>> aliasTypeMap,
             Set<Key> ambiguousAliasKeys
     ) {
-        if (tableName.indexOf('.') == -1) {
-            return;
-        }
-        Map<List<Object>, ImmutableType> subMap = map.get(new Key(microServiceName, tableName));
-        if (subMap == null) {
-            return;
-        }
+        String tableName = rawKey.tableName;
         int index;
         while ((index = tableName.indexOf('.')) != -1) {
             tableName = tableName.substring(index + 1);
-            Key key = new Key(microServiceName, tableName);
-            if (ambiguousAliasKeys.contains(key)) {
+            Key aliasKey = new Key(rawKey.microServiceName, tableName);
+            if (ambiguousAliasKeys.contains(aliasKey)) {
                 continue;
             }
-            Map<List<Object>, ImmutableType> conflictMap = map.putIfAbsent(key, subMap);
+            Map<List<Object>, ImmutableType> conflictMap = rawTypeMap.get(aliasKey);
             if (conflictMap != null && conflictMap != subMap) {
-                if (rawKeys.contains(key)) {
-                    tableSharedBy(key, firstType(conflictMap), firstType(subMap), null);
-                }
-                map.remove(key);
-                ambiguousAliasKeys.add(key);
+                tableSharedBy(aliasKey, firstType(conflictMap), firstType(subMap), null);
+            }
+            conflictMap = aliasTypeMap.putIfAbsent(aliasKey, subMap);
+            if (conflictMap != null && conflictMap != subMap) {
+                aliasTypeMap.remove(aliasKey);
+                ambiguousAliasKeys.add(aliasKey);
             }
         }
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
@@ -674,18 +674,20 @@ public class EntityManager {
                 }
             }
 
+            Set<Key> rawKeys = new HashSet<>(typeMap.keySet());
+            Set<Key> ambiguousAliasKeys = new HashSet<>();
             for (ImmutableType type : map.keySet()) {
                 if (!type.isEntity()) {
                     continue;
                 }
                 String tableName = DatabaseIdentifiers.comparableIdentifier(type.getTableName(strategy));
-                extendRawTypeMap(type.getMicroServiceName(), tableName, typeMap);
+                extendRawTypeMap(type.getMicroServiceName(), tableName, typeMap, rawKeys, ambiguousAliasKeys);
                 for (ImmutableProp prop : type.getProps().values()) {
                     if (prop.isMiddleTableDefinition()) {
                         String middleTableName = DatabaseIdentifiers.comparableIdentifier(
                                 prop.<MiddleTable>getStorage(strategy).getTableName()
                         );
-                        extendRawTypeMap(type.getMicroServiceName(), middleTableName, typeMap);
+                        extendRawTypeMap(type.getMicroServiceName(), middleTableName, typeMap, rawKeys, ambiguousAliasKeys);
                     }
                 }
             }
@@ -699,10 +701,6 @@ public class EntityManager {
                     continue;
                 }
                 String tableName = DatabaseIdentifiers.comparableIdentifier(type.getTableName(strategy));
-                int lastDotIndex = tableName.lastIndexOf('.');
-                if (lastDotIndex != -1) {
-                    tableName = tableName.substring(lastDotIndex + 1);
-                }
                 String microServiceName = type.getMicroServiceName();
                 Key key = new Key(microServiceName, tableName);
                 Map<List<Object>, ImmutableType> subTypeMap = typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
@@ -718,10 +716,6 @@ public class EntityManager {
                                 middleTable.getFilterInfo().getValues() :
                                 null;
                         String middleTableName = DatabaseIdentifiers.comparableIdentifier(middleTable.getTableName());
-                        lastDotIndex = middleTableName.lastIndexOf('.');
-                        if (lastDotIndex != -1) {
-                            middleTableName = middleTableName.substring(lastDotIndex + 1);
-                        }
                         key = new Key(microServiceName, middleTableName);
                         subTypeMap = typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
                         if (filteredValues != null) {
@@ -848,24 +842,34 @@ public class EntityManager {
         }
     }
 
-    private static void extendRawTypeMap(String microServiceName, String tableName, Map<Key, Map<List<Object>, ImmutableType>> map) {
-        int lastDotIndex = tableName.lastIndexOf('.');
-        if (lastDotIndex == -1) {
+    private static void extendRawTypeMap(
+            String microServiceName,
+            String tableName,
+            Map<Key, Map<List<Object>, ImmutableType>> map,
+            Set<Key> rawKeys,
+            Set<Key> ambiguousAliasKeys
+    ) {
+        if (tableName.indexOf('.') == -1) {
             return;
         }
-        Map<List<Object>, ImmutableType> subMap = map.get(
-                new Key(
-                        microServiceName,
-                        tableName.substring(lastDotIndex + 1)
-                )
-        );
+        Map<List<Object>, ImmutableType> subMap = map.get(new Key(microServiceName, tableName));
         if (subMap == null) {
             return;
         }
         int index;
         while ((index = tableName.indexOf('.')) != -1) {
-            map.put(new Key(microServiceName, tableName), subMap);
             tableName = tableName.substring(index + 1);
+            Key key = new Key(microServiceName, tableName);
+            if (ambiguousAliasKeys.contains(key)) {
+                continue;
+            }
+            Map<List<Object>, ImmutableType> conflictMap = map.putIfAbsent(key, subMap);
+            if (conflictMap != null && conflictMap != subMap) {
+                if (!rawKeys.contains(key)) {
+                    map.remove(key);
+                }
+                ambiguousAliasKeys.add(key);
+            }
         }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
@@ -865,11 +865,16 @@ public class EntityManager {
             }
             Map<List<Object>, ImmutableType> conflictMap = map.putIfAbsent(key, subMap);
             if (conflictMap != null && conflictMap != subMap) {
-                if (!rawKeys.contains(key)) {
-                    map.remove(key);
+                if (rawKeys.contains(key)) {
+                    tableSharedBy(key, firstType(conflictMap), firstType(subMap), null);
                 }
+                map.remove(key);
                 ambiguousAliasKeys.add(key);
             }
         }
+    }
+
+    private static ImmutableType firstType(Map<List<Object>, ImmutableType> subMap) {
+        return subMap.values().iterator().next();
     }
 }

--- a/project/jimmer-sql/src/test/dto/MapsId.dto
+++ b/project/jimmer-sql/src/test/dto/MapsId.dto
@@ -1,0 +1,11 @@
+export org.babyfish.jimmer.sql.model.mapsid.MapsIdMessageDelivery
+    -> package org.babyfish.jimmer.sql.model.mapsid.dto
+
+MapsIdMessageDeliveryView {
+    messageId
+    status
+    message {
+        id
+        text
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/MapsIdDtoTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/MapsIdDtoTest.java
@@ -1,0 +1,49 @@
+package org.babyfish.jimmer.sql.dto;
+
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdMessageDeliveryTable;
+import org.babyfish.jimmer.sql.model.mapsid.dto.MapsIdMessageDeliveryView;
+import org.junit.jupiter.api.Test;
+
+public class MapsIdDtoTest extends AbstractQueryTest {
+
+    @Test
+    public void testFetchFullScalarMappedIdWithAssociationIdName() {
+        MapsIdMessageDeliveryTable table = MapsIdMessageDeliveryTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.messageId().eq(100L))
+                        .select(table.fetch(MapsIdMessageDeliveryView.class)),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.MESSAGE_ID, tb_1_.STATUS, tb_1_.MESSAGE_ID " +
+                                    "from MAPS_ID_MESSAGE_DELIVERY tb_1_ " +
+                                    "where tb_1_.MESSAGE_ID = ?"
+                    );
+                    ctx.variables(100L);
+                    ctx.statement(1).sql(
+                            "select tb_1_.ID, tb_1_.TEXT " +
+                                    "from MAPS_ID_MESSAGE tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    );
+                    ctx.statement(1).variables(100L);
+                    ctx.rows(rows -> {
+                        assertContentEquals(
+                                "[" +
+                                        "--->MapsIdMessageDeliveryView(" +
+                                        "--->--->messageId=100, " +
+                                        "--->--->status=SENT, " +
+                                        "--->--->message=MapsIdMessageDeliveryView.TargetOf_message(" +
+                                        "--->--->--->id=100, " +
+                                        "--->--->--->text=Hello" +
+                                        "--->--->)" +
+                                        "--->)" +
+                                        "]",
+                                rows
+                        );
+                    });
+                }
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
@@ -402,7 +402,9 @@ public class JoinFetchTest extends AbstractQueryTest {
                             "select tb_1_.ID, tb_1_.NAME, " +
                                     "tb_2_.ID, tb_2_.NAME " +
                                     "from ADMINISTRATOR tb_1_ " +
-                                    "left join ADMINISTRATOR_METADATA tb_2_ on tb_1_.ID = tb_2_.ADMINISTRATOR_ID " +
+                                    "left join ADMINISTRATOR_METADATA tb_2_ " +
+                                    "--->on tb_1_.ID = tb_2_.ADMINISTRATOR_ID " +
+                                    "--->and tb_2_.DELETED <> ? " +
                                     "where tb_1_.DELETED <> ?"
                     );
                     ctx.rows(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdMessage.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdMessage.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+
+@Entity
+public interface MapsIdMessage {
+
+    @Id
+    long id();
+
+    String text();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdMessageDelivery.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/mapsid/MapsIdMessageDelivery.java
@@ -1,0 +1,21 @@
+package org.babyfish.jimmer.sql.model.mapsid;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.JoinColumn;
+import org.babyfish.jimmer.sql.MapsId;
+import org.babyfish.jimmer.sql.OneToOne;
+
+@Entity
+public interface MapsIdMessageDelivery {
+
+    @Id
+    long messageId();
+
+    String status();
+
+    @MapsId
+    @OneToOne
+    @JoinColumn
+    MapsIdMessage message();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/schema/SchemaATable.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/schema/SchemaATable.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.model.schema;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.Table;
+
+@Entity
+@Table(name = "MY_TABLE", schema = "SCHEMA_A")
+public interface SchemaATable {
+
+    @Id
+    long id();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/schema/SchemaBTable.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/schema/SchemaBTable.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.model.schema;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.Table;
+
+@Entity
+@Table(name = "MY_TABLE", schema = "SCHEMA_B")
+public interface SchemaBTable {
+
+    @Id
+    long id();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/GetIdTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/GetIdTest.java
@@ -145,11 +145,11 @@ public class GetIdTest extends AbstractMutationTest {
                         .setMode(SaveMode.UPDATE_ONLY),
                 ctx -> {
                     ctx.statement(it -> {
-                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ?");
-                        it.batchVariables(0, 1L, "Jacob");
-                        it.batchVariables(1, 1L, "Jessica");
-                        it.batchVariables(2, 1L, "Raines");
-                        it.batchVariables(3, 1L, "Sam");
+                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, 1L, "Jacob", 0L);
+                        it.batchVariables(1, 1L, "Jessica", 0L);
+                        it.batchVariables(2, 1L, "Raines", 0L);
+                        it.batchVariables(3, 1L, "Sam", 0L);
                     });
                     ctx.entity(it -> {
                         it.modified(
@@ -169,6 +169,64 @@ public class GetIdTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.modified(
                                 "{\"id\":\"1\",\"name\":\"Sam\",\"department\":{\"id\":\"1\"}}"
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateByKeyDoesNotAffectLogicalDeletedRowsFromH2() {
+        jdbc(con -> {
+            try (Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("delete from employee");
+                stmt.executeUpdate("delete from department");
+                stmt.executeUpdate("insert into department(id, name) values(1, 'Market')");
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(1, 'Sam', 'M', 1, 0)"
+                );
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(2, 'Jessica', 'F', 1, 0)"
+                );
+                stmt.executeUpdate(
+                        "insert into employee(id, name, gender, department_id, deleted_millis) " +
+                                "values(3, 'Sam', 'M', 1, 9)"
+                );
+            }
+        });
+
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new H2Dialect()));
+        Employee employee1 = EmployeeDraft.$.produce(draft -> {
+            draft.setName("Sam");
+            draft.setGender(Gender.FEMALE);
+        });
+        Employee employee2 = EmployeeDraft.$.produce(draft -> {
+            draft.setName("Jessica");
+            draft.setGender(Gender.MALE);
+        });
+        executeAndExpectResult(
+                sqlClient
+                        .getEntities()
+                        .saveEntitiesCommand(
+                                Arrays.asList(employee1, employee2)
+                        )
+                        .setMode(SaveMode.UPDATE_ONLY),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("update EMPLOYEE set GENDER = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, "F", "Sam", 0L);
+                        it.batchVariables(1, "M", "Jessica", 0L);
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{\"id\":\"1\",\"name\":\"Sam\",\"gender\":\"FEMALE\"}"
+                        );
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{\"id\":\"2\",\"name\":\"Jessica\",\"gender\":\"MALE\"}"
                         );
                     });
                 }
@@ -787,9 +845,9 @@ public class GetIdTest extends AbstractMutationTest {
                         it.queryReason(QueryReason.GET_ID_FOR_KEY_BASE_UPDATE);
                     });
                     ctx.statement(it -> {
-                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ?");
-                        it.batchVariables(0, 1L, "Jessica");
-                        it.batchVariables(1, 1L, "Sam");
+                        it.sql("update EMPLOYEE set DEPARTMENT_ID = ? where NAME = ? and DELETED_MILLIS = ?");
+                        it.batchVariables(0, 1L, "Jessica", 0L);
+                        it.batchVariables(1, 1L, "Sam", 0L);
                     });
                     ctx.entity(it -> {
                         it.modified(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
@@ -17,12 +17,15 @@ import org.babyfish.jimmer.sql.model.Gender;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.hr.Department;
 import org.babyfish.jimmer.sql.model.hr.DepartmentDraft;
+import org.babyfish.jimmer.sql.model.inheritance.Administrator;
+import org.babyfish.jimmer.sql.model.inheritance.AdministratorDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -972,7 +975,7 @@ public class IdentityTest extends AbstractMutationTest {
                         it.batchVariables(1, "Sales", 0L);
                     });
                     ctx.entity(it -> it.modified("{\"id\":\"1\",\"name\":\"Market\"}"));
-                    ctx.entity(it -> it.modified("{\"id\":\"101\",\"name\":\"Sales\"}"));
+                    ctx.entity(it -> it.modified("{\"id\":\"100\",\"name\":\"Sales\"}"));
                 }
         );
     }
@@ -1077,6 +1080,49 @@ public class IdentityTest extends AbstractMutationTest {
                     });
                     ctx.entity(it -> it.modified("{\"id\":\"1\",\"name\":\"Market\"}"));
                     ctx.entity(it -> it.modified("{\"id\":\"101\",\"name\":\"Sales\"}"));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertIfAbsentWithBooleanLogicalDeletedByH2() {
+
+        resetIdentity(null);
+
+        LocalDateTime time = LocalDateTime.of(2024, 6, 6, 22, 13);
+        Administrator administrator = AdministratorDraft.$.produce(draft -> {
+            draft.setName("a_5");
+            draft.setCreatedTime(time);
+            draft.setModifiedTime(time);
+        });
+        executeAndExpectResult(
+                getSqlClient(it -> it.setDialect(new H2Dialect()))
+                        .getEntities()
+                        .saveCommand(administrator)
+                        .setMode(SaveMode.INSERT_IF_ABSENT),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "merge into ADMINISTRATOR tb_1_ " +
+                                        "using(values(?, ?, ?, ?)) " +
+                                        "tb_2_(NAME, CREATED_TIME, MODIFIED_TIME, DELETED) " +
+                                        "on tb_1_.NAME = tb_2_.NAME and tb_1_.DELETED = tb_2_.DELETED::boolean " +
+                                        "when not matched then " +
+                                        "insert(NAME, CREATED_TIME, MODIFIED_TIME, DELETED) " +
+                                        "values(tb_2_.NAME, tb_2_.CREATED_TIME, tb_2_.MODIFIED_TIME, tb_2_.DELETED)"
+                        );
+                        it.variables("a_5", Timestamp.valueOf(time), Timestamp.valueOf(time), false);
+                    });
+                    ctx.entity(it -> {
+                        it.modified(
+                                "{" +
+                                        "--->\"name\":\"a_5\"," +
+                                        "--->\"createdTime\":\"2024-06-06 22:13:00\"," +
+                                        "--->\"modifiedTime\":\"2024-06-06 22:13:00\"," +
+                                        "--->\"id\":100" +
+                                        "}"
+                        );
+                    });
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/MapsIdMutationTest.java
@@ -9,6 +9,9 @@ import org.babyfish.jimmer.sql.model.mapsid.DualParentChild;
 import org.babyfish.jimmer.sql.model.mapsid.DualParentChildDraft;
 import org.babyfish.jimmer.sql.model.mapsid.MappedTenantDocument;
 import org.babyfish.jimmer.sql.model.mapsid.MappedTenantDocumentDraft;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdMessage;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdMessageDelivery;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdMessageDeliveryDraft;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdPrincipal;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfileDraft;
@@ -55,6 +58,46 @@ public class MapsIdMutationTest extends AbstractMutationTest {
                                     "--->\"id\":{\"a\":1,\"b\":2}," +
                                     "--->\"nickname\":\"Alex\"," +
                                     "--->\"principal\":{\"id\":{\"a\":1,\"b\":2},\"name\":\"Root\"}" +
+                                    "}"
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testSaveFullScalarMappedIdWithAssociationIdName() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                MapsIdMessageDeliveryDraft.$.produce(delivery -> {
+                                    delivery.setMessageId(101L);
+                                    delivery.setStatus("READ");
+                                    delivery.applyMessage(message -> {
+                                        message.setId(101L);
+                                        message.setText("Hi");
+                                    });
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.APPEND),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_MESSAGE(ID, TEXT) values(?, ?)");
+                        it.variables(101L, "Hi");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into MAPS_ID_MESSAGE_DELIVERY(MESSAGE_ID, STATUS) values(?, ?)");
+                        it.variables(101L, "READ");
+                    });
+                    ctx.totalRowCount(2);
+                    ctx.rowCount(AffectedTable.of(MapsIdMessage.class), 1);
+                    ctx.rowCount(AffectedTable.of(MapsIdMessageDelivery.class), 1);
+                    ctx.entity(it -> it.modified(
+                            "{" +
+                                    "--->\"messageId\":101," +
+                                    "--->\"status\":\"READ\"," +
+                                    "--->\"message\":{\"id\":101,\"text\":\"Hi\"}" +
                                     "}"
                     ));
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/GlobalFilterTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/GlobalFilterTest.java
@@ -2,8 +2,12 @@ package org.babyfish.jimmer.sql.query;
 
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
 import org.babyfish.jimmer.sql.filter.Filter;
 import org.babyfish.jimmer.sql.filter.FilterArgs;
+import org.babyfish.jimmer.sql.model.hr.DepartmentFetcher;
+import org.babyfish.jimmer.sql.model.hr.EmployeeFetcher;
+import org.babyfish.jimmer.sql.model.hr.EmployeeTable;
 import org.babyfish.jimmer.sql.model.inheritance.*;
 import org.babyfish.jimmer.sql.runtime.LogicalDeletedBehavior;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +27,46 @@ public class GlobalFilterTest extends AbstractQueryTest {
         });
         lambdaClient = new LambdaClient(sqlClient);
         lambdaClientForDeletedData = new LambdaClient(sqlClientForDeletedData);
+    }
+
+    @Test
+    public void testJoinFetchAppliesLogicalDeletedFilterToJoinedReference() {
+        EmployeeTable table = EmployeeTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(1L))
+                        .select(
+                                table.fetch(
+                                        EmployeeFetcher.$
+                                                .name()
+                                                .department(
+                                                        ReferenceFetchType.JOIN_ALWAYS,
+                                                        DepartmentFetcher.$.name()
+                                                )
+                                )
+                        ),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_2_.ID, tb_2_.NAME " +
+                                    "from EMPLOYEE tb_1_ " +
+                                    "left join DEPARTMENT tb_2_ " +
+                                    "--->on tb_1_.DEPARTMENT_ID = tb_2_.ID " +
+                                    "--->and tb_2_.DELETED_MILLIS = ? " +
+                                    "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?"
+                    );
+                    ctx.variables(0L, 1L, 0L);
+                    ctx.rows(
+                            "[" +
+                                    "--->{" +
+                                    "--->--->\"id\":\"1\"," +
+                                    "--->--->\"name\":\"Sam\"," +
+                                    "--->--->\"department\":{\"id\":\"1\",\"name\":\"Market\"}" +
+                                    "--->}" +
+                                    "]"
+                    );
+                }
+        );
     }
 
     @Test

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/EntityManagerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/EntityManagerTest.java
@@ -126,4 +126,40 @@ public class EntityManagerTest {
                 entityManager.getTypeMapByServiceAndTable("", "MY_TABLE", strategy).isEmpty()
         );
     }
+
+    @Test
+    public void testImplicitAndExplicitSchemaConflict() {
+        MetadataStrategy strategy = new MetadataStrategy(
+                DatabaseSchemaStrategy.IMPLICIT,
+                DefaultDatabaseNamingStrategy.UPPER_CASE,
+                ForeignKeyStrategy.REAL,
+                new H2Dialect(),
+                new ScalarTypeStrategy() {
+                    @Override
+                    public Class<?> getOverriddenSqlType(ImmutableProp prop) {
+                        return null;
+                    }
+                },
+                it -> {
+                    if ("SCHEMA_A".equals(it)) {
+                        return "";
+                    }
+                    if ("SCHEMA_B".equals(it)) {
+                        return "SCHEMA_A";
+                    }
+                    return it;
+                }
+        );
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new EntityManager(SchemaATable.class, SchemaBTable.class).validate(strategy)
+        );
+
+        Assertions.assertEquals(
+                "Illegal entity manager, the table \"MY_TABLE\" is shared by both " +
+                        "\"org.babyfish.jimmer.sql.model.schema.SchemaATable\" and " +
+                        "\"org.babyfish.jimmer.sql.model.schema.SchemaBTable\"",
+                ex.getMessage()
+        );
+    }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/EntityManagerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/EntityManagerTest.java
@@ -6,6 +6,8 @@ import org.babyfish.jimmer.sql.association.meta.AssociationType;
 import org.babyfish.jimmer.sql.dialect.H2Dialect;
 import org.babyfish.jimmer.sql.meta.*;
 import org.babyfish.jimmer.sql.model.inheritance.*;
+import org.babyfish.jimmer.sql.model.schema.SchemaATable;
+import org.babyfish.jimmer.sql.model.schema.SchemaBTable;
 import org.babyfish.jimmer.sql.runtime.DefaultDatabaseNamingStrategy;
 import org.babyfish.jimmer.sql.runtime.EntityManager;
 import org.junit.jupiter.api.Assertions;
@@ -90,6 +92,38 @@ public class EntityManagerTest {
         Assertions.assertEquals(
                 AssociationType.of(AdministratorProps.ROLES),
                 EntityManager.fromResources(null, null).getTypeMapByServiceAndTable("", "`Administrator_Role_Mapping`", strategy).get(null)
+        );
+    }
+
+    @Test
+    public void testSameTableNameInDifferentSchemas() {
+        MetadataStrategy strategy = new MetadataStrategy(
+                DatabaseSchemaStrategy.IMPLICIT,
+                DefaultDatabaseNamingStrategy.UPPER_CASE,
+                ForeignKeyStrategy.REAL,
+                new H2Dialect(),
+                new ScalarTypeStrategy() {
+                    @Override
+                    public Class<?> getOverriddenSqlType(ImmutableProp prop) {
+                        return null;
+                    }
+                },
+                MetaStringResolver.NO_OP
+        );
+        EntityManager entityManager = new EntityManager(SchemaATable.class, SchemaBTable.class);
+
+        entityManager.validate(strategy);
+
+        Assertions.assertEquals(
+                ImmutableType.get(SchemaATable.class),
+                entityManager.getTypeMapByServiceAndTable("", "SCHEMA_A.MY_TABLE", strategy).get(null)
+        );
+        Assertions.assertEquals(
+                ImmutableType.get(SchemaBTable.class),
+                entityManager.getTypeMapByServiceAndTable("", "SCHEMA_B.MY_TABLE", strategy).get(null)
+        );
+        Assertions.assertTrue(
+                entityManager.getTypeMapByServiceAndTable("", "MY_TABLE", strategy).isEmpty()
         );
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/util/MapsIdMetadataTest.java
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.model.mapsid.DualParentChild;
 import org.babyfish.jimmer.sql.model.mapsid.MappedTenantDocument;
 import org.babyfish.jimmer.sql.model.mapsid.MappedTenantDocumentBase;
 import org.babyfish.jimmer.sql.model.mapsid.MappedTenantDocumentIdBase;
+import org.babyfish.jimmer.sql.model.mapsid.MapsIdMessageDelivery;
 import org.babyfish.jimmer.sql.model.mapsid.LongMapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.MapsIdProfile;
 import org.babyfish.jimmer.sql.model.mapsid.TenantDocument;
@@ -54,6 +55,29 @@ public class MapsIdMetadataTest extends AbstractQueryTest {
         assertTrue(mappedId.isFull());
         assertEquals(
                 "[id->ID]",
+                mappedId.getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
+                        .stream()
+                        .map(it -> it.getSourceName() + "->" + it.getTargetName())
+                        .collect(Collectors.toList())
+                        .toString()
+        );
+    }
+
+    @Test
+    public void testWholeScalarIdMappingWithAssociationIdName() {
+        ImmutableType type = ImmutableType.get(MapsIdMessageDelivery.class);
+        List<MappedId> mappedIds = type.getMappedIds();
+
+        assertEquals("messageId", type.getIdProp().getName());
+        assertNull(type.getProp("messageId").getIdViewBaseProp());
+        assertEquals(1, mappedIds.size());
+        MappedId mappedId = mappedIds.get(0);
+        assertEquals("message", mappedId.getProp().getName());
+        assertEquals("messageId", mappedId.getIdProp().getName());
+        assertEquals("id", mappedId.getTargetIdProp().getName());
+        assertTrue(mappedId.isFull());
+        assertEquals(
+                "[MESSAGE_ID->ID]",
                 mappedId.getColumns(((JSqlClientImplementor) getSqlClient()).getMetadataStrategy())
                         .stream()
                         .map(it -> it.getSourceName() + "->" + it.getTargetName())

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -13,6 +13,8 @@ drop table mapped_tenant_document if exists;
 drop table tenant_document if exists;
 drop table long_maps_id_profile if exists;
 drop table tenant if exists;
+drop table maps_id_message_delivery if exists;
+drop table maps_id_message if exists;
 drop table maps_id_profile if exists;
 drop table maps_id_principal if exists;
 drop table time_row if exists;
@@ -1608,6 +1610,24 @@ create table long_maps_id_profile(
         foreign key(id)
             references tenant(id)
 );
+
+create table maps_id_message(
+    id bigint not null,
+    text varchar(50) not null,
+    constraint pk_maps_id_message primary key(id)
+);
+
+create table maps_id_message_delivery(
+    message_id bigint not null,
+    status varchar(50) not null,
+    constraint pk_maps_id_message_delivery primary key(message_id),
+    constraint fk_maps_id_message_delivery__message
+        foreign key(message_id)
+            references maps_id_message(id)
+);
+
+insert into maps_id_message(id, text) values(100, 'Hello');
+insert into maps_id_message_delivery(message_id, status) values(100, 'SENT');
 
 create table tenant_document(
     tenant_id bigint not null,


### PR DESCRIPTION
This change allows an entity id property to use the conventional association-id name for a whole `@MapsId` association, for example `messageId` for `message`, when both properties are backed by the same physical column.

The annotation processor now distinguishes this explicit scalar id from a missing generated `@IdView`, so the model is accepted without requiring users to rename the id property. The case also works with a default `@JoinColumn`, letting the normal naming strategy choose `MESSAGE_ID`.

DTO projection and save behavior are covered for this mapping so the scalar id and mapped association remain consistent when fetching and persisting entities.
