### PR TITLE
Add fold support for DTO generation

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -245,12 +245,11 @@ public class DtoGenerator {
                 addAccessorField(prop);
             }
         }
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             addField(prop);
-            addStateField(prop);
-        }
-        for (UserProp prop : dtoType.getUserProps()) {
-            addField(prop);
+            if (prop instanceof DtoProp<?, ?>) {
+                addStateField((DtoProp<ImmutableType, ImmutableProp>) prop);
+            }
         }
 
         addDefaultConstructor();
@@ -258,10 +257,7 @@ public class DtoGenerator {
             addConverterConstructor();
         }
 
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
-            addAccessors(prop);
-        }
-        for (UserProp prop : dtoType.getUserProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             addAccessors(prop);
         }
 
@@ -269,6 +265,7 @@ public class DtoGenerator {
             addEntityType();
             addApplyTo();
         } else {
+            addApplyToDraft();
             addToEntity(false);
             addToEntity(true);
         }
@@ -295,6 +292,15 @@ public class DtoGenerator {
                         targetSimpleName(prop)
                 ).generate();
             }
+        }
+        for (FoldProp<ImmutableType, ImmutableProp> prop : dtoType.getFoldProps()) {
+            new DtoGenerator(
+                    ctx,
+                    docMetadata,
+                    prop.getTargetType(),
+                    this,
+                    targetSimpleName(prop)
+            ).generate();
         }
 
         if (isSerializerRequired()) {
@@ -334,6 +340,22 @@ public class DtoGenerator {
                 .indent()
                 .add("$T.$L", dtoType.getBaseType().getFetcherClassName(), "$")
                 .indent();
+        addFetcherFields(dtoType, cb);
+        cb
+                .add(",\n")
+                .unindent()
+                .add("$T::new\n", getDtoClassName())
+                .unindent()
+                .unindent()
+                .add(")");
+        builder.initializer(cb.build());
+        typeBuilder.addField(builder.build());
+    }
+
+    private void addFetcherFields(
+            DtoType<ImmutableType, ImmutableProp> dtoType,
+            CodeBlock.Builder cb
+    ) {
         for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
             if (prop.getNextProp() == null) {
                 addFetcherField(prop, cb);
@@ -344,15 +366,9 @@ public class DtoGenerator {
                 addHiddenFetcherField(hiddenProp, cb);
             }
         }
-        cb
-                .add(",\n")
-                .unindent()
-                .add("$T::new\n", getDtoClassName())
-                .unindent()
-                .unindent()
-                .add(")");
-        builder.initializer(cb.build());
-        typeBuilder.addField(builder.build());
+        for (FoldProp<ImmutableType, ImmutableProp> foldProp : dtoType.getFoldProps()) {
+            addFetcherFields(foldProp.getTargetType(), cb);
+        }
     }
 
     private void addFetcherField(DtoProp<ImmutableType, ImmutableProp> prop, CodeBlock.Builder cb) {
@@ -794,7 +810,12 @@ public class DtoGenerator {
         cb.add("$<$<\n)");
     }
 
-    private void addField(DtoProp<ImmutableType, ImmutableProp> prop) {
+    @SuppressWarnings("unchecked")
+    private void addField(AbstractProp prop) {
+        if (prop instanceof UserProp) {
+            addField((UserProp) prop);
+            return;
+        }
         TypeName typeName = getPropTypeName(prop);
         if (isFieldNullable(prop)) {
             typeName = typeName.box();
@@ -806,22 +827,27 @@ public class DtoGenerator {
         if (doc != null) {
             builder.addJavadoc(doc);
         }
-        if (dtoType.getModifiers().contains(DtoModifier.INPUT) && prop.getInputModifier() == DtoModifier.FIXED) {
-            builder.addAnnotation(org.babyfish.jimmer.apt.immutable.generator.Constants.FIXED_INPUT_FIELD_CLASS_NAME);
-        }
         boolean isBuilderRequired = isBuildRequired();
-        for (AnnotationMirror annotationMirror : prop.toTailProp().getBaseProp().getAnnotations()) {
-            if (isBuilderRequired) {
-                String qualifiedName = ((TypeElement) annotationMirror.getAnnotationType()
-                        .asElement())
-                        .getQualifiedName()
-                        .toString();
-                if (qualifiedName.equals(ctx.getJacksonTypes().jsonDeserialize.reflectionName())) {
-                    continue;
-                }
+        if (prop instanceof DtoProp<?, ?>) {
+            DtoProp<ImmutableType, ImmutableProp> dtoProp =
+                    (DtoProp<ImmutableType, ImmutableProp>) prop;
+            if (dtoType.getModifiers().contains(DtoModifier.INPUT) &&
+                    dtoProp.getInputModifier() == DtoModifier.FIXED) {
+                builder.addAnnotation(org.babyfish.jimmer.apt.immutable.generator.Constants.FIXED_INPUT_FIELD_CLASS_NAME);
             }
-            if (isCopyableAnnotation(annotationMirror, dtoType.getAnnotations(), false)) {
-                builder.addAnnotation(AnnotationSpec.get(annotationMirror));
+            for (AnnotationMirror annotationMirror : dtoProp.toTailProp().getBaseProp().getAnnotations()) {
+                if (isBuilderRequired) {
+                    String qualifiedName = ((TypeElement) annotationMirror.getAnnotationType()
+                            .asElement())
+                            .getQualifiedName()
+                            .toString();
+                    if (qualifiedName.equals(ctx.getJacksonTypes().jsonDeserialize.reflectionName())) {
+                        continue;
+                    }
+                }
+                if (isCopyableAnnotation(annotationMirror, dtoType.getAnnotations(), false)) {
+                    builder.addAnnotation(AnnotationSpec.get(annotationMirror));
+                }
             }
         }
         for (Anno anno : prop.getAnnotations()) {
@@ -1050,7 +1076,22 @@ public class DtoGenerator {
                                 .addAnnotation(NonNull.class)
                                 .build()
                 );
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp abstractProp : dtoType.getProps()) {
+            if (abstractProp instanceof FoldProp<?, ?>) {
+                FoldProp<ImmutableType, ImmutableProp> foldProp =
+                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
+                builder.addStatement(
+                        "this.$L = new $T(base)",
+                        foldProp.getName(),
+                        getPropTypeName(foldProp)
+                );
+                continue;
+            }
+            if (!(abstractProp instanceof DtoProp<?, ?>)) {
+                continue;
+            }
+            DtoProp<ImmutableType, ImmutableProp> prop =
+                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
             if (isSimpleProp(prop)) {
                 if (prop.isNullable()) {
                     builder.addStatement(
@@ -1100,6 +1141,67 @@ public class DtoGenerator {
         typeBuilder.addMethod(builder.build());
     }
 
+    @SuppressWarnings("unchecked")
+    private void addApplyToDraft() {
+        MethodSpec.Builder builder = MethodSpec
+                .methodBuilder("__applyTo")
+                .addModifiers(Modifier.PRIVATE)
+                .addParameter(dtoType.getBaseType().getDraftClassName(), "__draft");
+        for (AbstractProp abstractProp : dtoType.getProps()) {
+            if (abstractProp instanceof FoldProp<?, ?>) {
+                FoldProp<ImmutableType, ImmutableProp> foldProp =
+                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
+                if (foldProp.isNullable()) {
+                    builder.beginControlFlow("if (this.$L != null)", foldProp.getName());
+                }
+                builder.addStatement("this.$L.__applyTo(__draft)", foldProp.getName());
+                if (foldProp.isNullable()) {
+                    builder.endControlFlow();
+                }
+                continue;
+            }
+            if (!(abstractProp instanceof DtoProp<?, ?>)) {
+                continue;
+            }
+            DtoProp<ImmutableType, ImmutableProp> prop =
+                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
+            if (prop.getBaseProp().isJavaFormula()) {
+                continue;
+            }
+            String stateFieldName = stateFieldName(prop, false);
+            boolean fuzzy = prop.getInputModifier() == DtoModifier.FUZZY && prop.isNullable();
+            if (stateFieldName != null) {
+                builder.beginControlFlow("if (this.$L)", stateFieldName);
+            } else if (fuzzy) {
+                builder.beginControlFlow("if (this.$L != null)", prop.getName());
+            }
+            if (isSimpleProp(prop)) {
+                builder.addStatement("__draft.$L(this.$L)", prop.getBaseProp().getSetterName(), prop.getName());
+            } else {
+                ImmutableProp tailBaseProp = prop.toTailProp().getBaseProp();
+                if (tailBaseProp.isList() && tailBaseProp.isAssociation(true)) {
+                    builder.addStatement(
+                            "$L.set(__draft, this.$L != null ? this.$L : $T.emptyList())",
+                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                            prop.getName(),
+                            prop.getName(),
+                            org.babyfish.jimmer.apt.immutable.generator.Constants.COLLECTIONS_CLASS_NAME
+                    );
+                } else {
+                    builder.addStatement(
+                            "$L.set(__draft, this.$L)",
+                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                            prop.getName()
+                    );
+                }
+            }
+            if (stateFieldName != null || fuzzy) {
+                builder.endControlFlow();
+            }
+        }
+        typeBuilder.addMethod(builder.build());
+    }
+
     private void addToEntity(boolean withId) {
         boolean idOverridable =
                 dtoType.getModifiers().contains(DtoModifier.INPUT) &&
@@ -1132,41 +1234,7 @@ public class DtoGenerator {
                     dtoType.getBaseType().getDraftClassName(),
                     "$"
             );
-            for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
-                if (prop.getBaseProp().isJavaFormula()) {
-                    continue;
-                }
-                String stateFieldName = stateFieldName(prop, false);
-                boolean fuzzy = prop.getInputModifier() == DtoModifier.FUZZY && prop.isNullable();
-                if (stateFieldName != null) {
-                    builder.beginControlFlow("if (this.$L)", stateFieldName);
-                } else if (fuzzy) {
-                    builder.beginControlFlow("if (this.$L != null)", prop.getName());
-                }
-                if (isSimpleProp(prop)) {
-                    builder.addStatement("__draft.$L(this.$L)", prop.getBaseProp().getSetterName(), prop.getName());
-                } else {
-                    ImmutableProp tailBaseProp = prop.toTailProp().getBaseProp();
-                    if (tailBaseProp.isList() && tailBaseProp.isAssociation(true)) {
-                        builder.addStatement(
-                                "$L.set(__draft, this.$L != null ? this.$L : $T.emptyList())",
-                                StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
-                                prop.getName(),
-                                prop.getName(),
-                                org.babyfish.jimmer.apt.immutable.generator.Constants.COLLECTIONS_CLASS_NAME
-                        );
-                    } else {
-                        builder.addStatement(
-                                "$L.set(__draft, this.$L)",
-                                StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
-                                prop.getName()
-                        );
-                    }
-                }
-                if (stateFieldName != null || fuzzy) {
-                    builder.endControlFlow();
-                }
-            }
+            builder.addStatement("this.__applyTo(__draft)");
             if (baseIdProp != null) {
                 builder.beginControlFlow("if (id != null)");
                 builder.addStatement("__draft.$L($L)", baseIdProp.getSetterName(), "id");
@@ -1228,7 +1296,25 @@ public class DtoGenerator {
                     org.babyfish.jimmer.apt.immutable.generator.Constants.PREDICATE_APPLIER_CLASS_NAME
             );
         }
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp abstractProp : dtoType.getProps()) {
+            if (abstractProp instanceof FoldProp<?, ?>) {
+                FoldProp<ImmutableType, ImmutableProp> foldProp =
+                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
+                stack = addStackOperations(builder, stack, Collections.emptyList());
+                builder.beginControlFlow("if (this.$L != null)", foldProp.getName());
+                if (dtoType.getBaseType().isEntity()) {
+                    builder.addStatement("this.$L.applyTo(args)", foldProp.getName());
+                } else {
+                    builder.addStatement("this.$L.applyTo(__applier)", foldProp.getName());
+                }
+                builder.endControlFlow();
+                continue;
+            }
+            if (!(abstractProp instanceof DtoProp<?, ?>)) {
+                continue;
+            }
+            DtoProp<ImmutableType, ImmutableProp> prop =
+                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
             List<ImmutableProp> newStack = new ArrayList<>(stack.size() + 2);
             DtoProp<ImmutableType, ImmutableProp> tailProp = prop.toTailProp();
             for (DtoProp<ImmutableType, ImmutableProp> p = prop; p != null; p = p.getNextProp()) {
@@ -1455,6 +1541,9 @@ public class DtoGenerator {
         if (prop instanceof DtoProp<?, ?>) {
             return getPropTypeName((DtoProp<ImmutableType, ImmutableProp>) prop);
         }
+        if (prop instanceof FoldProp<?, ?>) {
+            return getDtoClassName(targetSimpleName((FoldProp<ImmutableType, ImmutableProp>) prop));
+        }
         return getTypeName(((UserProp)prop).getTypeRef());
     }
 
@@ -1620,7 +1709,7 @@ public class DtoGenerator {
                 .addAnnotation(Override.class)
                 .returns(TypeName.INT);
         boolean first = true;
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             CodeBlock.Builder cb = CodeBlock.builder();
             if (first) {
                 cb.add("int hash = ");
@@ -1646,28 +1735,6 @@ public class DtoGenerator {
                 builder.addStatement("hash = hash * 31 + Boolean.hashCode($L)", stateFieldName);
             }
         }
-        for (UserProp prop : dtoType.getUserProps()) {
-            CodeBlock.Builder cb = CodeBlock.builder();
-            if (first) {
-                cb.add("int hash = ");
-                first = false;
-            } else {
-                cb.add("hash = hash * 31 + ");
-            }
-            TypeName typeName = getTypeName(prop.getTypeRef());
-            if (typeName.isPrimitive()) {
-                cb.add(
-                        "$T.hashCode($L)",
-                        typeName.box(),
-                        prop.getAlias().equals("hash") ? "this." + prop.getAlias() : prop.getAlias()
-                );
-            } else if (typeName instanceof ArrayTypeName) {
-                cb.add("$T.hashCode($L)", Arrays.class, prop.getName());
-            } else {
-                cb.add("$T.hashCode($L)", Objects.class, prop.getAlias());
-            }
-            builder.addStatement(cb.build());
-        }
         builder.addStatement(first ? "return 0" : "return hash");
         typeBuilder.addMethod(builder.build());
     }
@@ -1683,7 +1750,7 @@ public class DtoGenerator {
                 .addStatement("return false")
                 .endControlFlow();
         builder.addStatement("$L other = ($L) o", getSimpleName(), getSimpleName());
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             String propName = prop.getName();
             String stateFieldName = stateFieldName(prop, false);
             if (stateFieldName != null) {
@@ -1722,20 +1789,6 @@ public class DtoGenerator {
             builder.addStatement("return false");
             builder.endControlFlow();
         }
-        for (UserProp prop : dtoType.getUserProps()) {
-            String propName = prop.getAlias();
-            String thisProp = propName.equals("o") || propName.equals("other") ? "this" + propName : propName;
-            TypeName typeName = getTypeName(prop.getTypeRef());
-            if (typeName.isPrimitive() && !isFieldNullable(prop)) {
-                builder.beginControlFlow("if ($L != other.$L)", thisProp, propName);
-            } else if (typeName instanceof ArrayTypeName) {
-                builder.beginControlFlow("if (!$T.equals($L, other.$L))", Arrays.class, thisProp, propName);
-            } else {
-                builder.beginControlFlow("if (!$T.equals($L, other.$L))", Objects.class, thisProp, propName);
-            }
-            builder.addStatement("return false");
-            builder.endControlFlow();
-        }
         builder.addStatement("return true");
         typeBuilder.addMethod(builder.build());
     }
@@ -1757,9 +1810,11 @@ public class DtoGenerator {
         if (dynamicSeparator) {
             builder.addStatement("String _sp = \"\"");
         }
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             String stateFieldName = stateFieldName(prop, false);
-            boolean fuzzy = prop.getInputModifier() == DtoModifier.FUZZY && prop.isNullable();
+            boolean fuzzy = prop instanceof DtoProp<?, ?> &&
+                    ((DtoProp<?, ?>) prop).getInputModifier() == DtoModifier.FUZZY &&
+                    prop.isNullable();
             if (stateFieldName != null) {
                 builder.beginControlFlow("if ($L)", stateFieldName);
             } else if (fuzzy) {
@@ -1778,19 +1833,6 @@ public class DtoGenerator {
             }
             if (stateFieldName != null || fuzzy) {
                 builder.endControlFlow();
-            }
-        }
-        for (UserProp prop : dtoType.getUserProps()) {
-            if (prop.getAlias().equals("builder")) {
-                builder.addStatement("builder.append($L).append($S).append(this.$L)", separator, prop.getAlias() + '=', prop.getAlias());
-            } else {
-                builder.addStatement("builder.append($L).append($S).append($L)", separator, prop.getAlias() + '=', prop.getAlias());
-            }
-            if (dynamicSeparator) {
-                builder.addStatement("_sp = \", \"");
-                separator = "_sp";
-            } else {
-                separator = "\", \"";
             }
         }
         builder.addStatement("builder.append(')')");
@@ -1865,6 +1907,10 @@ public class DtoGenerator {
         if (prop.isRecursive() && !targetType.isFocusedRecursion()) {
             return innerClassName != null ? innerClassName : dtoType.getName();
         }
+        return standardTargetSimpleName("TargetOf_" + prop.getName());
+    }
+
+    private String targetSimpleName(FoldProp<ImmutableType, ImmutableProp> prop) {
         return standardTargetSimpleName("TargetOf_" + prop.getName());
     }
 
@@ -2070,12 +2116,8 @@ public class DtoGenerator {
 
     @SuppressWarnings("unchecked")
     String getterName(AbstractProp prop) {
-        TypeName typeName = prop instanceof DtoProp<?, ?> ?
-                getPropTypeName((DtoProp<ImmutableType, ImmutableProp>) prop) :
-                getTypeName(((UserProp)prop).getTypeRef());
-        String suffix = prop instanceof DtoProp<?, ?> ?
-                prop.getName() :
-                prop.getAlias();
+        TypeName typeName = getPropTypeName(prop);
+        String suffix = prop.getAlias();
         if (suffix.startsWith("is") &&
                 suffix.length() > 2 &&
                 Character.isUpperCase(suffix.charAt(2)) &&
@@ -2090,12 +2132,8 @@ public class DtoGenerator {
 
     @SuppressWarnings("unchecked")
     private String setterName(AbstractProp prop) {
-        TypeName typeName = prop instanceof DtoProp<?, ?> ?
-                getPropTypeName((DtoProp<ImmutableType, ImmutableProp>) prop) :
-                getTypeName(((UserProp)prop).getTypeRef());
-        String suffix = prop instanceof DtoProp<?, ?> ?
-                prop.getName() :
-                prop.getAlias();
+        TypeName typeName = getPropTypeName(prop);
+        String suffix = prop.getAlias();
         if (suffix.startsWith("is") &&
                 suffix.length() > 2 &&
                 Character.isUpperCase(suffix.charAt(2)) &&

--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -244,11 +244,14 @@ public class DtoGenerator {
             for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
                 addAccessorField(prop);
             }
+            for (FoldProp<ImmutableType, ImmutableProp> prop : dtoType.getFoldProps()) {
+                addFoldNullGuardAccessorField(prop);
+            }
         }
         for (AbstractProp prop : dtoType.getProps()) {
             addField(prop);
             if (prop instanceof DtoProp<?, ?>) {
-                addStateField((DtoProp<ImmutableType, ImmutableProp>) prop);
+                addStateField(asDtoProp(prop));
             }
         }
 
@@ -618,9 +621,35 @@ public class DtoGenerator {
         if (isSimpleProp(prop)) {
             return;
         }
+        addAccessorField(
+                prop,
+                accessorFieldName(prop.getName()),
+                accessorAcceptsNull(prop),
+                true
+        );
+    }
+
+    private void addFoldNullGuardAccessorField(FoldProp<ImmutableType, ImmutableProp> prop) {
+        DtoProp<ImmutableType, ImmutableProp> nullGuardProp = prop.getNullGuardProp();
+        if (nullGuardProp != null) {
+            addAccessorField(
+                    nullGuardProp,
+                    foldNullGuardAccessorFieldName(prop),
+                    true,
+                    false
+            );
+        }
+    }
+
+    private void addAccessorField(
+            DtoProp<ImmutableType, ImmutableProp> prop,
+            String fieldName,
+            boolean acceptNull,
+            boolean withConverters
+    ) {
         FieldSpec.Builder builder = FieldSpec.builder(
                 org.babyfish.jimmer.apt.immutable.generator.Constants.DTO_PROP_ACCESSOR_CLASS_NAME,
-                StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                fieldName,
                 Modifier.PRIVATE,
                 Modifier.STATIC,
                 Modifier.FINAL
@@ -630,16 +659,7 @@ public class DtoGenerator {
         cb.indent();
 
         DtoProp<ImmutableType, ImmutableProp> tailProp = prop.toTailProp();
-        if (prop.isNullable() && (
-                !prop.toTailProp().getBaseProp().isNullable() ||
-                        dtoType.getModifiers().contains(DtoModifier.SPECIFICATION) ||
-                        dtoType.getModifiers().contains(DtoModifier.FUZZY) ||
-                        prop.getInputModifier() == DtoModifier.FUZZY)
-        ) {
-            cb.add("\nfalse");
-        } else {
-            cb.add("\ntrue");
-        }
+        cb.add("\n$L", acceptNull);
 
         if (prop.getNextProp() == null) {
             cb.add(",\nnew int[] { $T.$L }", dtoType.getBaseType().getProducerClassName(), prop.getBaseProp().getSlotName());
@@ -659,7 +679,7 @@ public class DtoGenerator {
             cb.add("\n}");
         }
 
-        if (prop.isIdOnly()) {
+        if (withConverters && prop.isIdOnly()) {
             if (dtoType.getModifiers().contains(DtoModifier.SPECIFICATION)) {
                 cb.add(",\nnull");
             } else {
@@ -681,7 +701,7 @@ public class DtoGenerator {
                 addConverterLoading(cb, prop, false);
                 cb.add(")");
             }
-        } else if (tailProp.getTargetType() != null) {
+        } else if (withConverters && tailProp.getTargetType() != null) {
             if (dtoType.getModifiers().contains(DtoModifier.SPECIFICATION)) {
                 cb.add(",\nnull");
             } else {
@@ -701,7 +721,7 @@ public class DtoGenerator {
                         tailProp.getTargetType().getBaseType().isEntity() ? "toEntity" : "toImmutable"
                 );
             }
-        } else if (prop.getEnumType() != null) {
+        } else if (withConverters && prop.getEnumType() != null) {
             EnumType enumType = prop.getEnumType();
             TypeName enumTypeName = tailProp.getBaseProp().getTypeName();
             if (dtoType.getModifiers().contains(DtoModifier.SPECIFICATION)) {
@@ -732,7 +752,7 @@ public class DtoGenerator {
             addValueToEnum(cb, prop, "arg");
             cb.unindent();
             cb.add("}");
-        } else if (converterMetadataOf(prop) != null) {
+        } else if (withConverters && converterMetadataOf(prop) != null) {
             cb.add(",\narg -> ");
             addConverterLoading(cb, prop, true);
             cb.add(".output(arg)");
@@ -745,6 +765,15 @@ public class DtoGenerator {
         cb.add("\n)");
         builder.initializer(cb.build());
         typeBuilder.addField(builder.build());
+    }
+
+    private boolean accessorAcceptsNull(DtoProp<ImmutableType, ImmutableProp> prop) {
+        return !(prop.isNullable() && (
+                !prop.toTailProp().getBaseProp().isNullable() ||
+                        dtoType.getModifiers().contains(DtoModifier.SPECIFICATION) ||
+                        dtoType.getModifiers().contains(DtoModifier.FUZZY) ||
+                        prop.getInputModifier() == DtoModifier.FUZZY)
+        );
     }
 
     private void addValueToEnum(CodeBlock.Builder cb, DtoProp<ImmutableType, ImmutableProp> prop, String variableName) {
@@ -829,8 +858,7 @@ public class DtoGenerator {
         }
         boolean isBuilderRequired = isBuildRequired();
         if (prop instanceof DtoProp<?, ?>) {
-            DtoProp<ImmutableType, ImmutableProp> dtoProp =
-                    (DtoProp<ImmutableType, ImmutableProp>) prop;
+            DtoProp<ImmutableType, ImmutableProp> dtoProp = asDtoProp(prop);
             if (dtoType.getModifiers().contains(DtoModifier.INPUT) &&
                     dtoProp.getInputModifier() == DtoModifier.FIXED) {
                 builder.addAnnotation(org.babyfish.jimmer.apt.immutable.generator.Constants.FIXED_INPUT_FIELD_CLASS_NAME);
@@ -931,7 +959,7 @@ public class DtoGenerator {
         }
         boolean isBuilderRequired = isBuildRequired();
         if (prop instanceof DtoProp<?, ?>) {
-            DtoProp<ImmutableType, ImmutableProp> dtoProp = (DtoProp<ImmutableType, ImmutableProp>) prop;
+            DtoProp<ImmutableType, ImmutableProp> dtoProp = asDtoProp(prop);
             for (AnnotationMirror annotationMirror : dtoProp.toTailProp().getBaseProp().getAnnotations()) {
                 if (isBuilderRequired) {
                     String qualifiedName = ((TypeElement) annotationMirror.getAnnotationType()
@@ -1037,7 +1065,7 @@ public class DtoGenerator {
     private String doc(AbstractProp prop, boolean contentOnly) {
         String doc = document.get(prop);
         if (doc == null & prop instanceof DtoProp<?, ?>) {
-            DtoProp<ImmutableType, ImmutableProp> dtoProp = (DtoProp<ImmutableType, ImmutableProp>) prop;
+            DtoProp<ImmutableType, ImmutableProp> dtoProp = asDtoProp(prop);
             if (dtoProp.getBasePropMap().isEmpty() && dtoProp.getFuncName() == null) {
                 doc = baseDocComment(dtoProp.toTailProp().getBaseProp());
             }
@@ -1078,20 +1106,27 @@ public class DtoGenerator {
                 );
         for (AbstractProp abstractProp : dtoType.getProps()) {
             if (abstractProp instanceof FoldProp<?, ?>) {
-                FoldProp<ImmutableType, ImmutableProp> foldProp =
-                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
-                builder.addStatement(
-                        "this.$L = new $T(base)",
-                        foldProp.getName(),
-                        getPropTypeName(foldProp)
-                );
+                FoldProp<ImmutableType, ImmutableProp> foldProp = asFoldProp(abstractProp);
+                if (foldProp.getNullGuardProp() != null) {
+                    builder.addStatement(
+                            "this.$L = $L.get(base) != null ? new $T(base) : null",
+                            foldProp.getName(),
+                            foldNullGuardAccessorFieldName(foldProp),
+                            getPropTypeName(foldProp)
+                    );
+                } else {
+                    builder.addStatement(
+                            "this.$L = new $T(base)",
+                            foldProp.getName(),
+                            getPropTypeName(foldProp)
+                    );
+                }
                 continue;
             }
             if (!(abstractProp instanceof DtoProp<?, ?>)) {
                 continue;
             }
-            DtoProp<ImmutableType, ImmutableProp> prop =
-                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
+            DtoProp<ImmutableType, ImmutableProp> prop = asDtoProp(abstractProp);
             if (isSimpleProp(prop)) {
                 if (prop.isNullable()) {
                     builder.addStatement(
@@ -1118,7 +1153,7 @@ public class DtoGenerator {
                                     "$S\n" +
                                     "$<)",
                             prop.getName(),
-                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                            accessorFieldName(prop.getName()),
                             "Cannot convert \"" +
                                     dtoType.getBaseType().getClassName() +
                                     "\" to " +
@@ -1133,7 +1168,7 @@ public class DtoGenerator {
                     builder.addStatement(
                             "this.$L = $L.get(base)",
                             prop.getName(),
-                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER)
+                            accessorFieldName(prop.getName())
                     );
                 }
             }
@@ -1149,8 +1184,7 @@ public class DtoGenerator {
                 .addParameter(dtoType.getBaseType().getDraftClassName(), "__draft");
         for (AbstractProp abstractProp : dtoType.getProps()) {
             if (abstractProp instanceof FoldProp<?, ?>) {
-                FoldProp<ImmutableType, ImmutableProp> foldProp =
-                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
+                FoldProp<ImmutableType, ImmutableProp> foldProp = asFoldProp(abstractProp);
                 if (foldProp.isNullable()) {
                     builder.beginControlFlow("if (this.$L != null)", foldProp.getName());
                 }
@@ -1163,8 +1197,7 @@ public class DtoGenerator {
             if (!(abstractProp instanceof DtoProp<?, ?>)) {
                 continue;
             }
-            DtoProp<ImmutableType, ImmutableProp> prop =
-                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
+            DtoProp<ImmutableType, ImmutableProp> prop = asDtoProp(abstractProp);
             if (prop.getBaseProp().isJavaFormula()) {
                 continue;
             }
@@ -1182,7 +1215,7 @@ public class DtoGenerator {
                 if (tailBaseProp.isList() && tailBaseProp.isAssociation(true)) {
                     builder.addStatement(
                             "$L.set(__draft, this.$L != null ? this.$L : $T.emptyList())",
-                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                            accessorFieldName(prop.getName()),
                             prop.getName(),
                             prop.getName(),
                             org.babyfish.jimmer.apt.immutable.generator.Constants.COLLECTIONS_CLASS_NAME
@@ -1190,7 +1223,7 @@ public class DtoGenerator {
                 } else {
                     builder.addStatement(
                             "$L.set(__draft, this.$L)",
-                            StringUtil.snake(prop.getName() + "Accessor", StringUtil.SnakeCase.UPPER),
+                            accessorFieldName(prop.getName()),
                             prop.getName()
                     );
                 }
@@ -1298,8 +1331,7 @@ public class DtoGenerator {
         }
         for (AbstractProp abstractProp : dtoType.getProps()) {
             if (abstractProp instanceof FoldProp<?, ?>) {
-                FoldProp<ImmutableType, ImmutableProp> foldProp =
-                        (FoldProp<ImmutableType, ImmutableProp>) abstractProp;
+                FoldProp<ImmutableType, ImmutableProp> foldProp = asFoldProp(abstractProp);
                 stack = addStackOperations(builder, stack, Collections.emptyList());
                 builder.beginControlFlow("if (this.$L != null)", foldProp.getName());
                 if (dtoType.getBaseType().isEntity()) {
@@ -1313,8 +1345,7 @@ public class DtoGenerator {
             if (!(abstractProp instanceof DtoProp<?, ?>)) {
                 continue;
             }
-            DtoProp<ImmutableType, ImmutableProp> prop =
-                    (DtoProp<ImmutableType, ImmutableProp>) abstractProp;
+            DtoProp<ImmutableType, ImmutableProp> prop = asDtoProp(abstractProp);
             List<ImmutableProp> newStack = new ArrayList<>(stack.size() + 2);
             DtoProp<ImmutableType, ImmutableProp> tailProp = prop.toTailProp();
             for (DtoProp<ImmutableType, ImmutableProp> p = prop; p != null; p = p.getNextProp()) {
@@ -1539,12 +1570,22 @@ public class DtoGenerator {
     @SuppressWarnings("unchecked")
     public TypeName getPropTypeName(AbstractProp prop) {
         if (prop instanceof DtoProp<?, ?>) {
-            return getPropTypeName((DtoProp<ImmutableType, ImmutableProp>) prop);
+            return getPropTypeName(asDtoProp(prop));
         }
         if (prop instanceof FoldProp<?, ?>) {
-            return getDtoClassName(targetSimpleName((FoldProp<ImmutableType, ImmutableProp>) prop));
+            return getDtoClassName(targetSimpleName(asFoldProp(prop)));
         }
         return getTypeName(((UserProp)prop).getTypeRef());
+    }
+
+    @SuppressWarnings("unchecked")
+    private DtoProp<ImmutableType, ImmutableProp> asDtoProp(AbstractProp prop) {
+        return (DtoProp<ImmutableType, ImmutableProp>) prop;
+    }
+
+    @SuppressWarnings("unchecked")
+    private FoldProp<ImmutableType, ImmutableProp> asFoldProp(AbstractProp prop) {
+        return (FoldProp<ImmutableType, ImmutableProp>) prop;
     }
 
     private TypeName getPropTypeName(DtoProp<ImmutableType, ImmutableProp> prop) {
@@ -1914,6 +1955,14 @@ public class DtoGenerator {
         return standardTargetSimpleName("TargetOf_" + prop.getName());
     }
 
+    private String accessorFieldName(String propName) {
+        return StringUtil.snake(propName + "Accessor", StringUtil.SnakeCase.UPPER);
+    }
+
+    private String foldNullGuardAccessorFieldName(FoldProp<ImmutableType, ImmutableProp> prop) {
+        return StringUtil.snake(prop.getName() + "NullGuardAccessor", StringUtil.SnakeCase.UPPER);
+    }
+
     private String standardTargetSimpleName(String targetSimpleName) {
         boolean conflict = false;
         for (DtoGenerator generator = this; generator != null; generator = generator.parent) {
@@ -2252,13 +2301,13 @@ public class DtoGenerator {
         if (!prop.isNullable()) {
             return null;
         }
-        if (!(prop instanceof DtoProp<?, ?>)) {
-            return null;
-        }
         if (!dtoType.getModifiers().contains(DtoModifier.INPUT)) {
             return null;
         }
-        DtoModifier modifier = ((DtoProp<?, ?>) prop).getInputModifier();
+        DtoModifier modifier = prop.getInputModifier();
+        if (modifier == null) {
+            return null;
+        }
         if (modifier == DtoModifier.FIXED && !builder) {
             return null;
         }

--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/DtoGenerator.java
@@ -839,7 +839,6 @@ public class DtoGenerator {
         cb.add("$<$<\n)");
     }
 
-    @SuppressWarnings("unchecked")
     private void addField(AbstractProp prop) {
         if (prop instanceof UserProp) {
             addField((UserProp) prop);
@@ -924,7 +923,6 @@ public class DtoGenerator {
         );
     }
 
-    @SuppressWarnings("unchecked")
     private void addAccessors(AbstractProp prop) {
         TypeName typeName = getPropTypeName(prop);
         String getterName = getterName(prop);
@@ -1061,7 +1059,6 @@ public class DtoGenerator {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private String doc(AbstractProp prop, boolean contentOnly) {
         String doc = document.get(prop);
         if (doc == null & prop instanceof DtoProp<?, ?>) {
@@ -1176,7 +1173,6 @@ public class DtoGenerator {
         typeBuilder.addMethod(builder.build());
     }
 
-    @SuppressWarnings("unchecked")
     private void addApplyToDraft() {
         MethodSpec.Builder builder = MethodSpec
                 .methodBuilder("__applyTo")
@@ -1567,7 +1563,6 @@ public class DtoGenerator {
         typeBuilder.addMethod(builder.build());
     }
 
-    @SuppressWarnings("unchecked")
     public TypeName getPropTypeName(AbstractProp prop) {
         if (prop instanceof DtoProp<?, ?>) {
             return getPropTypeName(asDtoProp(prop));
@@ -1854,7 +1849,7 @@ public class DtoGenerator {
         for (AbstractProp prop : dtoType.getProps()) {
             String stateFieldName = stateFieldName(prop, false);
             boolean fuzzy = prop instanceof DtoProp<?, ?> &&
-                    ((DtoProp<?, ?>) prop).getInputModifier() == DtoModifier.FUZZY &&
+                    prop.getInputModifier() == DtoModifier.FUZZY &&
                     prop.isNullable();
             if (stateFieldName != null) {
                 builder.beginControlFlow("if ($L)", stateFieldName);
@@ -2163,7 +2158,6 @@ public class DtoGenerator {
         }
     }
 
-    @SuppressWarnings("unchecked")
     String getterName(AbstractProp prop) {
         TypeName typeName = getPropTypeName(prop);
         String suffix = prop.getAlias();
@@ -2179,7 +2173,6 @@ public class DtoGenerator {
         );
     }
 
-    @SuppressWarnings("unchecked")
     private String setterName(AbstractProp prop) {
         TypeName typeName = getPropTypeName(prop);
         String suffix = prop.getAlias();
@@ -2278,10 +2271,7 @@ public class DtoGenerator {
                 }
             }
             if (baseTypeDoc != null && baseProp != null) {
-                String doc = baseTypeDoc.getParameterValueMap().get(baseProp.getName());
-                if (doc != null) {
-                    return doc;
-                }
+                return baseTypeDoc.getParameterValueMap().get(baseProp.getName());
             }
             return null;
         }
@@ -2319,7 +2309,7 @@ public class DtoGenerator {
 
     private static boolean isFieldNullable(AbstractProp prop) {
         if (prop instanceof DtoProp<?, ?>) {
-            String funcName = ((DtoProp<?, ?>) prop).getFuncName();
+            String funcName = prop.getFuncName();
             return !"null".equals(funcName) && !"notNull".equals(funcName);
         }
         return true;

--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/InputBuilderGenerator.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/dto/InputBuilderGenerator.java
@@ -70,17 +70,11 @@ public class InputBuilderGenerator {
     }
 
     private void addMembers() {
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             addField(prop);
             addStateField(prop);
         }
-        for (UserProp prop : dtoType.getUserProps()) {
-            addField(prop);
-        }
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
-            addSetter(prop);
-        }
-        for (UserProp prop : dtoType.getUserProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
             addSetter(prop);
         }
         addBuild();
@@ -140,7 +134,6 @@ public class InputBuilderGenerator {
         typeBuilder.addMethod(builder.build());
     }
 
-    @SuppressWarnings("unchecked")
     private void addJacksonAnnotations(
             AbstractProp prop,
             MethodSpec.Builder builder
@@ -151,9 +144,9 @@ public class InputBuilderGenerator {
                 builder.addAnnotation(DtoGenerator.annotationOf(anno));
             }
         }
-        if (prop instanceof DtoProp<?, ?>) {
-            DtoProp<?, ImmutableProp> dtoProp = (DtoProp<?, ImmutableProp>) prop;
-            for (AnnotationMirror mirror : dtoProp.toTailProp().getBaseProp().getAnnotations()) {
+        ImmutableProp baseProp = (ImmutableProp) prop.getBasePropOrNull();
+        if (baseProp != null) {
+            for (AnnotationMirror mirror : baseProp.getAnnotations()) {
                 String qualifiedName = ((TypeElement) mirror.getAnnotationType()
                         .asElement())
                         .getQualifiedName()
@@ -172,7 +165,8 @@ public class InputBuilderGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(dtoClassName);
         builder.addStatement("$T _input = new $T()", dtoClassName, dtoClassName);
-        for (DtoProp<ImmutableType, ImmutableProp> prop : dtoType.getDtoProps()) {
+        for (AbstractProp prop : dtoType.getProps()) {
+            DtoModifier inputModifier = prop.getInputModifier();
             if (!prop.isNullable()) {
                 builder.beginControlFlow("if ($L == null)", prop.getName());
                 builder.addStatement(
@@ -188,9 +182,9 @@ public class InputBuilderGenerator {
                         setterName(prop),
                         prop.getName()
                 );
-            } else {
+            } else if (inputModifier != null) {
                 String stateFieldName = parentGenerator.stateFieldName(prop, true);
-                switch (prop.getInputModifier()) {
+                switch (inputModifier) {
                     case FIXED:
                         builder.beginControlFlow("if (!$L)", stateFieldName);
                         builder.addStatement(
@@ -227,25 +221,38 @@ public class InputBuilderGenerator {
                         builder.endControlFlow();
                         break;
                 }
+            } else if (prop instanceof UserProp) {
+                builder.addStatement(
+                        "_input.$L($L)",
+                        setterName((UserProp) prop),
+                        prop.getName()
+                );
+            } else {
+                if (!prop.isNullable()) {
+                    builder.beginControlFlow("if ($L == null)", prop.getName());
+                    builder.addStatement(
+                            "throw $T.$L($T.class, $S)",
+                            Constants.INPUT_CLASS_NAME,
+                            "unknownNonNullProperty",
+                            dtoClassName,
+                            prop.getName()
+                    );
+                    builder.endControlFlow();
+                }
+                builder.addStatement(
+                        "_input.$L($L)",
+                        setterName(prop),
+                        prop.getName()
+                );
             }
-        }
-        for (UserProp prop : dtoType.getUserProps()) {
-            builder.addStatement(
-                    "_input.$L($L)",
-                    setterName(prop),
-                    prop.getName()
-            );
         }
         builder.addStatement("return _input");
         typeBuilder.addMethod(builder.build());
     }
 
     private static boolean isFieldNullable(AbstractProp prop) {
-        if (prop instanceof DtoProp<?, ?>) {
-            String funcName = ((DtoProp<?, ?>) prop).getFuncName();
-            return !"null".equals(funcName) && !"notNull".equals(funcName);
-        }
-        return true;
+        String funcName = prop.getFuncName();
+        return !"null".equals(funcName) && !"notNull".equals(funcName);
     }
 
     private static boolean isJacksonQualifiedName(String qualifiedName) {
@@ -257,17 +264,6 @@ public class InputBuilderGenerator {
         return false;
     }
 
-    private static String setterName(DtoProp<?, ImmutableProp> prop) {
-        String name = prop.getName();
-        if (name.length() > 2 &&
-                name.startsWith("is") &&
-                Character.isUpperCase(name.charAt(2)) &&
-                prop.toTailProp().getBaseProp().getTypeName().equals(TypeName.BOOLEAN)) {
-            return StringUtil.identifier("set", prop.getName().substring(2));
-        }
-        return StringUtil.identifier("set", prop.getName());
-    }
-
     private static String setterName(UserProp prop) {
         String name = prop.getName();
         if (name.length() > 2 &&
@@ -276,6 +272,10 @@ public class InputBuilderGenerator {
                 TypeRef.TN_BOOLEAN.equals(prop.getTypeRef().getTypeName())) {
             return StringUtil.identifier("set", prop.getName().substring(2));
         }
+        return StringUtil.identifier("set", prop.getName());
+    }
+
+    private static String setterName(AbstractProp prop) {
         return StringUtil.identifier("set", prop.getName());
     }
 }

--- a/project/jimmer-dto-compiler/src/main/antlr/org/babyfish/jimmer/dto/compiler/Dto.g4
+++ b/project/jimmer-dto-compiler/src/main/antlr/org/babyfish/jimmer/dto/compiler/Dto.g4
@@ -54,7 +54,19 @@ dtoBody
 
 explicitProp
     :
-    aliasGroup | positiveProp | negativeProp | userProp
+    aliasGroup | foldProp | positiveProp | negativeProp | userProp
+    ;
+
+foldProp
+    :
+    (doc = DocComment)?
+    (annotations += annotation)*
+    'fold' '(' name = Identifier ')'
+    (optional = '?')?
+    (childDoc = DocComment)?
+    (bodyAnnotations += annotation)*
+    ('implements' bodySuperInterfaces += typeRef (',' bodySuperInterfaces += typeRef)*)?
+    dtoBody
     ;
 
 macro

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/AbstractProp.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/AbstractProp.java
@@ -1,5 +1,8 @@
 package org.babyfish.jimmer.dto.compiler;
 
+import org.babyfish.jimmer.dto.compiler.spi.BaseProp;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 public interface AbstractProp {
@@ -17,4 +20,19 @@ public interface AbstractProp {
     List<Anno> getAnnotations();
 
     String getDoc();
+
+    @Nullable
+    default String getFuncName() {
+        return null;
+    }
+
+    @Nullable
+    default DtoModifier getInputModifier() {
+        return null;
+    }
+
+    @Nullable
+    default BaseProp getBasePropOrNull() {
+        return null;
+    }
 }

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoProp.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoProp.java
@@ -15,6 +15,11 @@ public interface DtoProp<T extends BaseType, P extends BaseProp> extends DtoProp
     P getBaseProp();
 
     @Override
+    default P getBasePropOrNull() {
+        return getBaseProp();
+    }
+
+    @Override
     Map<String, P> getBasePropMap();
 
     String getBasePath();

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoType.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoType.java
@@ -36,6 +36,8 @@ public class DtoType<T extends BaseType, P extends BaseProp> {
 
     private List<UserProp> userProps;
 
+    private List<FoldProp<T, P>> foldProps;
+
     private List<DtoProp<T, P>> hiddenFlatProps;
 
     DtoType(
@@ -148,6 +150,21 @@ public class DtoType<T extends BaseType, P extends BaseProp> {
                 }
             }
             userProps = list;
+        }
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<FoldProp<T, P>> getFoldProps() {
+        List<FoldProp<T, P>> list = foldProps;
+        if (list == null) {
+            list = new ArrayList<>();
+            for (AbstractProp prop : props) {
+                if (prop instanceof FoldProp<?, ?>) {
+                    list.add((FoldProp<T, P>) prop);
+                }
+            }
+            foldProps = list;
         }
         return list;
     }

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoType.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoType.java
@@ -96,6 +96,7 @@ public class DtoType<T extends BaseType, P extends BaseProp> {
         return packageName;
     }
 
+    @Nullable
     public String getDoc() {
         return doc;
     }
@@ -117,6 +118,7 @@ public class DtoType<T extends BaseType, P extends BaseProp> {
         return name;
     }
 
+    @NotNull
     public DtoFile getDtoFile() {
         return dtoFile;
     }
@@ -169,7 +171,6 @@ public class DtoType<T extends BaseType, P extends BaseProp> {
         return list;
     }
 
-    @SuppressWarnings("unchecked")
     public List<DtoProp<T, P>> getHiddenFlatProps() {
         List<DtoProp<T, P>> hfps = this.hiddenFlatProps;
         if (hfps == null) {

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -596,7 +596,6 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         return dtoType;
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, AbstractProp> resolveDeclaredProps() {
         if (this.declaredProps != null) {
             return this.declaredProps;

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -717,7 +717,25 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         String name = renameFold ?
                 AliasPattern.join(head.getBaseProp().getName(), foldProp.getName()) :
                 foldProp.getName();
-        return new FoldProp<>(foldProp, name, head.isNullable() || foldProp.isNullable(), targetType);
+        DtoProp<T, P> nullGuardProp;
+        if (head.isNullable()) {
+            nullGuardProp = head;
+        } else if (foldProp.getNullGuardProp() != null) {
+            nullGuardProp = new DtoPropImpl<>(
+                    head,
+                    foldProp.getNullGuardProp(),
+                    aliasPattern
+            );
+        } else {
+            nullGuardProp = null;
+        }
+        return new FoldProp<>(
+                foldProp,
+                name,
+                head.isNullable() || foldProp.isNullable(),
+                nullGuardProp,
+                targetType
+        );
     }
 
     private boolean isExcluded(String alias) {

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -134,6 +134,8 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         for (DtoParser.ExplicitPropContext prop : body.explicitProps) {
             if (prop.aliasGroup() != null) {
                 handleAliasGroup(prop.aliasGroup());
+            } else if (prop.foldProp() != null) {
+                handleFoldProp(prop.foldProp());
             } else if (prop.positiveProp() != null) {
                 handlePositiveProp(prop.positiveProp());
             } else if (prop.negativeProp() != null) {
@@ -141,6 +143,26 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
             } else {
                 handleUserProp(prop.userProp());
             }
+        }
+    }
+
+    private void handleFoldProp(DtoParser.FoldPropContext prop) {
+        FoldPropBuilder<T, P> builder = new FoldPropBuilder<>(this, prop);
+        if (currentAliasGroup != null) {
+            throw ctx.exception(
+                    prop.start.getLine(),
+                    prop.start.getCharPositionInLine(),
+                    "Fold property cannot be declared in alias group"
+            );
+        }
+        if (aliasPositivePropMap.put(builder.getAlias(), builder) != null) {
+            throw ctx.exception(
+                    prop.name.getLine(),
+                    prop.name.getCharPositionInLine(),
+                    "Duplicated property alias \"" +
+                            prop.name.getText() +
+                            "\""
+            );
         }
     }
 

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -626,18 +626,16 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
                             "User defined property cannot be declared under flat type"
                     );
                 }
-                DtoProp<T, P> deeperDtoProp = (DtoProp<T, P>) deeperProp;
-                String alias = deeperDtoProp.getAlias();
-                DtoProp<T, P> dtoProp = new DtoPropImpl<>(head, deeperDtoProp, null);
-                if (isExcluded(alias)) {
+                AbstractProp flatProp = flatProp(head, deeperProp, null, true);
+                if (isExcluded(flatProp.getAlias())) {
                     continue;
                 }
-                if (declaredPropMap.put(alias, dtoProp) != null) {
+                if (declaredPropMap.put(flatProp.getAlias(), flatProp) != null) {
                     throw ctx.exception(
-                            dtoProp.getAliasLine(),
-                            dtoProp.getAliasColumn(),
+                            flatProp.getAliasLine(),
+                            flatProp.getAliasColumn(),
                             "Duplicated property alias \"" +
-                                    alias +
+                                    flatProp.getAlias() +
                                     "\""
                     );
                 }
@@ -651,7 +649,12 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         AbstractProp prop = propBuilder.build(dtoType);
         if (prop instanceof DtoProp<?, ?> && ((DtoProp<?, ?>)prop).isFlat()) {
             for (AbstractProp deeperProp : ((DtoProp<?, ?>)prop).getTargetType().getProps()) {
-                DtoProp<T, P> flattedProp = new DtoPropImpl<>((DtoPropImpl<T, P>) prop, (DtoPropImpl<T, P>)deeperProp, propBuilder.getAliasPattern());
+                AbstractProp flattedProp = flatProp(
+                        (DtoProp<T, P>) prop,
+                        deeperProp,
+                        propBuilder.getAliasPattern(),
+                        true
+                );
                 if (outMap.put(flattedProp.getAlias(), flattedProp) != null) {
                     throw ctx.exception(
                             flattedProp.getAliasLine(),
@@ -671,6 +674,50 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
                             "\""
             );
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private AbstractProp flatProp(
+            DtoProp<T, P> head,
+            AbstractProp deeperProp,
+            AliasPattern aliasPattern,
+            boolean renameFold
+    ) {
+        if (deeperProp instanceof UserProp) {
+            UserProp userProp = (UserProp) deeperProp;
+            throw ctx.exception(
+                    userProp.getAliasLine(),
+                    userProp.getAliasColumn(),
+                    "User defined property cannot be declared under flat type"
+            );
+        }
+        if (deeperProp instanceof DtoProp<?, ?>) {
+            return new DtoPropImpl<>(
+                    (DtoProp<T, P>) head,
+                    (DtoProp<T, P>) deeperProp,
+                    aliasPattern
+            );
+        }
+        FoldProp<T, P> foldProp = (FoldProp<T, P>) deeperProp;
+        List<AbstractProp> props = new ArrayList<>();
+        for (AbstractProp prop : foldProp.getTargetType().getProps()) {
+            props.add(flatProp(head, prop, aliasPattern, false));
+        }
+        DtoType<T, P> targetType = new DtoType<>(
+                dtoType.getBaseType(),
+                dtoType.getPackageName(),
+                dtoType.getModifiers(),
+                foldProp.getTargetType().getAnnotations(),
+                foldProp.getTargetType().getSuperInterfaces(),
+                null,
+                dtoType.getDtoFile(),
+                foldProp.getTargetType().getDoc()
+        );
+        targetType.setProps(Collections.unmodifiableList(props));
+        String name = renameFold ?
+                AliasPattern.join(head.getBaseProp().getName(), foldProp.getName()) :
+                foldProp.getName();
+        return new FoldProp<>(foldProp, name, head.isNullable() || foldProp.isNullable(), targetType);
     }
 
     private boolean isExcluded(String alias) {

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
@@ -1,0 +1,92 @@
+package org.babyfish.jimmer.dto.compiler;
+
+import org.babyfish.jimmer.dto.compiler.spi.BaseProp;
+import org.babyfish.jimmer.dto.compiler.spi.BaseType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class FoldProp<T extends BaseType, P extends BaseProp> implements AbstractProp {
+
+    private final String name;
+
+    private final int line;
+
+    private final int col;
+
+    private final boolean nullable;
+
+    private final List<Anno> annotations;
+
+    @Nullable
+    private final String doc;
+
+    private final DtoType<T, P> targetType;
+
+    FoldProp(
+            String name,
+            int line,
+            int col,
+            boolean nullable,
+            List<Anno> annotations,
+            @Nullable String doc,
+            DtoType<T, P> targetType
+    ) {
+        this.name = name;
+        this.line = line;
+        this.col = col;
+        this.nullable = nullable;
+        this.annotations = annotations;
+        this.doc = doc;
+        this.targetType = targetType;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getAlias() {
+        return name;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    @Override
+    public int getAliasLine() {
+        return line;
+    }
+
+    @Override
+    public int getAliasColumn() {
+        return col;
+    }
+
+    @Override
+    public List<Anno> getAnnotations() {
+        return annotations;
+    }
+
+    @Nullable
+    @Override
+    public String getDoc() {
+        return doc;
+    }
+
+    public DtoType<T, P> getTargetType() {
+        return targetType;
+    }
+
+    @Override
+    public String toString() {
+        return (nullable ? "@optional " : "") +
+                "fold(" +
+                name +
+                "): " +
+                targetType;
+    }
+}

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
@@ -21,6 +21,9 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
     @Nullable
     private final String doc;
 
+    @Nullable
+    private final DtoProp<T, P> nullGuardProp;
+
     private final DtoType<T, P> targetType;
 
     FoldProp(
@@ -30,6 +33,7 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
             boolean nullable,
             List<Anno> annotations,
             @Nullable String doc,
+            @Nullable DtoProp<T, P> nullGuardProp,
             DtoType<T, P> targetType
     ) {
         this.name = name;
@@ -38,6 +42,7 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
         this.nullable = nullable;
         this.annotations = annotations;
         this.doc = doc;
+        this.nullGuardProp = nullGuardProp;
         this.targetType = targetType;
     }
 
@@ -45,6 +50,7 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
             FoldProp<T, P> original,
             String name,
             boolean nullable,
+            @Nullable DtoProp<T, P> nullGuardProp,
             DtoType<T, P> targetType
     ) {
         this.name = name;
@@ -53,6 +59,7 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
         this.nullable = nullable;
         this.annotations = original.annotations;
         this.doc = original.doc;
+        this.nullGuardProp = nullGuardProp;
         this.targetType = targetType;
     }
 
@@ -94,6 +101,11 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
 
     public DtoType<T, P> getTargetType() {
         return targetType;
+    }
+
+    @Nullable
+    public DtoProp<T, P> getNullGuardProp() {
+        return nullGuardProp;
     }
 
     @Override

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldProp.java
@@ -41,6 +41,21 @@ public class FoldProp<T extends BaseType, P extends BaseProp> implements Abstrac
         this.targetType = targetType;
     }
 
+    FoldProp(
+            FoldProp<T, P> original,
+            String name,
+            boolean nullable,
+            DtoType<T, P> targetType
+    ) {
+        this.name = name;
+        this.line = original.line;
+        this.col = original.col;
+        this.nullable = nullable;
+        this.annotations = original.annotations;
+        this.doc = original.doc;
+        this.targetType = targetType;
+    }
+
     @Override
     public String getName() {
         return name;

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldPropBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldPropBuilder.java
@@ -1,0 +1,80 @@
+package org.babyfish.jimmer.dto.compiler;
+
+import org.babyfish.jimmer.dto.compiler.spi.BaseProp;
+import org.babyfish.jimmer.dto.compiler.spi.BaseType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class FoldPropBuilder<T extends BaseType, P extends BaseProp> implements AbstractPropBuilder {
+
+    private final String name;
+
+    private final int line;
+
+    private final int col;
+
+    private final boolean nullable;
+
+    private final List<Anno> annotations;
+
+    private final String doc;
+
+    private final DtoTypeBuilder<T, P> targetTypeBuilder;
+
+    FoldPropBuilder(
+            DtoTypeBuilder<T, P> parent,
+            DtoParser.FoldPropContext prop
+    ) {
+        name = prop.name.getText();
+        line = prop.name.getLine();
+        col = prop.name.getCharPositionInLine();
+        nullable = prop.optional != null;
+        if (prop.annotations.isEmpty()) {
+            annotations = Collections.emptyList();
+        } else {
+            AnnoParser parser = new AnnoParser(parent.ctx);
+            List<Anno> parsedAnnotations = new ArrayList<>(prop.annotations.size());
+            for (DtoParser.AnnotationContext annotation : prop.annotations) {
+                parsedAnnotations.add(parser.parse(annotation));
+            }
+            annotations = Collections.unmodifiableList(parsedAnnotations);
+        }
+        doc = Docs.parse(prop.doc);
+        targetTypeBuilder = new DtoTypeBuilder<>(
+                null,
+                parent.baseType,
+                prop.dtoBody(),
+                null,
+                Docs.parse(prop.childDoc),
+                parent.modifiers,
+                prop.bodyAnnotations,
+                prop.bodySuperInterfaces,
+                parent.ctx
+        );
+    }
+
+    @Override
+    public String getAlias() {
+        return name;
+    }
+
+    @Override
+    public AliasPattern getAliasPattern() {
+        return null;
+    }
+
+    @Override
+    public FoldProp<T, P> build(DtoType<?, ?> type) {
+        return new FoldProp<>(
+                name,
+                line,
+                col,
+                nullable,
+                annotations,
+                doc,
+                targetTypeBuilder.build()
+        );
+    }
+}

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldPropBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/FoldPropBuilder.java
@@ -74,6 +74,7 @@ class FoldPropBuilder<T extends BaseType, P extends BaseProp> implements Abstrac
                 nullable,
                 annotations,
                 doc,
+                null,
                 targetTypeBuilder.build()
         );
     }

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -384,6 +384,77 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testFold() {
+        List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
+                "BookView {\n" +
+                        "    id\n" +
+                        "    fold(summary) {\n" +
+                        "        name\n" +
+                        "        edition\n" +
+                        "    }\n" +
+                        "    fold(details)? {\n" +
+                        "        price\n" +
+                        "        fold(audit) {\n" +
+                        "            tenant\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
+        );
+        assertContentEquals(
+                "BookView {" +
+                        "--->id, " +
+                        "--->fold(summary): {" +
+                        "--->--->name, " +
+                        "--->--->edition" +
+                        "--->}, " +
+                        "--->@optional fold(details): {" +
+                        "--->--->price, " +
+                        "--->--->fold(audit): {" +
+                        "--->--->--->tenant" +
+                        "--->--->}" +
+                        "--->}" +
+                        "}",
+                dtoTypes.get(0).toString()
+        );
+        Assertions.assertEquals(2, dtoTypes.get(0).getFoldProps().size());
+        Assertions.assertFalse(dtoTypes.get(0).getFoldProps().get(0).isNullable());
+        Assertions.assertTrue(dtoTypes.get(0).getFoldProps().get(1).isNullable());
+        Assertions.assertEquals(
+                "audit",
+                dtoTypes.get(0)
+                        .getFoldProps()
+                        .get(1)
+                        .getTargetType()
+                        .getFoldProps()
+                        .get(0)
+                        .getName()
+        );
+    }
+
+    @Test
+    public void testFlatInsideFold() {
+        List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
+                "BookView {\n" +
+                        "    fold(storeInfo) {\n" +
+                        "        flat(store) {\n" +
+                        "            name as storeName\n" +
+                        "            website\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
+        );
+        assertContentEquals(
+                "BookView {" +
+                        "--->fold(storeInfo): {" +
+                        "--->--->@optional store.name as storeName, " +
+                        "--->--->@optional store.website" +
+                        "--->}" +
+                        "}",
+                dtoTypes.get(0).toString()
+        );
+    }
+
+    @Test
     public void testFlat2() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.treeNode(
                 "FlatTreeNode {\n" +

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -455,6 +455,27 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testFoldInsideFlat() {
+        List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
+                "BookView {\n" +
+                        "    flat(store) {\n" +
+                        "        fold(key) {\n" +
+                        "            name\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
+        );
+        assertContentEquals(
+                "BookView {" +
+                        "--->@optional fold(storeKey): {" +
+                        "--->--->@optional store.name" +
+                        "--->}" +
+                        "}",
+                dtoTypes.get(0).toString()
+        );
+    }
+
+    @Test
     public void testFlat2() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.treeNode(
                 "FlatTreeNode {\n" +

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -69,6 +69,7 @@ import org.babyfish.jimmer.dto.compiler.Constants
 import org.babyfish.jimmer.dto.compiler.DtoModifier
 import org.babyfish.jimmer.dto.compiler.DtoProp
 import org.babyfish.jimmer.dto.compiler.DtoType
+import org.babyfish.jimmer.dto.compiler.FoldProp
 import org.babyfish.jimmer.dto.compiler.LikeOption
 import org.babyfish.jimmer.dto.compiler.PropConfig.PathNode
 import org.babyfish.jimmer.dto.compiler.PropConfig.Predicate
@@ -253,10 +254,13 @@ class DtoGenerator private constructor(
                 collectImports(targetType, packages)
             } else {
                 prop.baseProp.targetType?.className?.packageName?.let {
-                    packages += it
-                }
+                packages += it
             }
         }
+        for (foldProp in dtoType.foldProps) {
+            collectImports(foldProp.targetType, packages)
+        }
+    }
     }
 
     private fun TypeSpec.Builder.addTypeAnnotations() {
@@ -336,14 +340,12 @@ class DtoGenerator private constructor(
             addConverterConstructor()
         }
 
-        for (prop in dtoType.dtoProps) {
+        for (prop in dtoType.props) {
             addProp(prop)
-            addStateProp(prop)
+            if (prop is DtoProp<*, *>) {
+                addStateProp(prop as DtoProp<ImmutableType, ImmutableProp>)
+            }
         }
-        for (prop in dtoType.userProps) {
-            addProp(prop)
-        }
-
         if (isSpecification) {
             addEntityType()
             addApplyTo()
@@ -390,6 +392,17 @@ class DtoGenerator private constructor(
                     targetSimpleName(prop)
                 ).generate(emptyList())
             }
+        }
+        for (foldProp in dtoType.foldProps) {
+            DtoGenerator(
+                ctx,
+                docMetadata,
+                mutable,
+                foldProp.targetType,
+                null,
+                this,
+                targetSimpleName(foldProp)
+            ).generate(emptyList())
         }
 
         if (isHibernateValidatorEnhancementRequired) {
@@ -463,8 +476,27 @@ class DtoGenerator private constructor(
                 addHiddenFetcherField(hiddenFlatProp)
             }
         }
+        for (foldProp in dtoType.foldProps) {
+            addFoldFetcherFields(foldProp.targetType)
+        }
         unindent()
         add("}")
+    }
+
+    private fun CodeBlock.Builder.addFoldFetcherFields(dtoType: DtoType<ImmutableType, ImmutableProp>) {
+        for (prop in dtoType.dtoProps) {
+            if (prop.nextProp === null) {
+                addFetcherField(prop)
+            }
+        }
+        for (hiddenFlatProp in dtoType.hiddenFlatProps) {
+            if (!hiddenFlatProp.baseProp.isId) {
+                addHiddenFetcherField(hiddenFlatProp)
+            }
+        }
+        for (foldProp in dtoType.foldProps) {
+            addFoldFetcherFields(foldProp.targetType)
+        }
     }
 
     private fun CodeBlock.Builder.addFetcherField(prop: DtoProp<ImmutableType, ImmutableProp>) {
@@ -720,6 +752,14 @@ class DtoGenerator private constructor(
         for (childProp in targetDtoType.dtoProps) {
             addHiddenFetcherField(childProp)
         }
+        for (hiddenFlatProp in targetDtoType.hiddenFlatProps) {
+            if (!hiddenFlatProp.baseProp.isId) {
+                addHiddenFetcherField(hiddenFlatProp)
+            }
+        }
+        for (foldProp in targetDtoType.foldProps) {
+            addFoldFetcherFields(foldProp.targetType)
+        }
         unindent()
         add("\n}\n")
     }
@@ -841,7 +881,7 @@ class DtoGenerator private constructor(
             FunSpec
                 .constructorBuilder()
                 .apply {
-                    for (prop in dtoType.dtoProps) {
+                    for (prop in dtoType.props) {
                         addParameter(
                             ParameterSpec.builder(prop.name, propTypeName(prop))
                                 .apply {
@@ -870,19 +910,6 @@ class DtoGenerator private constructor(
                                     .build()
                             )
                         }
-                    }
-                    for (prop in dtoType.userProps) {
-                        addParameter(
-                            ParameterSpec.builder(prop.name, typeName(prop.typeRef))
-                                .apply {
-                                    if (prop.defaultValueText !== null) {
-                                        defaultValue(prop.defaultValueText!!)
-                                    } else if (prop.isNullable) {
-                                        defaultValue("null")
-                                    }
-                                }
-                                .build()
-                        )
                     }
                 }
                 .build()
@@ -915,7 +942,9 @@ class DtoGenerator private constructor(
                         .indent()
                         .add("\n")
                         .apply {
-                            if (prop is DtoProp<*, *>) {
+                            if (prop is FoldProp<*, *>) {
+                                add("%T(base)", propTypeName(prop).copy(nullable = false))
+                            } else if (prop is DtoProp<*, *>) {
                                 if (isSimpleProp(prop as DtoProp<ImmutableType, ImmutableProp>)) {
                                     add("base.%L", prop.baseProp.name)
                                 } else if (!prop.isNullable && prop.isBaseNullable) {
@@ -956,7 +985,8 @@ class DtoGenerator private constructor(
                                     }
                                 }
                             } else {
-                                add("%N", prop.alias)
+                                val userProp = prop as UserProp
+                                add("%N", userProp.alias)
                             }
                         }
                         .unindent()
@@ -1060,25 +1090,49 @@ class DtoGenerator private constructor(
     }
 
     private fun addToEntityImpl() {
+        addApplyToDraft()
         typeBuilder.addFunction(
             FunSpec
                 .builder(if (dtoType.baseType.isEntity) "toEntityImpl" else "toImmutableImpl")
                 .addKdoc(DOC_EXPLICIT_FUN)
                 .addModifiers(KModifier.PRIVATE)
                 .addParameter("_draft", dtoType.baseType.draftClassName)
+                .addStatement("this.__applyTo(_draft)")
+                .build()
+        )
+    }
+
+    private fun addApplyToDraft() {
+        typeBuilder.addFunction(
+            FunSpec
+                .builder("__applyTo")
+                .addModifiers(KModifier.INTERNAL)
+                .addParameter("_draft", dtoType.baseType.draftClassName)
                 .apply {
-                    for (prop in dtoType.dtoProps) {
-                        val baseProp = prop.toTailProp().baseProp
-                        if (baseProp.isKotlinFormula) {
-                            continue
-                        }
-                        val statePropName = statePropName(prop, false)
-                        if (statePropName !== null) {
-                            beginControlFlow("if (%L)", statePropName)
-                            addDraftAssignment(prop, prop.name)
-                            endControlFlow()
-                        } else {
-                            addDraftAssignment(prop, prop.name)
+                    for (prop in dtoType.props) {
+                        when (prop) {
+                            is FoldProp<*, *> -> {
+                                if (prop.isNullable) {
+                                    addStatement("this.%L?.__applyTo(_draft)", prop.name)
+                                } else {
+                                    addStatement("this.%L.__applyTo(_draft)", prop.name)
+                                }
+                            }
+                            is DtoProp<*, *> -> {
+                                val dtoProp = prop as DtoProp<ImmutableType, ImmutableProp>
+                                val baseProp = dtoProp.toTailProp().baseProp
+                                if (baseProp.isKotlinFormula) {
+                                    continue
+                                }
+                                val statePropName = statePropName(dtoProp, false)
+                                if (statePropName !== null) {
+                                    beginControlFlow("if (%L)", statePropName)
+                                    addDraftAssignment(dtoProp, dtoProp.name)
+                                    endControlFlow()
+                                } else {
+                                    addDraftAssignment(dtoProp, dtoProp.name)
+                                }
+                            }
                         }
                     }
                 }
@@ -1145,18 +1199,39 @@ class DtoGenerator private constructor(
                         )
                     }
                     var stack = emptyList<ImmutableProp>()
-                    for (prop in dtoType.dtoProps) {
-                        val newStack = mutableListOf<ImmutableProp>()
-                        val tailProp = prop.toTailProp()
-                        var p: DtoProp<ImmutableType, ImmutableProp>? = prop
-                        while (p != null) {
-                            if (p !== tailProp || p.getTargetType() != null) {
-                                newStack.add(p.getBaseProp())
+                    for (prop in dtoType.props) {
+                        when (prop) {
+                            is FoldProp<*, *> -> {
+                                stack = addStackOperations(stack, emptyList())
+                                if (prop.isNullable) {
+                                    if (dtoType.baseType.isEntity) {
+                                        addStatement("this.%L?.applyTo(args)", prop.name)
+                                    } else {
+                                        addStatement("this.%L?.applyTo(_applier)", prop.name)
+                                    }
+                                } else {
+                                    if (dtoType.baseType.isEntity) {
+                                        addStatement("this.%L.applyTo(args)", prop.name)
+                                    } else {
+                                        addStatement("this.%L.applyTo(_applier)", prop.name)
+                                    }
+                                }
                             }
-                            p = p.getNextProp()
+                            is DtoProp<*, *> -> {
+                                val dtoProp = prop as DtoProp<ImmutableType, ImmutableProp>
+                                val newStack = mutableListOf<ImmutableProp>()
+                                val tailProp = dtoProp.toTailProp()
+                                var p: DtoProp<ImmutableType, ImmutableProp>? = dtoProp
+                                while (p != null) {
+                                    if (p !== tailProp || p.getTargetType() != null) {
+                                        newStack.add(p.getBaseProp())
+                                    }
+                                    p = p.getNextProp()
+                                }
+                                stack = addStackOperations(stack, newStack)
+                                addPredicateOperation(dtoProp)
+                            }
                         }
-                        stack = addStackOperations(stack, newStack)
-                        addPredicateOperation(prop)
                     }
                     addStackOperations(stack, emptyList())
                 }
@@ -1522,10 +1597,14 @@ class DtoGenerator private constructor(
     @Suppress("UNCHECKED_CAST")
     fun propTypeName(prop: AbstractProp): TypeName =
         when (prop) {
+            is FoldProp<*, *> -> propTypeName(prop as FoldProp<ImmutableType, ImmutableProp>)
             is DtoProp<*, *> -> propTypeName(prop as DtoProp<ImmutableType, ImmutableProp>)
             is UserProp -> typeName(prop.typeRef)
             else -> error("Internal bug")
         }
+
+    private fun propTypeName(prop: FoldProp<ImmutableType, ImmutableProp>): TypeName =
+        getDtoClassName(targetSimpleName(prop)).copy(nullable = prop.isNullable)
 
     private fun propTypeName(prop: DtoProp<ImmutableType, ImmutableProp>): TypeName {
 
@@ -1620,6 +1699,9 @@ class DtoGenerator private constructor(
         }
         return standardTargetSimpleName("TargetOf_${prop.name}")
     }
+
+    private fun targetSimpleName(prop: FoldProp<ImmutableType, ImmutableProp>): String =
+        standardTargetSimpleName("TargetOf_${prop.name}")
 
     private fun standardTargetSimpleName(targetSimpleName: String): String {
         var conflict = false
@@ -1792,14 +1874,14 @@ class DtoGenerator private constructor(
                 .returns(getDtoClassName())
                 .apply {
                     val args = mutableListOf<String>()
-                    for (dtoProp in dtoType.dtoProps) {
+                    for (prop in dtoType.props) {
                         addParameter(
-                            ParameterSpec.builder(dtoProp.name, propTypeName(dtoProp))
-                                .defaultValue("this.${dtoProp.name}")
+                            ParameterSpec.builder(prop.name, propTypeName(prop))
+                                .defaultValue("this.${prop.name}")
                                 .build()
                         )
-                        args += dtoProp.name
-                        statePropName(dtoProp, false)?.let {
+                        args += prop.name
+                        statePropName(prop, false)?.let {
                             addParameter(
                                 ParameterSpec.builder(it, BOOLEAN)
                                     .defaultValue("this.$it")
@@ -1807,14 +1889,6 @@ class DtoGenerator private constructor(
                             )
                             args += it
                         }
-                    }
-                    for (userProp in dtoType.userProps) {
-                        addParameter(
-                            ParameterSpec.builder(userProp.alias, typeName(userProp.typeRef))
-                                .defaultValue("this.${userProp.alias}")
-                                .build()
-                        )
-                        args += userProp.alias
                     }
                     addStatement("return %T(%L)", getDtoClassName(), args.joinToString())
                 }
@@ -1916,11 +1990,11 @@ class DtoGenerator private constructor(
                                 addStatement("val builder = StringBuilder()")
                                 addStatement("var separator = \"\"")
                                 addStatement("builder.append(%S).append('(')", simpleNamePart())
-                                for (prop in dtoType.getDtoProps()) {
+                                for (prop in dtoType.props) {
                                     val stateFieldName = statePropName(prop, false)
                                     if (stateFieldName != null) {
                                         beginControlFlow("if (%L)", stateFieldName)
-                                    } else if (prop.getInputModifier() == DtoModifier.FUZZY) {
+                                    } else if (prop is DtoProp<*, *> && prop.getInputModifier() == DtoModifier.FUZZY) {
                                         beginControlFlow("if (%L != null)", prop.getName())
                                     }
                                     if (prop.getName() == "builder") {
@@ -1938,25 +2012,9 @@ class DtoGenerator private constructor(
                                         )
                                         addStatement("separator = \", \"")
                                     }
-                                    if (stateFieldName != null || prop.getInputModifier() == DtoModifier.FUZZY) {
+                                    if (stateFieldName != null || (prop is DtoProp<*, *> && prop.getInputModifier() == DtoModifier.FUZZY)) {
                                         endControlFlow()
                                     }
-                                }
-                                for (prop in dtoType.getUserProps()) {
-                                    if (prop.alias == "builder") {
-                                        addStatement(
-                                            "builder.append(separator).append(%S).append(this.%L)",
-                                            prop.alias + '=',
-                                            prop.alias
-                                        )
-                                    } else {
-                                        addStatement(
-                                            "builder.append(separator).append(%S).append(%L)",
-                                            prop.alias + '=',
-                                            prop.alias
-                                        )
-                                    }
-                                    addStatement("separator = \", \"")
                                 }
                                 addStatement("builder.append(')')")
                                 addStatement("return builder.toString()")

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -343,7 +343,7 @@ class DtoGenerator private constructor(
         for (prop in dtoType.props) {
             addProp(prop)
             if (prop is DtoProp<*, *>) {
-                addStateProp(prop as DtoProp<ImmutableType, ImmutableProp>)
+                addStateProp(prop.asDtoProp())
             }
         }
         if (isSpecification) {
@@ -373,6 +373,9 @@ class DtoGenerator private constructor(
                         addMetadata()
                         for (prop in dtoType.dtoProps) {
                             addAccessorField(prop)
+                        }
+                        for (prop in dtoType.foldProps) {
+                            addFoldNullGuardAccessorField(prop)
                         }
                     }
                     .build()
@@ -812,7 +815,7 @@ class DtoGenerator private constructor(
                                 .useSiteTarget(AnnotationSpec.UseSiteTarget.PARAM)
                                 .apply {
                                     addMember("%S", prop.name)
-                                    if (!prop.isNullable) {
+                                    if (!isGeneratedNullable(prop)) {
                                         addMember("required = true")
                                     }
                                 }
@@ -820,7 +823,7 @@ class DtoGenerator private constructor(
                         )
                     }
                     if (prop is DtoProp<*, *>) {
-                        val dtoProp = prop as DtoProp<ImmutableType, ImmutableProp>
+                        val dtoProp = prop.asDtoProp()
                         if (dtoType.modifiers.contains(DtoModifier.INPUT) && dtoProp.inputModifier == DtoModifier.FIXED) {
                             addAnnotation(FIXED_INPUT_FIELD_CLASS_NAME)
                         }
@@ -885,7 +888,7 @@ class DtoGenerator private constructor(
                         addParameter(
                             ParameterSpec.builder(prop.name, propTypeName(prop))
                                 .apply {
-                                    if (prop.isNullable) {
+                                    if (isGeneratedNullable(prop)) {
                                         defaultValue("null")
                                     } else if (propTypeName(prop) == BOOLEAN) {
                                         defaultValue("false")
@@ -943,15 +946,26 @@ class DtoGenerator private constructor(
                         .add("\n")
                         .apply {
                             if (prop is FoldProp<*, *>) {
-                                add("%T(base)", propTypeName(prop).copy(nullable = false))
+                                val foldProp = prop.asFoldProp()
+                                if (foldProp.nullGuardProp != null) {
+                                    add(
+                                        "%L.get<%T>(base)?.let { %T(base) }",
+                                        foldNullGuardAccessorFieldName(foldProp),
+                                        ANY.copy(nullable = true),
+                                        propTypeName(foldProp).copy(nullable = false)
+                                    )
+                                } else {
+                                    add("%T(base)", propTypeName(foldProp).copy(nullable = false))
+                                }
                             } else if (prop is DtoProp<*, *>) {
-                                if (isSimpleProp(prop as DtoProp<ImmutableType, ImmutableProp>)) {
-                                    add("base.%L", prop.baseProp.name)
-                                } else if (!prop.isNullable && prop.isBaseNullable) {
+                                val dtoProp = prop.asDtoProp()
+                                if (isSimpleProp(dtoProp)) {
+                                    add("base.%L", dtoProp.baseProp.name)
+                                } else if (!dtoProp.isNullable && dtoProp.isBaseNullable) {
                                     add(
                                         "%L.get<%T>(\n",
-                                        StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER),
-                                        propTypeName(prop)
+                                        accessorFieldName(dtoProp.name),
+                                        propTypeName(dtoProp)
                                     )
                                     indent()
                                     add("base,\n")
@@ -959,28 +973,28 @@ class DtoGenerator private constructor(
                                         "%S\n",
                                         "Cannot convert \"${dtoType.baseType.className}\" to " +
                                                 "\"${getDtoClassName()}\" because the cannot get non-null " +
-                                                "value for \"${prop.name}\""
+                                                "value for \"${dtoProp.name}\""
                                     )
                                     unindent()
                                     add(")")
                                 } else {
                                     add(
                                         "%L.get<%T>(base)",
-                                        StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER),
-                                        propTypeName(prop)
+                                        accessorFieldName(dtoProp.name),
+                                        propTypeName(dtoProp)
                                     )
                                 }
-                                statePropName(prop, false)?.let {
-                                    if (isSimpleProp(prop as DtoProp<ImmutableType, ImmutableProp>)) {
+                                statePropName(dtoProp, false)?.let {
+                                    if (isSimpleProp(dtoProp)) {
                                         add(
                                             ",\n%T.%L.isLoaded(base)",
                                             dtoType.baseType.propsClassName,
-                                            StringUtil.snake(prop.baseProp.name, SnakeCase.UPPER)
+                                            StringUtil.snake(dtoProp.baseProp.name, SnakeCase.UPPER)
                                         )
                                     } else {
                                         add(
                                             ",\n%L.isLoaded(base)\n",
-                                            StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER)
+                                            accessorFieldName(dtoProp.name)
                                         )
                                     }
                                 }
@@ -1119,7 +1133,7 @@ class DtoGenerator private constructor(
                                 }
                             }
                             is DtoProp<*, *> -> {
-                                val dtoProp = prop as DtoProp<ImmutableType, ImmutableProp>
+                                val dtoProp = prop.asDtoProp()
                                 val baseProp = dtoProp.toTailProp().baseProp
                                 if (baseProp.isKotlinFormula) {
                                     continue
@@ -1148,13 +1162,13 @@ class DtoGenerator private constructor(
             if (prop.isNullable && baseProp.let { it.isList && it.isAssociation(true) }) {
                 addStatement(
                     "%L.set(_draft, %L)",
-                    StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER),
+                    accessorFieldName(prop.name),
                     valueExpr
                 )
             } else {
                 addStatement(
                     "%L.set(_draft, %L)",
-                    StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER),
+                    accessorFieldName(prop.name),
                     valueExpr
                 )
             }
@@ -1203,7 +1217,7 @@ class DtoGenerator private constructor(
                         when (prop) {
                             is FoldProp<*, *> -> {
                                 stack = addStackOperations(stack, emptyList())
-                                if (prop.isNullable) {
+                                if (isGeneratedNullable(prop)) {
                                     if (dtoType.baseType.isEntity) {
                                         addStatement("this.%L?.applyTo(args)", prop.name)
                                     } else {
@@ -1218,7 +1232,7 @@ class DtoGenerator private constructor(
                                 }
                             }
                             is DtoProp<*, *> -> {
-                                val dtoProp = prop as DtoProp<ImmutableType, ImmutableProp>
+                                val dtoProp = prop.asDtoProp()
                                 val newStack = mutableListOf<ImmutableProp>()
                                 val tailProp = dtoProp.toTailProp()
                                 var p: DtoProp<ImmutableType, ImmutableProp>? = dtoProp
@@ -1354,9 +1368,32 @@ class DtoGenerator private constructor(
         if (isSimpleProp(prop)) {
             return
         }
+        addAccessorField(
+            prop,
+            accessorFieldName(prop.name),
+            accessorAcceptsNull(prop),
+            true
+        )
+    }
 
+    private fun TypeSpec.Builder.addFoldNullGuardAccessorField(prop: FoldProp<ImmutableType, ImmutableProp>) {
+        val nullGuardProp = prop.nullGuardProp ?: return
+        addAccessorField(
+            nullGuardProp,
+            foldNullGuardAccessorFieldName(prop),
+            true,
+            false
+        )
+    }
+
+    private fun TypeSpec.Builder.addAccessorField(
+        prop: DtoProp<ImmutableType, ImmutableProp>,
+        fieldName: String,
+        acceptNull: Boolean,
+        withConverters: Boolean,
+    ) {
         val builder = PropertySpec.builder(
-            StringUtil.snake("${prop.name}Accessor", SnakeCase.UPPER),
+            fieldName,
             DTO_PROP_ACCESSOR,
             KModifier.PRIVATE
         ).initializer(
@@ -1366,16 +1403,7 @@ class DtoGenerator private constructor(
                     add("%T(", DTO_PROP_ACCESSOR)
                     indent()
 
-                    if (prop.isNullable() && (!prop.toTailProp().getBaseProp().isNullable ||
-                                dtoType.modifiers.contains(DtoModifier.SPECIFICATION) ||
-                                dtoType.modifiers.contains(DtoModifier.FUZZY) ||
-                                prop.inputModifier == DtoModifier.FUZZY
-                                )
-                    ) {
-                        add("\nfalse")
-                    } else {
-                        add("\ntrue")
-                    }
+                    add("\n%L", acceptNull)
 
                     if (prop.nextProp === null) {
                         add(
@@ -1404,7 +1432,7 @@ class DtoGenerator private constructor(
 
                     val tailProp = prop.toTailProp()
                     val tailBaseProp = tailProp.baseProp
-                    if (prop.isIdOnly) {
+                    if (withConverters && prop.isIdOnly) {
                         if (dtoType.modifiers.contains(DtoModifier.SPECIFICATION)) {
                             add(",\nnull")
                         } else {
@@ -1425,7 +1453,7 @@ class DtoGenerator private constructor(
                             addConverterLoading(prop, false)
                             add(")")
                         }
-                    } else if (tailProp.targetType != null) {
+                    } else if (withConverters && tailProp.targetType != null) {
                         if (dtoType.modifiers.contains(DtoModifier.SPECIFICATION)) {
                             add(",\nnull")
                         } else {
@@ -1456,7 +1484,7 @@ class DtoGenerator private constructor(
                             unindent()
                             add("\n}")
                         }
-                    } else if (prop.enumType !== null) {
+                    } else if (withConverters && prop.enumType !== null) {
                         val enumType = prop.enumType!!
                         val enumTypeName = tailBaseProp.targetTypeName(overrideNullable = false)
                         if (dtoType.modifiers.contains(DtoModifier.SPECIFICATION)) {
@@ -1477,7 +1505,7 @@ class DtoGenerator private constructor(
                         addValueToEnum(prop)
                         unindent()
                         add("}")
-                    } else if (prop.dtoConverterMetadata != null) {
+                    } else if (withConverters && prop.dtoConverterMetadata != null) {
                         add(",\n{ ")
                         addConverterLoading(prop, true)
                         add(".output(it) }")
@@ -1493,6 +1521,14 @@ class DtoGenerator private constructor(
         )
         addProperty(builder.build())
     }
+
+    private fun accessorAcceptsNull(prop: DtoProp<ImmutableType, ImmutableProp>): Boolean =
+        !(prop.isNullable() && (!prop.toTailProp().getBaseProp().isNullable ||
+                dtoType.modifiers.contains(DtoModifier.SPECIFICATION) ||
+                dtoType.modifiers.contains(DtoModifier.FUZZY) ||
+                prop.inputModifier == DtoModifier.FUZZY
+                )
+        )
 
     private fun TypeSpec.Builder.addSpecificationConverter(prop: DtoProp<ImmutableType, ImmutableProp>) {
         if (!isSpecificationConverterRequired(prop)) {
@@ -1597,14 +1633,26 @@ class DtoGenerator private constructor(
     @Suppress("UNCHECKED_CAST")
     fun propTypeName(prop: AbstractProp): TypeName =
         when (prop) {
-            is FoldProp<*, *> -> propTypeName(prop as FoldProp<ImmutableType, ImmutableProp>)
-            is DtoProp<*, *> -> propTypeName(prop as DtoProp<ImmutableType, ImmutableProp>)
+            is FoldProp<*, *> -> propTypeName(prop.asFoldProp())
+            is DtoProp<*, *> -> propTypeName(prop.asDtoProp())
             is UserProp -> typeName(prop.typeRef)
             else -> error("Internal bug")
         }
 
+    @Suppress("UNCHECKED_CAST")
+    private fun AbstractProp.asDtoProp(): DtoProp<ImmutableType, ImmutableProp> =
+        this as DtoProp<ImmutableType, ImmutableProp>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun AbstractProp.asFoldProp(): FoldProp<ImmutableType, ImmutableProp> =
+        this as FoldProp<ImmutableType, ImmutableProp>
+
     private fun propTypeName(prop: FoldProp<ImmutableType, ImmutableProp>): TypeName =
-        getDtoClassName(targetSimpleName(prop)).copy(nullable = prop.isNullable)
+        getDtoClassName(targetSimpleName(prop)).copy(nullable = isGeneratedNullable(prop))
+
+    private fun isGeneratedNullable(prop: AbstractProp): Boolean =
+        prop.isNullable ||
+            (prop is FoldProp<*, *> && dtoType.modifiers.contains(DtoModifier.SPECIFICATION))
 
     private fun propTypeName(prop: DtoProp<ImmutableType, ImmutableProp>): TypeName {
 
@@ -1702,6 +1750,12 @@ class DtoGenerator private constructor(
 
     private fun targetSimpleName(prop: FoldProp<ImmutableType, ImmutableProp>): String =
         standardTargetSimpleName("TargetOf_${prop.name}")
+
+    private fun accessorFieldName(propName: String): String =
+        StringUtil.snake("${propName}Accessor", SnakeCase.UPPER)
+
+    private fun foldNullGuardAccessorFieldName(prop: FoldProp<ImmutableType, ImmutableProp>): String =
+        StringUtil.snake("${prop.name}NullGuardAccessor", SnakeCase.UPPER)
 
     private fun standardTargetSimpleName(targetSimpleName: String): String {
         var conflict = false
@@ -2103,7 +2157,6 @@ class DtoGenerator private constructor(
     internal fun statePropName(prop: AbstractProp, builder: Boolean): String? =
         when {
             !prop.isNullable -> null
-            prop !is DtoProp<*, *> -> null
             !dtoType.modifiers.contains(DtoModifier.INPUT) -> null
             else -> prop.inputModifier?.takeIf {
                 (it == DtoModifier.FIXED && builder) || it == DtoModifier.DYNAMIC

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/InputBuilderGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/InputBuilderGenerator.kt
@@ -61,19 +61,11 @@ class InputBuilderGenerator(
     }
 
     private fun TypeSpec.Builder.addMembers() {
-        parentGenerator
-        for (prop in dtoType.dtoProps) {
+        for (prop in dtoType.props) {
             addField(prop)
             addStateField(prop)
         }
-        for (prop in dtoType.userProps) {
-            addField(prop)
-            addStateField(prop)
-        }
-        for (prop in dtoType.dtoProps) {
-            addSetter(prop)
-        }
-        for (prop in dtoType.userProps) {
+        for (prop in dtoType.props) {
             addSetter(prop)
         }
         addBuild()
@@ -142,15 +134,16 @@ class InputBuilderGenerator(
                         .add("return %T(\n", parentGenerator.getDtoClassName())
                         .indent()
                         .apply {
-                            for (prop in dtoType.dtoProps) {
+                            for (prop in dtoType.props) {
                                 val builderStatePropName = parentGenerator.statePropName(prop, true)
                                 val dtoStatePropName = parentGenerator.statePropName(prop, false)
                                 if (builderStatePropName === null) {
                                     addArg(prop)
                                     add(",\n")
                                 } else {
-                                    add("// %L\n", prop.inputModifier)
-                                    if (prop.inputModifier == DtoModifier.FIXED) {
+                                    val inputModifier = prop.inputModifier
+                                    add("// %L\n", inputModifier)
+                                    if (inputModifier == DtoModifier.FIXED) {
                                         beginControlFlow("if (!%L)", builderStatePropName)
                                         add(
                                             "throw %T.unknownNullableProperty(%T::class.java, %S)",
@@ -170,10 +163,6 @@ class InputBuilderGenerator(
                                         add("%L,\n", builderStatePropName)
                                     }
                                 }
-                            }
-                            for (prop in dtoType.userProps) {
-                                addArg(prop)
-                                add(",\n")
                             }
                         }
                         .unindent()
@@ -205,7 +194,7 @@ class InputBuilderGenerator(
         )
 
         private fun isFieldNullable(prop: AbstractProp): Boolean =
-            prop !is DtoProp<*, *> || (prop.funcName != "null" && prop.funcName != "notNull")
+            prop.funcName != "null" && prop.funcName != "notNull"
 
         @Suppress("UNCHECKED_CAST")
         private fun FunSpec.Builder.addJacksonAnnotations(prop: AbstractProp, resolver: Resolver) {
@@ -216,9 +205,9 @@ class InputBuilderGenerator(
                     addAnnotation(DtoGenerator.annotationOf(anno, resolver))
                 }
             }
-            if (prop is DtoProp<*, *>) {
-                val dtoProp = prop as DtoProp<*, ImmutableProp>
-                for (anno in dtoProp.toTailProp().baseProp.annotations { an ->
+            val baseProp = prop.basePropOrNull as ImmutableProp?
+            if (baseProp !== null) {
+                for (anno in baseProp.annotations { an ->
                     JACKSON_ANNO_PREFIXIES.any { an.fullName.startsWith(it) }
                 }) {
                     if (typeNames.add(anno.fullName)) {

--- a/project/jimmer-sql-kotlin/src/test/dto/TreeNode.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/TreeNode.dto
@@ -23,3 +23,13 @@ FlatTreeNode {
         id(parent) as grandParentId
     }
 }
+
+TreeNodeFoldInsideFlatView {
+    id
+    name
+    flat(parent) {
+        fold(key) {
+            name
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/dto/embeddable/Rect.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/embeddable/Rect.dto
@@ -31,3 +31,16 @@ RectFlatView {
         }
     }
 }
+
+RectFoldView {
+    fold(leftTopPoint) {
+        flat(leftTop) {
+            #allScalars
+        }
+    }
+    fold(rightBottomPoint) {
+        flat(rightBottom) {
+            #allScalars
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
@@ -277,6 +277,18 @@ BookFoldView {
     }
 }
 
+BookNestedFoldView {
+    id
+    name
+    fold(summary) {
+        name
+        fold(detail) {
+            name
+            edition
+        }
+    }
+}
+
 BookFoldInsideFlatView {
     id
     flat(store) {
@@ -287,6 +299,38 @@ BookFoldInsideFlatView {
 }
 
 input BookFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+fixed input BookFixedFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+static input BookStaticFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+dynamic input BookDynamicFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+fuzzy input BookFuzzyFoldInput {
     id
     fold(summary) {
         name

--- a/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
@@ -268,3 +268,36 @@ BookViewWithConfiguration2 {
         lastName
     }
 }
+
+BookFoldView {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+BookFoldInsideFlatView {
+    id
+    flat(store) {
+        fold(key) {
+            name
+        }
+    }
+}
+
+input BookFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+specification BookFoldSpecification {
+    fold(summary) {
+        like/i(name)
+        ge(price)
+        le(price)
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/org/babyfish/jimmer/sql/kt/model/classic/book/Book.dto
@@ -277,6 +277,14 @@ BookFoldView {
     }
 }
 
+BookNullableFoldView {
+    id
+    fold(summary)? {
+        name
+        edition
+    }
+}
+
 BookNestedFoldView {
     id
     name
@@ -301,6 +309,14 @@ BookFoldInsideFlatView {
 input BookFoldInput {
     id
     fold(summary) {
+        name
+        edition
+    }
+}
+
+input BookNullableFoldInput {
+    id
+    fold(summary)? {
         name
         edition
     }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
@@ -1,0 +1,89 @@
+package org.babyfish.jimmer.sql.kt.dto
+
+import org.babyfish.jimmer.jackson.codec.JsonCodec.jsonCodec
+import org.babyfish.jimmer.sql.dialect.H2Dialect
+import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
+import org.babyfish.jimmer.sql.kt.common.assertContent
+import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInput
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInsideFlatView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldSpecification
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldView
+import org.junit.Test
+import java.math.BigDecimal
+
+class BookFoldTest : AbstractQueryTest() {
+
+    @Test
+    fun testFoldView() {
+        val view = BookFoldView(
+            id = 1L,
+            summary = BookFoldView.TargetOf_summary(
+                name = "Programming TypeScript",
+                edition = 2
+            )
+        )
+        assertContent(
+            """{"id":1,"summary":{"name":"Programming TypeScript","edition":2}}""",
+            jsonCodec().writer().writeAsString(view)
+        )
+    }
+
+    @Test
+    fun testFoldInsideFlatView() {
+        val view = BookFoldInsideFlatView(
+            id = 1L,
+            storeKey = BookFoldInsideFlatView.TargetOf_storeKey(
+                name = "MANNING"
+            )
+        )
+        assertContent(
+            """{"id":1,"storeKey":{"name":"MANNING"}}""",
+            jsonCodec().writer().writeAsString(view)
+        )
+    }
+
+    @Test
+    fun testFoldInput() {
+        val input = BookFoldInput(
+            id = 1L,
+            summary = BookFoldInput.TargetOf_summary(
+                name = "SQL in Action",
+                edition = 1
+            )
+        )
+        assertContent(
+            """{"id":1,"name":"SQL in Action","edition":1}""",
+            input.toEntity()
+        )
+        assertContent(
+            "BookFoldInput(id=1, summary=BookFoldInput.TargetOf_summary(name=SQL in Action, edition=1))",
+            BookFoldInput(input.toEntity())
+        )
+    }
+
+    @Test
+    fun testFoldSpecification() {
+        val specification = BookFoldSpecification(
+            summary = BookFoldSpecification.TargetOf_summary(
+                name = "GraphQL",
+                minPrice = BigDecimal("40"),
+                maxPrice = BigDecimal("60")
+            )
+        )
+        executeAndExpect(
+            sqlClient {
+                setDialect(H2Dialect())
+            }.createQuery(Book::class) {
+                where(specification)
+                select(table)
+            }
+        ) {
+            sql(
+                """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID 
+                    |from BOOK tb_1_ 
+                    |where tb_1_.NAME ilike ? and tb_1_.PRICE >= ? and tb_1_.PRICE <= ?""".trimMargin()
+            )
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
@@ -5,12 +5,19 @@ import org.babyfish.jimmer.sql.dialect.H2Dialect
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.common.assertContent
 import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookDynamicFoldInput
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFixedFoldInput
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInput
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInsideFlatView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldSpecification
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFuzzyFoldInput
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNestedFoldView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookStaticFoldInput
+import org.babyfish.jimmer.sql.kt.model.classic.book.id
 import org.junit.Test
 import java.math.BigDecimal
+import kotlin.test.assertNull
 
 class BookFoldTest : AbstractQueryTest() {
 
@@ -30,6 +37,32 @@ class BookFoldTest : AbstractQueryTest() {
     }
 
     @Test
+    fun testNestedFoldView() {
+        val view = BookNestedFoldView(
+            id = 12L,
+            name = "GraphQL in Action",
+            summary = BookNestedFoldView.TargetOf_summary(
+                name = "GraphQL in Action",
+                detail = BookNestedFoldView.TargetOf_summary.TargetOf_detail(
+                    name = "GraphQL in Action",
+                    edition = 3
+                )
+            )
+        )
+        assertContent(
+            """{
+                |--->"id":12,
+                |--->"name":"GraphQL in Action",
+                |--->"summary":{
+                |--->--->"name":"GraphQL in Action",
+                |--->--->"detail":{"name":"GraphQL in Action","edition":3}
+                |--->}
+                |}""".trimMargin(),
+            jsonCodec().writer().writeAsString(view)
+        )
+    }
+
+    @Test
     fun testFoldInsideFlatView() {
         val view = BookFoldInsideFlatView(
             id = 1L,
@@ -41,6 +74,20 @@ class BookFoldTest : AbstractQueryTest() {
             """{"id":1,"storeKey":{"name":"MANNING"}}""",
             jsonCodec().writer().writeAsString(view)
         )
+    }
+
+    @Test
+    fun testFoldInsideFlatViewFromEntityWithNullFlatHead() {
+        val book = Book {
+            id = 1L
+            name = "Programming TypeScript"
+            edition = 2
+            price = BigDecimal("59.99")
+        }
+
+        val view = BookFoldInsideFlatView(book)
+
+        assertNull(view.storeKey)
     }
 
     @Test
@@ -63,12 +110,72 @@ class BookFoldTest : AbstractQueryTest() {
     }
 
     @Test
-    fun testFoldSpecification() {
+    fun testFoldInputStrategies() {
+        assertBookFoldEntity(
+            BookFixedFoldInput(
+                id = 1L,
+                summary = BookFixedFoldInput.TargetOf_summary(
+                    name = "SQL in Action",
+                    edition = 1
+                )
+            ).toEntity()
+        )
+        assertBookFoldEntity(
+            BookStaticFoldInput(
+                id = 1L,
+                summary = BookStaticFoldInput.TargetOf_summary(
+                    name = "SQL in Action",
+                    edition = 1
+                )
+            ).toEntity()
+        )
+        assertBookFoldEntity(
+            BookDynamicFoldInput(
+                id = 1L,
+                summary = BookDynamicFoldInput.TargetOf_summary(
+                    name = "SQL in Action",
+                    edition = 1
+                )
+            ).toEntity()
+        )
+        assertBookFoldEntity(
+            BookFuzzyFoldInput(
+                id = 1L,
+                summary = BookFuzzyFoldInput.TargetOf_summary(
+                    name = "SQL in Action",
+                    edition = 1
+                )
+            ).toEntity()
+        )
+    }
+
+    @Test
+    fun testFoldSpecificationWithoutValues() {
+        val specification = BookFoldSpecification()
+        executeAndExpect(
+            sqlClient {
+                setDialect(H2Dialect())
+            }.createQuery(Book::class) {
+                where(specification)
+                orderBy(table.id)
+                select(table)
+            }
+        ) {
+            sql(
+                """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID 
+                    |from BOOK tb_1_ 
+                    |order by tb_1_.ID asc""".trimMargin()
+            )
+        }
+    }
+
+    @Test
+    fun testFoldSpecificationWithValues() {
         val specification = BookFoldSpecification(
             summary = BookFoldSpecification.TargetOf_summary(
                 name = "GraphQL",
-                minPrice = BigDecimal("40"),
-                maxPrice = BigDecimal("60")
+                minPrice = BigDecimal("70"),
+                maxPrice = BigDecimal("90")
             )
         )
         executeAndExpect(
@@ -76,14 +183,33 @@ class BookFoldTest : AbstractQueryTest() {
                 setDialect(H2Dialect())
             }.createQuery(Book::class) {
                 where(specification)
+                orderBy(table.id)
                 select(table)
             }
         ) {
             sql(
                 """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID 
                     |from BOOK tb_1_ 
-                    |where tb_1_.NAME ilike ? and tb_1_.PRICE >= ? and tb_1_.PRICE <= ?""".trimMargin()
-            )
+                    |where tb_1_.NAME ilike ? and tb_1_.PRICE >= ? and tb_1_.PRICE <= ? 
+                    |order by tb_1_.ID asc""".trimMargin()
+            ).variables("%graphql%", BigDecimal("70"), BigDecimal("90"))
+            rows {
+                assertContent(
+                    """[
+                        |--->{"id":10,"name":"GraphQL in Action","edition":1,"price":80.00,"storeId":2}, 
+                        |--->{"id":11,"name":"GraphQL in Action","edition":2,"price":81.00,"storeId":2}, 
+                        |--->{"id":12,"name":"GraphQL in Action","edition":3,"price":80.00,"storeId":2}
+                        |]""".trimMargin(),
+                    it
+                )
+            }
         }
+    }
+
+    private fun assertBookFoldEntity(book: Book) {
+        assertContent(
+            """{"id":1,"name":"SQL in Action","edition":1}""",
+            book
+        )
     }
 }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/BookFoldTest.kt
@@ -13,6 +13,8 @@ import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldSpecification
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFuzzyFoldInput
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNestedFoldView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNullableFoldInput
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNullableFoldView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookStaticFoldInput
 import org.babyfish.jimmer.sql.kt.model.classic.book.id
 import org.junit.Test
@@ -32,6 +34,18 @@ class BookFoldTest : AbstractQueryTest() {
         )
         assertContent(
             """{"id":1,"summary":{"name":"Programming TypeScript","edition":2}}""",
+            jsonCodec().writer().writeAsString(view)
+        )
+    }
+
+    @Test
+    fun testNullableFoldView() {
+        val view = BookNullableFoldView(
+            id = 1L,
+            summary = null
+        )
+        assertContent(
+            """{"id":1,"summary":null}""",
             jsonCodec().writer().writeAsString(view)
         )
     }
@@ -88,6 +102,18 @@ class BookFoldTest : AbstractQueryTest() {
         val view = BookFoldInsideFlatView(book)
 
         assertNull(view.storeKey)
+    }
+
+    @Test
+    fun testNullableFoldInputWithoutSummary() {
+        val input = BookNullableFoldInput(
+            id = 1L,
+            summary = null
+        )
+        assertContent(
+            """{"id":1}""",
+            input.toEntity()
+        )
     }
 
     @Test

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/QueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/QueryTest.kt
@@ -10,6 +10,7 @@ import org.babyfish.jimmer.sql.kt.model.id
 import org.babyfish.jimmer.sql.kt.model.classic.book.Book
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInsideFlatView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNestedFoldView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNullableFoldView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookView
 import org.babyfish.jimmer.sql.kt.model.classic.book.edition
 import org.babyfish.jimmer.sql.kt.model.classic.book.id
@@ -85,6 +86,36 @@ class QueryTest : AbstractQueryTest() {
                         |--->--->id=1, 
                         |--->--->name=Home, 
                         |--->--->parentKey=null
+                        |--->)
+                        |]""".trimMargin(),
+                    it
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testNullableFoldView() {
+        executeAndExpect(
+            sqlClient.createQuery(Book::class) {
+                where(table.id eq 12L)
+                select(table.fetch(BookNullableFoldView::class))
+            }
+        ) {
+            sql(
+                "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                    "from BOOK tb_1_ " +
+                    "where tb_1_.ID = ?"
+            )
+            rows {
+                assertContent(
+                    """[
+                        |--->BookNullableFoldView(
+                        |--->--->id=12, 
+                        |--->--->summary=BookNullableFoldView.TargetOf_summary(
+                        |--->--->--->name=GraphQL in Action, 
+                        |--->--->--->edition=3
+                        |--->--->)
                         |--->)
                         |]""".trimMargin(),
                     it

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/QueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/QueryTest.kt
@@ -4,7 +4,12 @@ import org.babyfish.jimmer.sql.kt.ast.expression.desc
 import org.babyfish.jimmer.sql.kt.ast.expression.eq
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.common.assertContent
+import org.babyfish.jimmer.sql.kt.model.TreeNode
+import org.babyfish.jimmer.sql.kt.model.dto.TreeNodeFoldInsideFlatView
+import org.babyfish.jimmer.sql.kt.model.id
 import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookFoldInsideFlatView
+import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookNestedFoldView
 import org.babyfish.jimmer.sql.kt.model.classic.book.dto.BookView
 import org.babyfish.jimmer.sql.kt.model.classic.book.edition
 import org.babyfish.jimmer.sql.kt.model.classic.book.id
@@ -15,6 +20,112 @@ import org.junit.Test
 import kotlin.test.expect
 
 class QueryTest : AbstractQueryTest() {
+
+    @Test
+    fun testFoldInsideFlatView() {
+        executeAndExpect(
+            sqlClient.createQuery(Book::class) {
+                where(table.name eq "GraphQL in Action")
+                orderBy(table.edition.desc())
+                select(
+                    table.fetch(BookFoldInsideFlatView::class)
+                )
+            }
+        ) {
+            sql(
+                "select tb_1_.ID, tb_1_.STORE_ID " +
+                    "from BOOK tb_1_ " +
+                    "where tb_1_.NAME = ? " +
+                    "order by tb_1_.EDITION desc"
+            )
+            statement(1).sql(
+                "select tb_1_.ID, tb_1_.NAME " +
+                    "from BOOK_STORE tb_1_ " +
+                    "where tb_1_.ID = ?"
+            )
+            rows {
+                assertContent(
+                    """[
+                        |--->BookFoldInsideFlatView(
+                        |--->--->id=12, 
+                        |--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)
+                        |--->), 
+                        |--->BookFoldInsideFlatView(
+                        |--->--->id=11, 
+                        |--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)
+                        |--->), 
+                        |--->BookFoldInsideFlatView(
+                        |--->--->id=10, 
+                        |--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)
+                        |--->)
+                        |]""".trimMargin(),
+                    it
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testTreeNodeFoldInsideFlatViewWithNullFlatHead() {
+        executeAndExpect(
+            sqlClient.createQuery(TreeNode::class) {
+                where(table.id eq 1L)
+                select(table.fetch(TreeNodeFoldInsideFlatView::class))
+            }
+        ) {
+            sql(
+                "select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID " +
+                    "from TREE_NODE tb_1_ " +
+                    "where tb_1_.NODE_ID = ?"
+            )
+            rows {
+                assertContent(
+                    """[
+                        |--->TreeNodeFoldInsideFlatView(
+                        |--->--->id=1, 
+                        |--->--->name=Home, 
+                        |--->--->parentKey=null
+                        |--->)
+                        |]""".trimMargin(),
+                    it
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testNestedFoldView() {
+        executeAndExpect(
+            sqlClient.createQuery(Book::class) {
+                where(table.id eq 12L)
+                select(table.fetch(BookNestedFoldView::class))
+            }
+        ) {
+            sql(
+                "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                    "from BOOK tb_1_ " +
+                    "where tb_1_.ID = ?"
+            )
+            rows {
+                assertContent(
+                    """[
+                        |--->BookNestedFoldView(
+                        |--->--->id=12, 
+                        |--->--->name=GraphQL in Action, 
+                        |--->--->summary=BookNestedFoldView.TargetOf_summary(
+                        |--->--->--->name=GraphQL in Action, 
+                        |--->--->--->detail=BookNestedFoldView.TargetOf_summary.TargetOf_detail(
+                        |--->--->--->--->name=GraphQL in Action, 
+                        |--->--->--->--->edition=3
+                        |--->--->--->)
+                        |--->--->)
+                        |--->)
+                        |]""".trimMargin(),
+                    it
+                )
+            }
+        }
+    }
 
     @Test
     fun testBookView() {
@@ -174,4 +285,5 @@ class QueryTest : AbstractQueryTest() {
             }
         }
     }
+
 }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/RectTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/RectTest.kt
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.sql.kt.common.assertContent
 import org.babyfish.jimmer.sql.kt.model.embedded.Rect
 import org.babyfish.jimmer.sql.kt.model.embedded.Transform
 import org.babyfish.jimmer.sql.kt.model.embedded.dto.RectFlatView
+import org.babyfish.jimmer.sql.kt.model.embedded.dto.RectFoldView
 import org.babyfish.jimmer.sql.kt.model.embedded.dto.RectView
 import org.babyfish.jimmer.sql.kt.model.embedded.source
 import org.babyfish.jimmer.sql.kt.model.embedded.target
@@ -53,6 +54,32 @@ class RectTest : AbstractQueryTest() {
         val view = RectFlatView(rect)
         assertContent(
             """RectFlatView(ltX=1, ltY=4, rbX=9, rbY=16)""".trimMargin(),
+            view
+        )
+        assertContent(
+            """{"leftTop":{"x":1,"y":4},"rightBottom":{"x":9,"y":16}}""",
+            view.toImmutable()
+        )
+    }
+
+    @Test
+    fun testRectFoldView() {
+        val rect = Rect {
+            leftTop {
+                x = 1
+                y = 4
+            }
+            rightBottom {
+                x = 9
+                y = 16
+            }
+        }
+        val view = RectFoldView(rect)
+        assertContent(
+            """RectFoldView(
+                |--->leftTopPoint=RectFoldView.TargetOf_leftTopPoint(x=1, y=4), 
+                |--->rightBottomPoint=RectFoldView.TargetOf_rightBottomPoint(x=9, y=16)
+                |)""".trimMargin(),
             view
         )
         assertContent(

--- a/project/jimmer-sql/src/test/dto/TreeNode.dto
+++ b/project/jimmer-sql/src/test/dto/TreeNode.dto
@@ -27,3 +27,13 @@ FlatTreeNode {
         id(parent) as grandParentId
     }
 }
+
+TreeNodeFoldInsideFlatView {
+    id
+    name
+    flat(parent) {
+        fold(key) {
+            name
+        }
+    }
+}

--- a/project/jimmer-sql/src/test/dto/embeddable/Rect.dto
+++ b/project/jimmer-sql/src/test/dto/embeddable/Rect.dto
@@ -31,3 +31,16 @@ RectFlatView {
         }
     }
 }
+
+RectFoldView {
+    fold(leftTopPoint) {
+        flat(leftTop) {
+            #allScalars
+        }
+    }
+    fold(rightBottomPoint) {
+        flat(rightBottom) {
+            #allScalars
+        }
+    }
+}

--- a/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
+++ b/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
@@ -305,3 +305,36 @@ BookViewWithConfiguration2 {
 specification BookSpecificationForIssue1108 {
     associatedIdIn(authors) as authorIds
 }
+
+BookFoldView {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+BookFoldInsideFlatView {
+    id
+    flat(store) {
+        fold(key) {
+            name
+        }
+    }
+}
+
+input BookFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+specification BookFoldSpecification {
+    fold(summary) {
+        like/i(name)
+        ge(price)
+        le(price)
+    }
+}

--- a/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
+++ b/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
@@ -314,6 +314,18 @@ BookFoldView {
     }
 }
 
+BookNestedFoldView {
+    id
+    name
+    fold(summary) {
+        name
+        fold(detail) {
+            name
+            edition
+        }
+    }
+}
+
 BookFoldInsideFlatView {
     id
     flat(store) {
@@ -324,6 +336,38 @@ BookFoldInsideFlatView {
 }
 
 input BookFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+fixed input BookFixedFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+static input BookStaticFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+dynamic input BookDynamicFoldInput {
+    id
+    fold(summary) {
+        name
+        edition
+    }
+}
+
+fuzzy input BookFuzzyFoldInput {
     id
     fold(summary) {
         name

--- a/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
+++ b/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/Book.dto
@@ -314,6 +314,14 @@ BookFoldView {
     }
 }
 
+BookNullableFoldView {
+    id
+    fold(summary)? {
+        name
+        edition
+    }
+}
+
 BookNestedFoldView {
     id
     name
@@ -338,6 +346,14 @@ BookFoldInsideFlatView {
 input BookFoldInput {
     id
     fold(summary) {
+        name
+        edition
+    }
+}
+
+input BookNullableFoldInput {
+    id
+    fold(summary)? {
         name
         edition
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookInputTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookInputTest.java
@@ -5,7 +5,11 @@ import org.babyfish.jimmer.sql.model.Book;
 import org.babyfish.jimmer.sql.model.dto.BookInput;
 import org.babyfish.jimmer.sql.model.dto.BookInput2;
 import org.babyfish.jimmer.sql.model.dto.BookInput3;
+import org.babyfish.jimmer.sql.model.dto.BookDynamicFoldInput;
+import org.babyfish.jimmer.sql.model.dto.BookFixedFoldInput;
 import org.babyfish.jimmer.sql.model.dto.BookFoldInput;
+import org.babyfish.jimmer.sql.model.dto.BookFuzzyFoldInput;
+import org.babyfish.jimmer.sql.model.dto.BookStaticFoldInput;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -126,5 +130,51 @@ public class BookInputTest extends Tests {
                 book
         );
         Assertions.assertEquals(input, new BookFoldInput(book));
+    }
+
+    @Test
+    public void testBookFoldInputStrategies() {
+        BookFixedFoldInput fixed = new BookFixedFoldInput();
+        fixed.setId(UUID.fromString("66eee693-4b80-4d28-98b9-5e3aafca8d05"));
+        BookFixedFoldInput.TargetOf_summary fixedSummary = new BookFixedFoldInput.TargetOf_summary();
+        fixedSummary.setName("SQL in Action");
+        fixedSummary.setEdition(1);
+        fixed.setSummary(fixedSummary);
+        assertBookFoldEntity(fixed.toEntity());
+
+        BookStaticFoldInput statik = new BookStaticFoldInput();
+        statik.setId(UUID.fromString("66eee693-4b80-4d28-98b9-5e3aafca8d05"));
+        BookStaticFoldInput.TargetOf_summary staticSummary = new BookStaticFoldInput.TargetOf_summary();
+        staticSummary.setName("SQL in Action");
+        staticSummary.setEdition(1);
+        statik.setSummary(staticSummary);
+        assertBookFoldEntity(statik.toEntity());
+
+        BookDynamicFoldInput dynamic = new BookDynamicFoldInput();
+        dynamic.setId(UUID.fromString("66eee693-4b80-4d28-98b9-5e3aafca8d05"));
+        BookDynamicFoldInput.TargetOf_summary dynamicSummary = new BookDynamicFoldInput.TargetOf_summary();
+        dynamicSummary.setName("SQL in Action");
+        dynamicSummary.setEdition(1);
+        dynamic.setSummary(dynamicSummary);
+        assertBookFoldEntity(dynamic.toEntity());
+
+        BookFuzzyFoldInput fuzzy = new BookFuzzyFoldInput();
+        fuzzy.setId(UUID.fromString("66eee693-4b80-4d28-98b9-5e3aafca8d05"));
+        BookFuzzyFoldInput.TargetOf_summary fuzzySummary = new BookFuzzyFoldInput.TargetOf_summary();
+        fuzzySummary.setName("SQL in Action");
+        fuzzySummary.setEdition(1);
+        fuzzy.setSummary(fuzzySummary);
+        assertBookFoldEntity(fuzzy.toEntity());
+    }
+
+    private void assertBookFoldEntity(Book book) {
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"66eee693-4b80-4d28-98b9-5e3aafca8d05\"," +
+                        "--->\"name\":\"SQL in Action\"," +
+                        "--->\"edition\":1" +
+                        "}",
+                book
+        );
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookInputTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookInputTest.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.sql.model.Book;
 import org.babyfish.jimmer.sql.model.dto.BookInput;
 import org.babyfish.jimmer.sql.model.dto.BookInput2;
 import org.babyfish.jimmer.sql.model.dto.BookInput3;
+import org.babyfish.jimmer.sql.model.dto.BookFoldInput;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -105,5 +106,25 @@ public class BookInputTest extends Tests {
                 book
         );
         Assertions.assertEquals(input, new BookInput3(book));
+    }
+
+    @Test
+    public void testBookFoldInput() {
+        BookFoldInput input = new BookFoldInput();
+        input.setId(UUID.fromString("66eee693-4b80-4d28-98b9-5e3aafca8d05"));
+        BookFoldInput.TargetOf_summary summary = new BookFoldInput.TargetOf_summary();
+        summary.setName("SQL in Action");
+        summary.setEdition(1);
+        input.setSummary(summary);
+        Book book = input.toEntity();
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"66eee693-4b80-4d28-98b9-5e3aafca8d05\"," +
+                        "--->\"name\":\"SQL in Action\"," +
+                        "--->\"edition\":1" +
+                        "}",
+                book
+        );
+        Assertions.assertEquals(input, new BookFoldInput(book));
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookSpecificationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookSpecificationTest.java
@@ -572,4 +572,29 @@ public class BookSpecificationTest extends AbstractQueryTest {
                 }
         );
     }
+
+    @Test
+    public void testFoldSpecification() {
+        BookFoldSpecification spec = new BookFoldSpecification();
+        BookFoldSpecification.TargetOf_summary summary = new BookFoldSpecification.TargetOf_summary();
+        summary.setName("GraphQL");
+        summary.setMinPrice(new BigDecimal("40"));
+        summary.setMaxPrice(new BigDecimal("60"));
+        spec.setSummary(summary);
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(spec)
+                        .orderBy(table.id())
+                        .select(table),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID " +
+                                    "from BOOK tb_1_ " +
+                                    "where tb_1_.NAME ilike ? and tb_1_.PRICE >= ? and tb_1_.PRICE <= ? " +
+                                    "order by tb_1_.ID asc"
+                    );
+                }
+        );
+    }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookSpecificationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookSpecificationTest.java
@@ -574,12 +574,31 @@ public class BookSpecificationTest extends AbstractQueryTest {
     }
 
     @Test
-    public void testFoldSpecification() {
+    public void testFoldSpecificationWithoutValues() {
+        BookFoldSpecification spec = new BookFoldSpecification();
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(spec)
+                        .orderBy(table.id())
+                        .select(table),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID " +
+                                    "from BOOK tb_1_ " +
+                                    "order by tb_1_.ID asc"
+                    );
+                }
+        );
+    }
+
+    @Test
+    public void testFoldSpecificationWithValues() {
         BookFoldSpecification spec = new BookFoldSpecification();
         BookFoldSpecification.TargetOf_summary summary = new BookFoldSpecification.TargetOf_summary();
         summary.setName("GraphQL");
-        summary.setMinPrice(new BigDecimal("40"));
-        summary.setMaxPrice(new BigDecimal("60"));
+        summary.setMinPrice(new BigDecimal("70"));
+        summary.setMaxPrice(new BigDecimal("90"));
         spec.setSummary(summary);
         executeAndExpect(
                 getSqlClient()
@@ -593,6 +612,27 @@ public class BookSpecificationTest extends AbstractQueryTest {
                                     "from BOOK tb_1_ " +
                                     "where tb_1_.NAME ilike ? and tb_1_.PRICE >= ? and tb_1_.PRICE <= ? " +
                                     "order by tb_1_.ID asc"
+                    ).variables("%graphql%", new BigDecimal("70"), new BigDecimal("90"));
+                    ctx.rows(
+                            "[{" +
+                                    "--->\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
+                                    "--->\"name\":\"GraphQL in Action\"," +
+                                    "--->\"edition\":3," +
+                                    "--->\"price\":80.00," +
+                                    "--->\"storeId\":\"2fa3955e-3e83-49b9-902e-0465c109c779\"" +
+                                    "},{" +
+                                    "--->\"id\":\"a62f7aa3-9490-4612-98b5-98aae0e77120\"," +
+                                    "--->\"name\":\"GraphQL in Action\"," +
+                                    "--->\"edition\":1," +
+                                    "--->\"price\":80.00," +
+                                    "--->\"storeId\":\"2fa3955e-3e83-49b9-902e-0465c109c779\"" +
+                                    "},{" +
+                                    "--->\"id\":\"e37a8344-73bb-4b23-ba76-82eac11f03e6\"," +
+                                    "--->\"name\":\"GraphQL in Action\"," +
+                                    "--->\"edition\":2," +
+                                    "--->\"price\":81.00," +
+                                    "--->\"storeId\":\"2fa3955e-3e83-49b9-902e-0465c109c779\"" +
+                                    "}]"
                     );
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
@@ -2,14 +2,18 @@ package org.babyfish.jimmer.sql.dto;
 
 import org.babyfish.jimmer.sql.common.Constants;
 import org.babyfish.jimmer.sql.common.Tests;
+import org.babyfish.jimmer.sql.model.Book;
+import org.babyfish.jimmer.sql.model.BookDraft;
 import org.babyfish.jimmer.sql.model.dto.BookFoldInsideFlatView;
 import org.babyfish.jimmer.sql.model.dto.BookFoldView;
+import org.babyfish.jimmer.sql.model.dto.BookNestedFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookViewForIssue843;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
 import static org.babyfish.jimmer.jackson.codec.JsonCodec.jsonCodec;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BookVIewTest extends Tests {
 
@@ -48,6 +52,32 @@ public class BookVIewTest extends Tests {
     }
 
     @Test
+    public void testNestedFoldView() throws Exception {
+        BookNestedFoldView view = new BookNestedFoldView();
+        view.setId(Constants.graphQLInActionId3);
+        view.setName("GraphQL in Action");
+        BookNestedFoldView.TargetOf_summary summary = new BookNestedFoldView.TargetOf_summary();
+        summary.setName("GraphQL in Action");
+        BookNestedFoldView.TargetOf_summary.TargetOf_detail detail =
+                new BookNestedFoldView.TargetOf_summary.TargetOf_detail();
+        detail.setName("GraphQL in Action");
+        detail.setEdition(3);
+        summary.setDetail(detail);
+        view.setSummary(summary);
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
+                        "--->\"name\":\"GraphQL in Action\"," +
+                        "--->\"summary\":{" +
+                        "--->--->\"name\":\"GraphQL in Action\"," +
+                        "--->--->\"detail\":{\"name\":\"GraphQL in Action\",\"edition\":3}" +
+                        "--->}" +
+                        "}",
+                jsonCodec().writer().writeAsString(view)
+        );
+    }
+
+    @Test
     public void testFoldInsideFlatView() throws Exception {
         BookFoldInsideFlatView view = new BookFoldInsideFlatView();
         view.setId(Constants.programmingTypeScriptId2);
@@ -62,5 +92,19 @@ public class BookVIewTest extends Tests {
                         "}",
                 jsonCodec().writer().writeAsString(view)
         );
+    }
+
+    @Test
+    public void testFoldInsideFlatViewFromEntityWithNullFlatHead() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(Constants.programmingTypeScriptId2);
+            draft.setName("Programming TypeScript");
+            draft.setEdition(2);
+            draft.setPrice(new BigDecimal("59.99"));
+        });
+
+        BookFoldInsideFlatView view = new BookFoldInsideFlatView(book);
+
+        assertNull(view.getStoreKey());
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
@@ -2,6 +2,8 @@ package org.babyfish.jimmer.sql.dto;
 
 import org.babyfish.jimmer.sql.common.Constants;
 import org.babyfish.jimmer.sql.common.Tests;
+import org.babyfish.jimmer.sql.model.dto.BookFoldInsideFlatView;
+import org.babyfish.jimmer.sql.model.dto.BookFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookViewForIssue843;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +25,40 @@ public class BookVIewTest extends Tests {
                         "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"," +
                         "--->\"name\":\"Programming TypeScript\"," +
                         "--->\"price\":59.99" +
+                        "}",
+                jsonCodec().writer().writeAsString(view)
+        );
+    }
+
+    @Test
+    public void testFoldView() throws Exception {
+        BookFoldView view = new BookFoldView();
+        view.setId(Constants.programmingTypeScriptId2);
+        BookFoldView.TargetOf_summary summary = new BookFoldView.TargetOf_summary();
+        summary.setName("Programming TypeScript");
+        summary.setEdition(2);
+        view.setSummary(summary);
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"," +
+                        "--->\"summary\":{\"name\":\"Programming TypeScript\",\"edition\":2}" +
+                        "}",
+                jsonCodec().writer().writeAsString(view)
+        );
+    }
+
+    @Test
+    public void testFoldInsideFlatView() throws Exception {
+        BookFoldInsideFlatView view = new BookFoldInsideFlatView();
+        view.setId(Constants.programmingTypeScriptId2);
+        BookFoldInsideFlatView.TargetOf_storeKey storeKey =
+                new BookFoldInsideFlatView.TargetOf_storeKey();
+        storeKey.setName("MANNING");
+        view.setStoreKey(storeKey);
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"," +
+                        "--->\"storeKey\":{\"name\":\"MANNING\"}" +
                         "}",
                 jsonCodec().writer().writeAsString(view)
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/BookVIewTest.java
@@ -5,6 +5,8 @@ import org.babyfish.jimmer.sql.common.Tests;
 import org.babyfish.jimmer.sql.model.Book;
 import org.babyfish.jimmer.sql.model.BookDraft;
 import org.babyfish.jimmer.sql.model.dto.BookFoldInsideFlatView;
+import org.babyfish.jimmer.sql.model.dto.BookNullableFoldInput;
+import org.babyfish.jimmer.sql.model.dto.BookNullableFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookNestedFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookViewForIssue843;
@@ -46,6 +48,19 @@ public class BookVIewTest extends Tests {
                 "{" +
                         "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"," +
                         "--->\"summary\":{\"name\":\"Programming TypeScript\",\"edition\":2}" +
+                        "}",
+                jsonCodec().writer().writeAsString(view)
+        );
+    }
+
+    @Test
+    public void testNullableFoldView() throws Exception {
+        BookNullableFoldView view = new BookNullableFoldView();
+        view.setId(Constants.programmingTypeScriptId2);
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"," +
+                        "--->\"summary\":null" +
                         "}",
                 jsonCodec().writer().writeAsString(view)
         );
@@ -106,5 +121,17 @@ public class BookVIewTest extends Tests {
         BookFoldInsideFlatView view = new BookFoldInsideFlatView(book);
 
         assertNull(view.getStoreKey());
+    }
+
+    @Test
+    public void testNullableFoldInputWithoutSummary() {
+        BookNullableFoldInput input = new BookNullableFoldInput();
+        input.setId(Constants.programmingTypeScriptId2);
+        assertContentEquals(
+                "{" +
+                        "--->\"id\":\"058ecfd0-047b-4979-a7dc-46ee24d08f08\"" +
+                        "}",
+                input.toEntity()
+        );
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/QueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/QueryTest.java
@@ -3,13 +3,129 @@ package org.babyfish.jimmer.sql.dto;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.Constants;
 import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.model.TreeNodeTable;
+import org.babyfish.jimmer.sql.model.dto.BookFoldInsideFlatView;
+import org.babyfish.jimmer.sql.model.dto.BookNestedFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookView;
+import org.babyfish.jimmer.sql.model.dto.TreeNodeFoldInsideFlatView;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 public class QueryTest extends AbstractQueryTest {
+
+    @Test
+    public void testFoldInsideFlatViewQuery() {
+        BookTable table = BookTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.name().eq("GraphQL in Action"))
+                        .orderBy(table.edition().desc())
+                        .select(
+                                table.fetch(BookFoldInsideFlatView.class)
+                        ),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.STORE_ID " +
+                                    "from BOOK tb_1_ " +
+                                    "where tb_1_.NAME = ? " +
+                                    "order by tb_1_.EDITION desc"
+                    );
+                    ctx.statement(1).sql(
+                            "select tb_1_.ID, tb_1_.NAME " +
+                                    "from BOOK_STORE tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    );
+                    ctx.rows(rows -> {
+                        assertContentEquals(
+                                "[" +
+                                        "--->BookFoldInsideFlatView(" +
+                                        "--->--->id=780bdf07-05af-48bf-9be9-f8c65236fecc, " +
+                                        "--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)" +
+                                        "--->), " +
+                                        "--->BookFoldInsideFlatView(" +
+                                        "--->--->id=e37a8344-73bb-4b23-ba76-82eac11f03e6, " +
+                                        "--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)" +
+                                        "--->), " +
+                                        "--->BookFoldInsideFlatView(" +
+                                        "--->--->id=a62f7aa3-9490-4612-98b5-98aae0e77120, " +
+                                        "--->--->storeKey=BookFoldInsideFlatView.TargetOf_storeKey(name=MANNING)" +
+                                        "--->)" +
+                                        "]",
+                                rows
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testTreeNodeFoldInsideFlatViewQueryWithNullFlatHead() {
+        TreeNodeTable table = TreeNodeTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(1L))
+                        .select(table.fetch(TreeNodeFoldInsideFlatView.class)),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID " +
+                                    "from TREE_NODE tb_1_ " +
+                                    "where tb_1_.NODE_ID = ?"
+                    );
+                    ctx.rows(rows -> {
+                        assertContentEquals(
+                                "[" +
+                                        "--->TreeNodeFoldInsideFlatView(" +
+                                        "--->--->id=1, " +
+                                        "--->--->name=Home, " +
+                                        "--->--->parentKey=null" +
+                                        "--->)" +
+                                        "]",
+                                rows
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testNestedFoldViewQuery() {
+        BookTable table = BookTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(Constants.graphQLInActionId3))
+                        .select(table.fetch(BookNestedFoldView.class)),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                                    "from BOOK tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    );
+                    ctx.rows(rows -> {
+                        assertContentEquals(
+                                "[" +
+                                        "--->BookNestedFoldView(" +
+                                        "--->--->id=780bdf07-05af-48bf-9be9-f8c65236fecc, " +
+                                        "--->--->name=GraphQL in Action, " +
+                                        "--->--->summary=BookNestedFoldView.TargetOf_summary(" +
+                                        "--->--->--->name=GraphQL in Action, " +
+                                        "--->--->--->detail=BookNestedFoldView.TargetOf_summary.TargetOf_detail(" +
+                                        "--->--->--->--->name=GraphQL in Action, " +
+                                        "--->--->--->--->edition=3" +
+                                        "--->--->--->)" +
+                                        "--->--->)" +
+                                        "--->)" +
+                                        "]",
+                                rows
+                        );
+                    });
+                }
+        );
+    }
 
     @Test
     public void testQuery() {
@@ -204,4 +320,5 @@ public class QueryTest extends AbstractQueryTest {
                 }
         );
     }
+
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/QueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/QueryTest.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.sql.common.Constants;
 import org.babyfish.jimmer.sql.model.BookTable;
 import org.babyfish.jimmer.sql.model.TreeNodeTable;
 import org.babyfish.jimmer.sql.model.dto.BookFoldInsideFlatView;
+import org.babyfish.jimmer.sql.model.dto.BookNullableFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookNestedFoldView;
 import org.babyfish.jimmer.sql.model.dto.BookView;
 import org.babyfish.jimmer.sql.model.dto.TreeNodeFoldInsideFlatView;
@@ -82,6 +83,38 @@ public class QueryTest extends AbstractQueryTest {
                                         "--->--->id=1, " +
                                         "--->--->name=Home, " +
                                         "--->--->parentKey=null" +
+                                        "--->)" +
+                                        "]",
+                                rows
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testNullableFoldViewQuery() {
+        BookTable table = BookTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(Constants.graphQLInActionId3))
+                        .select(table.fetch(BookNullableFoldView.class)),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                                    "from BOOK tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    );
+                    ctx.rows(rows -> {
+                        assertContentEquals(
+                                "[" +
+                                        "--->BookNullableFoldView(" +
+                                        "--->--->id=780bdf07-05af-48bf-9be9-f8c65236fecc, " +
+                                        "--->--->summary=BookNullableFoldView.TargetOf_summary(" +
+                                        "--->--->--->name=GraphQL in Action, " +
+                                        "--->--->--->edition=3" +
+                                        "--->--->)" +
                                         "--->)" +
                                         "]",
                                 rows

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/RectTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/RectTest.java
@@ -6,6 +6,7 @@ import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.embedded.Rect;
 import org.babyfish.jimmer.sql.model.embedded.TransformTable;
 import org.babyfish.jimmer.sql.model.embedded.dto.RectFlatView;
+import org.babyfish.jimmer.sql.model.embedded.dto.RectFoldView;
 import org.babyfish.jimmer.sql.model.embedded.dto.RectView;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,26 @@ public class RectTest extends AbstractQueryTest {
         RectFlatView view = new RectFlatView(rect);
         Tests.assertContentEquals(
                 "RectFlatView(ltX=1, ltY=4, rbX=9, rbY=16)",
+                view
+        );
+        Tests.assertContentEquals(
+                "{\"leftTop\":{\"x\":1,\"y\":4},\"rightBottom\":{\"x\":9,\"y\":16}}",
+                view.toImmutable()
+        );
+    }
+
+    @Test
+    public void testRectFoldView() {
+        Rect rect = Immutables.createRect(draft -> {
+            draft.applyLeftTop(leftTop -> leftTop.setX(1).setY(4));
+            draft.applyRightBottom(rightBottom -> rightBottom.setX(9).setY(16));
+        });
+        RectFoldView view = new RectFoldView(rect);
+        Tests.assertContentEquals(
+                "RectFoldView(" +
+                        "--->leftTopPoint=RectFoldView.TargetOf_leftTopPoint(x=1, y=4), " +
+                        "--->rightBottomPoint=RectFoldView.TargetOf_rightBottomPoint(x=9, y=16)" +
+                        ")",
                 view
         );
         Tests.assertContentEquals(


### PR DESCRIPTION
## Fold DTO support

This change adds `fold(...)` as a first-class DTO construct.

`fold(name) { ... }` groups several DTO properties under a synthetic nested DTO field while still reading from and writing to the same base type. It is intended for cases where the DTO shape should expose a structured object, but the underlying model fields stay on the current entity or embeddable.

Example:

```dto
BookView {
    id
    fold(summary) {
        name
        edition
    }
}
```

This generates a DTO with shape equivalent to:

```text
{
  id,
  summary: {
    name,
    edition
  }
}
```

while `name` and `edition` still come from the current `Book`.

## What changed

### DTO compiler model

The DTO grammar and compiler model now recognize fold properties and represent them explicitly as `FoldProp`.

A fold property owns a nested `DtoType` that describes the synthetic target object. This allows fold to participate in the same DTO compilation pipeline as regular DTO properties, including nesting and flattening.

`flat(...)` and `fold(...)` can now compose with each other:

- `flat(...) { fold(...) { ... } }`
- `fold(...) { flat(...) { ... } }`

When a fold is produced under a flattened nullable path, the compiler tracks a null-guard path so generated code can decide whether the folded object should exist at all.

### Java and Kotlin DTO generation

APT and KSP generators now emit nested DTO classes for fold targets and expose them as normal generated DTO properties.

For views:

- entity/immutable to DTO conversion creates the folded nested object from the same source instance
- if the fold comes from a nullable flattened head, the nested object is created only when the head path is present

For inputs:

- folded nested DTOs apply their values back into the same draft as the parent DTO
- nested fold application is recursive, so deeply nested folds write into the enclosing draft correctly
- input strategy handling continues to work for folded content because folded target DTOs are generated as regular input DTOs

For specifications:

- folded nested DTOs apply predicates into the same predicate applier/query context as the parent specification
- folded fields therefore behave like grouped specification clauses, not like association traversal to another DTO root

### Runtime behavior

`fold` changes DTO shape, not the underlying model ownership.

That means:

- fetcher generation still loads the required underlying fields from the current base type
- `toEntity()` / `toImmutable()` writes folded values back to the same base draft
- specification application contributes predicates for the same base table/path

In other words, `fold` is a structural DTO feature: it introduces a nested object in the DTO API without changing where the actual data lives.
