### PR TITLE
fix(sql): Fix nested sub-query, count and global filters under createBaseQuery

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableSubQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableSubQueryImpl.kt
@@ -33,11 +33,12 @@ internal class KMutableSubQueryImpl<PP: KPropsLike, E: Any>(
         KNonNullTableExImpl(javaSubQuery.getTable())
 
     @Suppress("UNCHECKED_CAST")
-    override val parentTable: PP =
+    override val parentTable: PP by lazy {
         parentTable ?: KNonNullTableExImpl<Any>(
             javaSubQuery.parent.getTable(),
             "The parent of sub query does not support join"
         ) as PP
+    }
 
     override val where: Where by lazy {
         Where(this)
@@ -232,7 +233,7 @@ internal class KMutableSubQueryImpl<PP: KPropsLike, E: Any>(
         )
 
     override val subQueries: KSubQueries<KNonNullTableEx<E>> =
-        KSubQueriesImpl(javaSubQuery)
+        KSubQueriesImpl(javaSubQuery, table)
 
     override val wildSubQueries: KWildSubQueries<KNonNullTableEx<E>> =
         KWildSubQueriesImpl(javaSubQuery)

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
@@ -17,8 +17,43 @@ import org.babyfish.jimmer.sql.kt.model.embedded.id
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class CteBaseQueryTest : AbstractQueryTest() {
+
+    @Test
+    fun testNestedSubQueryAndFetchPageInBaseQuery() {
+        val baseTable = cteBaseTableSymbol {
+            sqlClient.createBaseQuery(BookStore::class) {
+                val newerEditionCount = subQuery(Book::class) {
+                    where(table.storeId eq parentTable.id)
+                    val edition = table.edition
+                    val storeId = table.storeId
+                    where(
+                        exists(
+                            subQuery(Book::class) {
+                                where(table.storeId eq storeId)
+                                where(table.edition gt edition)
+                                select(table.id)
+                            }
+                        )
+                    )
+                    select(rowCount())
+                }
+                selections
+                    .add(table)
+                    .add(newerEditionCount)
+            }
+        }
+        jdbc { con ->
+            val page = sqlClient.createQuery(baseTable) {
+                orderBy(table._2.desc())
+                select(table._1)
+            }.fetchPage(0, 10, con)
+            assertTrue(page.totalRowCount > 0, "totalRowCount should be > 0")
+            assertTrue(page.rows.isNotEmpty(), "rows should not be empty")
+        }
+    }
 
     @Test
     fun testBaseQueryWithFetch() {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
@@ -11,6 +11,8 @@ import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.model.classic.author.*
 import org.babyfish.jimmer.sql.kt.model.classic.book.*
 import org.babyfish.jimmer.sql.kt.model.classic.store.*
+import org.babyfish.jimmer.sql.kt.model.inheritance.Role
+import org.babyfish.jimmer.sql.kt.model.inheritance.name
 import org.babyfish.jimmer.sql.kt.model.embedded.Transform
 import org.babyfish.jimmer.sql.kt.model.embedded.fetchBy
 import org.babyfish.jimmer.sql.kt.model.embedded.id
@@ -53,6 +55,33 @@ class CteBaseQueryTest : AbstractQueryTest() {
             assertTrue(page.totalRowCount > 0, "totalRowCount should be > 0")
             assertTrue(page.rows.isNotEmpty(), "rows should not be empty")
         }
+    }
+
+    @Test
+    fun testLogicalDeletedAppliedToSubQueryInBaseQuery() {
+        val baseTable = cteBaseTableSymbol {
+            sqlClient.createBaseQuery(BookStore::class) {
+                val roleCount = subQuery(Role::class) {
+                    where(table.name like "ADMIN")
+                    select(rowCount())
+                }
+                selections
+                    .add(table)
+                    .add(roleCount)
+            }
+        }
+        clearExecutions()
+        jdbc { con ->
+            sqlClient.createQuery(baseTable) {
+                orderBy(table._2.desc())
+                select(table._1)
+            }.execute(con)
+        }
+        val sql = executions.last().sql
+        assertTrue(
+            sql.contains("DELETED", ignoreCase = true),
+            "logical-deleted filter must be applied to the Role sub-query under createBaseQuery, but SQL was:\n$sql"
+        )
     }
 
     @Test

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableBaseQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableBaseQueryImpl.java
@@ -163,8 +163,16 @@ public class ConfigurableBaseQueryImpl<T extends BaseTable>
     }
 
     @Override
+    public void accept(@NotNull AstVisitor visitor) {
+        bindParent(visitor);
+        getMutableQuery().applyGlobalFiltersOnce(visitor.getAstContext(), getData().selections);
+        acceptImpl(visitor);
+    }
+
+    @Override
     public void renderTo(@NotNull AbstractSqlBuilder<?> abstractBuilder) {
         SqlBuilder builder = abstractBuilder.assertSimple();
+        getMutableQuery().applyGlobalFiltersOnce(builder.getAstContext(), getData().selections);
         renderTo(builder, builder.getQueryRenderContext().getBaseSelectionRender(this));
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
@@ -352,7 +352,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
                 sqlResult.get_2(),
                 sqlResult.get_3(),
                 Collections.singletonList(Expression.rowCount()),
-                data.tupleCreator,
+                null,
                 getMutableQuery().getPurpose(),
                 data.forUpdate != null
         );
@@ -380,7 +380,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
                 sqlResult.get_2(),
                 sqlResult.get_3(),
                 Collections.singletonList(Expression.rowCount()),
-                data.tupleCreator,
+                null,
                 getMutableQuery().getPurpose(),
                 getForUpdate() != null
         );

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableBaseQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableBaseQueryImpl.java
@@ -26,6 +26,8 @@ public class MutableBaseQueryImpl extends AbstractMutableQueryImpl implements Mu
 
     private StatementContext ctx;
 
+    private boolean globalFiltersApplied;
+
     public MutableBaseQueryImpl(
             JSqlClientImplementor sqlClient,
             TableLike<?> table
@@ -188,6 +190,19 @@ public class MutableBaseQueryImpl extends AbstractMutableQueryImpl implements Mu
     public void resolveVirtualPredicate(AstContext ctx) {
         bindParent(ctx.getStatement());
         super.resolveVirtualPredicate(ctx);
+    }
+
+    public void applyGlobalFiltersOnce(AstContext astContext, List<Selection<?>> selections) {
+        if (globalFiltersApplied) {
+            return;
+        }
+        globalFiltersApplied = true;
+        applyVirtualPredicates(astContext);
+        applyGlobalFilters(
+                astContext,
+                ctx != null ? ctx.getFilterLevel() : FilterLevel.DEFAULT,
+                selections
+        );
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix three independent bugs hit when a CTE-based query built via
`createBaseQuery` projects correlated sub-queries and is then paged with
`fetchPage(...)`.

This fixes three cases:

- A nested sub-query referencing `parentTable` throws `NullPointerException`
  while the base query is being built.
- `fetchPage(...)` over a base table whose original projection is a tuple
  throws `ClassCastException` on the count path.
- Global filters (e.g. `@LogicalDeleted`) are not applied to sub-queries
  declared inside `createBaseQuery`, silently emitting SQL without the
  deleted predicate.

## Failure

A downstream Kotlin query shaped like this failed on Jimmer `0.10.12`:

```kotlin
sql.createQuery(cteBaseTableSymbol {
    sql.createBaseQuery(BookStore::class) {
        val newerEditionCount = subQuery(Book::class) {
            where(table.storeId eq parentTable.id)
            val edition = table.edition
            val storeId = table.storeId
            where(
                exists(
                    subQuery(Book::class) {                 // nested sub-query
                        where(table.storeId eq storeId)
                        where(table.edition gt edition)
                        select(table.id)
                    }
                )
            )
            select(rowCount())
        }
        selections
            .add(table)
            .add(newerEditionCount)
    }
}) {
    orderBy(table._2.desc())
    select(table._1.fetch(BookStoreView::class))
}.fetchPage(page, size)
```

Real stacktrace excerpts:

```text
java.lang.NullPointerException
    at org.babyfish.jimmer.sql.kt.ast.query.impl.KMutableSubQueryImpl.<init>(KMutableSubQueryImpl.kt)
        -> javaSubQuery.parent.getTable()
```

```text
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class java.lang.Long
    at org.babyfish.jimmer.sql.ast.impl.query.ConfigurableRootQueryImpl.simpleCount(ConfigurableRootQueryImpl.java)
    at org.babyfish.jimmer.sql.ast.impl.query.ConfigurableRootQueryImpl.fetchUnlimitedCount(ConfigurableRootQueryImpl.java)
```

And, once the above were fixed, the generated CTE for a sub-query targeting a
logically-deleted entity rendered without the `is_deleted` predicate.

## Cause

- `KMutableSubQueryImpl` resolved `parentTable` eagerly in its constructor,
  before the Java sub-query's parent was bound, so `javaSubQuery.parent`
  was still null. The nested `KSubQueries` were also created without the
  current table, so an inner sub-query could not see its enclosing context.
- `simpleCountImpl` / `simpleExistsImpl` build a reader from a single-element
  selection list (`Expression.rowCount()`) but still passed `data.tupleCreator`.
  For a base query whose original projection is a tuple, that creator expects
  multiple columns and fails on the single count column.
- The global-filter pass early-returns for base tables, and the base-query
  statement's own selections were never walked for filtering, so sub-queries
  declared under `createBaseQuery` never received global filters.

## Fix

- Resolve `KMutableSubQueryImpl.parentTable` lazily and pass the table into
  `KSubQueriesImpl` so nested sub-queries bind to their enclosing query.
- Pass `null` as the tuple creator in `simpleCount` / `simpleExists` so a plain
  single-column (`Long`) reader is used, matching their single-selection shape.
- Add `MutableBaseQueryImpl#applyGlobalFiltersOnce`, an idempotent pass that
  resolves virtual predicates and applies global filters over the base query's
  selections, invoked from `ConfigurableBaseQueryImpl#accept` and `#renderTo`
  so filters apply exactly once per render pass.

## Verification

Added two tests in `CteBaseQueryTest`:

- `testNestedSubQueryAndFetchPageInBaseQuery` — base query over `BookStore`
  with a nested sub-query referencing `parentTable`, then `fetchPage(...)`.
  Reproduces the NPE and `ClassCastException` before the fix; green after.
- `testLogicalDeletedAppliedToSubQueryInBaseQuery` — base query whose
  sub-query targets a logically-deleted entity (`Role`); asserts the generated
  SQL contains the deleted predicate. Fails before the fix; green after.

The downstream endpoint-level query using `cteBaseTableSymbol + createBaseQuery`
with nested sub-queries and `fetchPage(...)` passes with this fix.