### PR TITLE
fix(sql): preserve real-FK @Key prop loaded-state in trigger events

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationTrigger.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationTrigger.java
@@ -21,7 +21,45 @@ public class MutationTrigger {
     private final List<MutationTrigger.ChangedData> changedList = new ArrayList<>();
 
     public void modifyEntityTable(Object oldEntity, Object newEntity) {
-        changedList.add(new MutationTrigger.EntityChangedData(oldEntity, newEntity));
+        changedList.add(new MutationTrigger.EntityChangedData(oldEntity, snapshot(newEntity)));
+    }
+
+    /**
+     * `newEntity` is usually a live draft that keeps participating in the rest
+     * of the save process. For example, `Saver.fetchImpl`/`replaceDraft` may
+     * later reshape that same draft in place - including unloading real-FK
+     * `@Key` props that were already loaded - to match an explicitly requested
+     * `Fetcher`. Since trigger events are only fired after the whole save
+     * command finishes, holding onto the live reference here would let that
+     * later reshaping retroactively corrupt the event already recorded.
+     * <p>
+     * Take an immediate, independent shallow snapshot of the currently loaded
+     * props instead, so later mutation of the original draft cannot affect
+     * the data already captured for this event. No extra SQL is involved:
+     * everything copied here is already in memory.
+     */
+    private static Object snapshot(Object obj) {
+        if (!(obj instanceof DraftSpi)) {
+            return obj;
+        }
+        DraftSpi spi = (DraftSpi) obj;
+        if (spi.__isResolved()) {
+            return obj;
+        }
+        DraftContext draftContext = spi.__draftContext();
+        if (draftContext == null) {
+            return obj;
+        }
+        ImmutableType type = spi.__type();
+        DraftSpi snapshot = (DraftSpi) type.getDraftFactory().apply(draftContext, null);
+        for (ImmutableProp prop : type.getProps().values()) {
+            PropId propId = prop.getId();
+            if (spi.__isLoaded(propId)) {
+                snapshot.__set(propId, spi.__get(propId));
+                snapshot.__show(propId, spi.__isVisible(propId));
+            }
+        }
+        return snapshot;
     }
 
     public void insertMiddleTable(ImmutableProp prop, Object sourceId, Object targetId) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -183,13 +183,15 @@ class Operator {
                     );
         }
 
+        int rowCount = execute(builder, batch, false, false);
+        // Fire the trigger after `execute` so the draft already reflects its final,
+        // post-execution state (generated id, version, ...) before being captured.
         MutationTrigger trigger = ctx.trigger;
         if (trigger != null) {
             for (DraftSpi draft : batch.entities()) {
                 trigger.modifyEntityTable(null, draft);
             }
         }
-        int rowCount = execute(builder, batch, false, false);
         AffectedRows.add(ctx.affectedRowCountMap, ctx.path.getType(), rowCount);
     }
 
