### PR TITLE
Fix NPE when join-fetched association is null

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherContext.java
@@ -85,6 +85,9 @@ class FetcherContext {
         @SuppressWarnings("unchecked")
         @Override
         protected void visit(Field field, int depth) {
+            if (draft == null) {
+                return;
+            }
             if (!isFetchRequired(field)) {
                 return;
             }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/JoinFetchTest.java
@@ -311,6 +311,46 @@ public class JoinFetchTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testNullJoinFetchWithDeeperFetcher() {
+        TreeNodeTable table = TreeNodeTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .where(table.id().eq(1L))
+                        .select(
+                                table.fetch(
+                                        TreeNodeFetcher.$
+                                                .allScalarFields()
+                                                .parent(
+                                                        ReferenceFetchType.JOIN_ALWAYS,
+                                                        TreeNodeFetcher.$
+                                                                .allScalarFields()
+                                                                .childNodes(
+                                                                        TreeNodeFetcher.$.allScalarFields()
+                                                                )
+                                                )
+                                )
+                        ),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.NODE_ID, tb_1_.NAME, " +
+                                    "tb_2_.NODE_ID, tb_2_.NAME " +
+                                    "from TREE_NODE tb_1_ " +
+                                    "left join TREE_NODE tb_2_ on tb_1_.PARENT_ID = tb_2_.NODE_ID " +
+                                    "where tb_1_.NODE_ID = ?"
+                    ).variables(1L);
+                    ctx.rows(
+                            "[{" +
+                                    "--->\"id\":1," +
+                                    "--->\"name\":\"Home\"," +
+                                    "--->\"parent\":null" +
+                                    "}]"
+                    );
+                }
+        );
+    }
+
+    @Test
     public void testPage() {
         // Data query uses fetch
         // Count query ignore fetch


### PR DESCRIPTION
## Summary

Fix an NPE when a join-fetched association is `null` and its child fetcher has deeper fields.

## Changes

- Skip deeper fetch task creation when the current joined object is `null`
- Add a regression test for null join fetch with a deeper fetcher