@@ -306,6 +308,12 @@ class Operator {
         EntityCollection<DraftSpi> entities = changedProps != null ?
                 new EntityList<>(batch.entities().size()) :
                 null;
+        // Drafts keep being mutated in place after this point (id/version filled in
+        // below, and possibly reshaped later by `Saver.fetchImpl`/`replaceDraft` to
+        // match an explicitly requested `Fetcher`). Recording trigger events must be
+        // deferred until the draft reflects its final, post-execution state, so we
+        // only remember which (oldRow, draft) pairs need an event here.
+        List<Object[]> pendingTriggerData = trigger != null ? new ArrayList<>() : null;
         if (entities != null || trigger != null) {
             if (keyProps != null) {
                 Map<Object, ImmutableSpi> subMap = originalIdObjMap != null ?
@@ -314,8 +322,8 @@ class Operator {
                 for (DraftSpi draft : batch.entities()) {
                     ImmutableSpi oldRow = subMap.get(Keys.keyOf(draft, keyProps));
                     if (isChanged(changedProps, oldRow, draft)) {
-                        if (trigger != null) {
-                            trigger.modifyEntityTable(oldRow, draft);
+                        if (pendingTriggerData != null) {
+                            pendingTriggerData.add(new Object[]{oldRow, draft});
                         }
                         if (entities != null) {
                             entities.add(draft);
@@ -329,8 +337,8 @@ class Operator {
                             originalIdObjMap.get(draft.__get(idPropId)) :
                             null;
                     if (isChanged(changedProps, oldRow, draft) || hasOptimisticLock) {
-                        if (trigger != null) {
-                            trigger.modifyEntityTable(oldRow, draft);
+                        if (pendingTriggerData != null) {
+                            pendingTriggerData.add(new Object[]{oldRow, draft});
                         }
                         if (entities != null) {
                             entities.add(draft);
@@ -355,6 +363,11 @@ class Operator {
                 if (rowCounts[index++] == 0) {
                     ctx.throwOptimisticLockError(row);
                 }
+            }
+        }
+        if (pendingTriggerData != null) {
+            for (Object[] pair : pendingTriggerData) {
+                trigger.modifyEntityTable(pair[0], pair[1]);
             }
         }
         AffectedRows.add(ctx.affectedRowCountMap, ctx.path.getType(), rowCount(rowCounts));

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/Endorsement.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/Endorsement.java
@@ -1,0 +1,39 @@
+package org.babyfish.jimmer.sql.model;
+
+import org.babyfish.jimmer.sql.*;
+import org.babyfish.jimmer.sql.meta.UUIDIdGenerator;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Minimal reproduction model for the trigger FK-key-unload bug:
+ * a join-like entity with two real-FK `@Key` props referencing two
+ * distinct parent entity types, plus a nullable `@Key` string,
+ * and its own client-side-generated id (loaded on the draft before insert).
+ */
+@DatabaseValidationIgnore
+@Entity
+@KeyUniqueConstraint(noMoreUniqueConstraints = true, isNullNotDistinct = true)
+public interface Endorsement {
+
+    @Id
+    @GeneratedValue(generatorType = UUIDIdGenerator.class)
+    UUID id();
+
+    @Nullable
+    @Key
+    String code();
+
+    @Key
+    @ManyToOne
+    @OnDissociate(DissociateAction.LAX)
+    BookStore bookStore();
+
+    @Key
+    @ManyToOne
+    @OnDissociate(DissociateAction.LAX)
+    Author author();
+
+    String level();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/trigger/FkKeyPropLoadStateTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/trigger/FkKeyPropLoadStateTest.java
@@ -1,0 +1,66 @@
+package org.babyfish.jimmer.sql.trigger;
+
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.event.EntityEvent;
+import org.babyfish.jimmer.sql.event.TriggerType;
+import org.babyfish.jimmer.sql.model.Endorsement;
+import org.babyfish.jimmer.sql.model.EndorsementDraft;
+import org.babyfish.jimmer.sql.model.EndorsementFetcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.babyfish.jimmer.sql.common.Constants.eveId;
+import static org.babyfish.jimmer.sql.common.Constants.oreillyId;
+
+/**
+ * Reproduces a production bug: an entity with two real-FK `@Key` props referencing
+ * two distinct parent entity types, and its own client-side-generated id, loses the
+ * loaded-state of one FK prop on the `EntityEvent.getNewEntity()` fired for an INSERT
+ * via a TRANSACTION_ONLY trigger.
+ */
+public class FkKeyPropLoadStateTest extends AbstractMutationTest {
+
+    @Test
+    public void testBothRealFkKeyPropsLoadedOnInsertEvent() {
+        JSqlClient sqlClient = getSqlClient(builder -> builder.setTriggerType(TriggerType.TRANSACTION_ONLY));
+
+        AtomicReference<EntityEvent<Endorsement>> capturedEvent = new AtomicReference<>();
+        sqlClient.getTriggers(true).addEntityListener(Endorsement.class, capturedEvent::set);
+
+        jdbc(con ->
+                sqlClient.getEntities().saveCommand(
+                        EndorsementDraft.$.produce(draft -> {
+                            draft.setCode("GOLD_TIER");
+                            draft.applyBookStore(s -> s.setId(oreillyId));
+                            draft.applyAuthor(a -> a.setId(eveId));
+                            draft.setLevel("FEATURED");
+                        })
+                ).execute(
+                        con,
+                        EndorsementFetcher.$.level().bookStore()
+                )
+        );
+
+        EntityEvent<Endorsement> event = capturedEvent.get();
+        Assertions.assertNotNull(event, "No EntityEvent was fired for the insert");
+
+        ImmutableSpi newEntity = (ImmutableSpi) event.getNewEntity();
+        ImmutableType type = newEntity.__type();
+
+        Assertions.assertTrue(
+                newEntity.__isLoaded(type.getProp("bookStore").getId()),
+                "`bookStore` (real-FK @Key prop) should still be loaded on the fired EntityEvent's newEntity, " +
+                        "because it was explicitly set on the input draft before save"
+        );
+        Assertions.assertTrue(
+                newEntity.__isLoaded(type.getProp("author").getId()),
+                "`author` (real-FK @Key prop) should still be loaded on the fired EntityEvent's newEntity, " +
+                        "because it was explicitly set on the input draft before save"
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -4,6 +4,7 @@ create schema if not exists C;
 create schema if not exists D;
 
 
+drop table endorsement if exists;
 drop table issue1125_mp_role_perm if exists;
 drop table issue1125_sys_role if exists;
 drop table issue1125_sys_perm if exists;
@@ -1688,4 +1689,19 @@ create table dual_parent_child(
     constraint fk_dual_parent_child__right
         foreign key(right_id)
             references tenant(id)
+);
+
+create table endorsement(
+    id uuid not null,
+    code varchar(50),
+    book_store_id uuid not null,
+    author_id uuid not null,
+    level varchar(20) not null,
+    constraint pk_endorsement primary key(id),
+    constraint fk_endorsement__book_store
+        foreign key(book_store_id)
+            references book_store(id),
+    constraint fk_endorsement__author
+        foreign key(author_id)
+            references author(id)
 );


### PR DESCRIPTION
## Summary

Entity with two real-FK `@Key` props loses loaded-state of one prop on
the `EntityEvent` fired for INSERT, when the save command is given an
explicit `Fetcher`. The association-changed event for that prop's
inverse side never fires - cache/listener on that side never invalidates.

## Model

```java
@Entity
public interface Endorsement {

    @Id
    @GeneratedValue(generatorType = UUIDIdGenerator.class)
    UUID id();

    @Key
    @ManyToOne
    BookStore bookStore();

    @Key
    @ManyToOne
    Author author();

    String level();
}
```

## Repro

```java
trigger.addEntityListener(Endorsement.class, e -> capturedEvent.set(e));

saveCommand(
    Endorsement { bookStore { id = oreillyId }; author { id = eveId }; level = "FEATURED" }
).execute(con, newFetcher(Endorsement.class).by { level(); bookStore() }); // author omitted

// capturedEvent.newEntity: bookStore loaded, author NOT loaded
```

## Cause

`Operator` hands the *live* `DraftSpi` to
`MutationTrigger.modifyEntityTable(oldRow, draft)` right after insert.
`MutationTrigger.changedList` keeps that same reference until the save
command finishes.

Later in the same save, `Saver.fetchImpl()` → `replaceDraft()` reshapes
that same draft to match the requested `Fetcher`, unloading every prop
not in it - `author` included. Event was recorded by reference, not by
value, so this retroactively corrupts it.

## Fix

- `MutationTrigger.modifyEntityTable` snapshots the draft's loaded props
  immediately instead of holding the live reference.
- `Operator` calls `modifyEntityTable(...)` *after*
  `execute(...)`/`executeAndGetRowCounts(...)`, so generated id/version
  are part of the snapshot too.

No extra query - everything was already in memory.

## Verification

`FkKeyPropLoadStateTest#testBothRealFkKeyPropsLoadedOnInsertEvent` -
red before fix (`author` unloaded), green after.