### PR TITLE
Specifications api polishing and createUpdate improvement

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/util/Keywords.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/impl/util/Keywords.java
@@ -40,6 +40,7 @@ public class Keywords {
 
                             // Specification
                             "applyTo", "entityType",
+                            "and", "or", "not",
 
                             // AbstractTypedTable
                             "immutableType",

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -697,15 +697,6 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
     }
 
     private DtoPolymorphicBranch<T, P> buildDefaultBranch(DtoParser.DefaultBranchContext branch) {
-        if (!branch.dtoBody().macros.isEmpty() ||
-                !branch.dtoBody().explicitProps.isEmpty() ||
-                !branch.dtoBody().typesBlocks.isEmpty()) {
-            throw ctx.exception(
-                    branch.dtoBody().start.getLine(),
-                    branch.dtoBody().start.getCharPositionInLine(),
-                    "The body of default branch must be empty"
-            );
-        }
         DtoType<T, P> branchType = new DtoTypeBuilder<>(
                 null,
                 baseType,
@@ -717,6 +708,7 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
                 branch.superInterfaces,
                 ctx
         ).build();
+        validateNoNestedTypesBlock(branchType, branch.dtoBody());
         return new DtoPolymorphicBranch<>(
                 DtoPolymorphicBranch.Kind.DEFAULT,
                 null,
@@ -795,14 +787,7 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
                 branch.superInterfaces,
                 ctx
         ).build();
-        if (branchType.getPolymorphism() != null) {
-            DtoParser.TypesBlockContext block = branch.dtoBody().typesBlocks.get(0);
-            throw ctx.exception(
-                    block.start.getLine(),
-                    block.start.getCharPositionInLine(),
-                    "Nested #types block is not supported inside polymorphic DTO type branch"
-            );
-        }
+        validateNoNestedTypesBlock(branchType, branch.dtoBody());
         return new DtoPolymorphicBranch<>(
                 DtoPolymorphicBranch.Kind.TYPE,
                 targetType,
@@ -812,6 +797,17 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
                 branch.targetType.start.getLine(),
                 branch.targetType.start.getCharPositionInLine()
         );
+    }
+
+    private void validateNoNestedTypesBlock(DtoType<T, P> branchType, DtoParser.DtoBodyContext body) {
+        if (branchType.getPolymorphism() != null) {
+            DtoParser.TypesBlockContext block = body.typesBlocks.get(0);
+            throw ctx.exception(
+                    block.start.getLine(),
+                    block.start.getCharPositionInLine(),
+                    "Nested #types block is not supported inside polymorphic DTO branch"
+            );
+        }
     }
 
     private DtoPolymorphicBranch<T, P> implicitTypeBranch(

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1350,27 +1350,32 @@ public class DtoCompilerTest {
     }
 
     @Test
-    public void testDefaultBranchBodyMustBeEmpty() {
-        DtoAstException ex = Assertions.assertThrows(DtoAstException.class, () -> {
-            MyDtoCompiler.client(
-                    "ClientView {\n" +
-                            "    name\n" +
-                            "    #types {\n" +
-                            "        default {\n" +
-                            "            id\n" +
-                            "        }\n" +
-                            "        Person {\n" +
-                            "            firstName\n" +
-                            "        }\n" +
-                            "    }\n" +
-                            "}"
-            );
-        });
-        Assertions.assertEquals(
-                "/User/test/Client.dto:4 : The body of default branch must be empty\n" +
+    public void testDefaultBranchCanDeclareFields() {
+        DtoType<BaseType, BaseProp> dtoType = MyDtoCompiler.client(
+                "ClientView {\n" +
+                        "    id\n" +
+                        "    #types {\n" +
                         "        default {\n" +
-                        "                ^",
-                ex.getMessage()
+                        "            name\n" +
+                        "        }\n" +
+                        "        Organization {\n" +
+                        "            taxCode\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
+        ).get(0);
+        DtoPolymorphism<BaseType, BaseProp> polymorphism = dtoType.getPolymorphism();
+        Assertions.assertNotNull(polymorphism);
+        DtoPolymorphicBranch<BaseType, BaseProp> defaultBranch = polymorphism.getDefaultBranch();
+        Assertions.assertNotNull(defaultBranch);
+        Assertions.assertEquals(
+                Collections.singletonList("name"),
+                defaultBranch.getDtoType().getProps().stream().map(AbstractProp::getAlias).collect(Collectors.toList())
+        );
+        DtoPolymorphicBranch<BaseType, BaseProp> organizationBranch = polymorphism.getTypeBranches().get(0);
+        Assertions.assertEquals(
+                Collections.singletonList("taxCode"),
+                organizationBranch.getDtoType().getProps().stream().map(AbstractProp::getAlias).collect(Collectors.toList())
         );
     }
 
@@ -1462,7 +1467,34 @@ public class DtoCompilerTest {
             );
         });
         Assertions.assertEquals(
-                "/User/test/Client.dto:6 : Nested #types block is not supported inside polymorphic DTO type branch\n" +
+                "/User/test/Client.dto:6 : Nested #types block is not supported inside polymorphic DTO branch\n" +
+                        "            #types {\n" +
+                        "            ^",
+                ex.getMessage()
+        );
+    }
+
+    @Test
+    public void testNestedTypesBlockInDefaultBranchIsRejected() {
+        DtoAstException ex = Assertions.assertThrows(DtoAstException.class, () -> {
+            MyDtoCompiler.client(
+                    "ClientView {\n" +
+                            "    name\n" +
+                            "    #types {\n" +
+                            "        default {\n" +
+                            "            id\n" +
+                            "            #types {\n" +
+                            "                Person {\n" +
+                            "                    firstName\n" +
+                            "                }\n" +
+                            "            }\n" +
+                            "        }\n" +
+                            "    }\n" +
+                            "}"
+            );
+        });
+        Assertions.assertEquals(
+                "/User/test/Client.dto:6 : Nested #types block is not supported inside polymorphic DTO branch\n" +
                         "            #types {\n" +
                         "            ^",
                 ex.getMessage()

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableRootQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableRootQuery.kt
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.kt.ast.query
 import org.babyfish.jimmer.Specification
 import org.babyfish.jimmer.kt.DslScope
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
+import org.babyfish.jimmer.sql.kt.ast.query.specification.KSpecification
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
 import org.babyfish.jimmer.sql.kt.ast.table.KPropsLike
 
@@ -12,6 +13,8 @@ interface KMutableRootQuery<P: KPropsLike> : KMutableQuery<P>, KRootSelectable<P
     fun typeMatchMode(mode: TypeMatchMode)
 
     interface ForEntity<E: Any> : KMutableRootQuery<KNonNullTable<E>> {
+
+        fun where(specification: KSpecification<out E>?)
 
         fun where(specification: Specification<out E>?)
     }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
@@ -4,11 +4,11 @@ import org.babyfish.jimmer.Specification
 import org.babyfish.jimmer.sql.association.Association
 import org.babyfish.jimmer.sql.ast.Expression
 import org.babyfish.jimmer.sql.ast.Selection
+import org.babyfish.jimmer.sql.ast.TypeMatchMode
 import org.babyfish.jimmer.sql.ast.impl.AstContext
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl
 import org.babyfish.jimmer.sql.ast.impl.query.MutableStatementImplementor
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor
-import org.babyfish.jimmer.sql.ast.TypeMatchMode
 import org.babyfish.jimmer.sql.ast.query.Order
 import org.babyfish.jimmer.sql.ast.query.specification.PredicateApplier
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike
@@ -246,15 +246,21 @@ internal abstract class KMutableRootQueryImpl<P: KPropsLike>(
         KNonNullTableExImpl(javaQuery.getTable() as TableImplementor<E>)
     ), KMutableRootQuery.ForEntity<E> {
 
+        override fun where(specification: KSpecification<out E>?) {
+            if (specification != null) {
+                val applier = PredicateApplier(javaQuery)
+                @Suppress("UNCHECKED_CAST")
+                applier.applyKSpecification(specification as KSpecification<E>)
+            }
+        }
+
         override fun where(specification: Specification<out E>?) {
             if (specification != null) {
                 val ks = specification as? KSpecification<out E>
                     ?: throw IllegalArgumentException(
                         "The specification must be instance of \"${KSpecification::class.qualifiedName}\""
-                )
-                val applier = PredicateApplier(javaQuery)
-                @Suppress("UNCHECKED_CAST")
-                applier.applyKSpecification(ks as KSpecification<E>)
+                    )
+                where(ks)
             }
         }
     }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/specification/KSpecification.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/specification/KSpecification.kt
@@ -10,6 +10,29 @@ import org.babyfish.jimmer.sql.ast.table.Table
 interface KSpecification<E : Any> : Specification<E> {
 
     fun applyTo(args: KSpecificationArgs<E>)
+
+    companion object {
+
+        @JvmStatic
+        fun <E : Any> and(vararg specifications: KSpecification<out E>?): KSpecification<E>? =
+            compose(Operator.AND, specifications.asList())
+
+        @JvmStatic
+        fun <E : Any> and(specifications: Iterable<KSpecification<out E>?>): KSpecification<E>? =
+            compose(Operator.AND, specifications)
+
+        @JvmStatic
+        fun <E : Any> or(vararg specifications: KSpecification<out E>?): KSpecification<E>? =
+            compose(Operator.OR, specifications.asList())
+
+        @JvmStatic
+        fun <E : Any> or(specifications: Iterable<KSpecification<out E>?>): KSpecification<E>? =
+            compose(Operator.OR, specifications)
+
+        @JvmStatic
+        fun <E : Any> not(specification: KSpecification<out E>?): KSpecification<E>? =
+            negate(specification)
+    }
 }
 
 fun <E : Any> KSpecification<E>.toJavaSpecification(): JSpecification<E, Table<E>> =

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/specification/KSpecifications.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/specification/KSpecifications.kt
@@ -5,35 +5,8 @@ import org.babyfish.jimmer.sql.ast.Predicate
 import org.babyfish.jimmer.sql.ast.query.specification.PredicateApplier
 import java.util.*
 
-fun <E : Any> allOf(vararg specifications: KSpecification<out E>?): KSpecification<E>? =
-    allOf(specifications.asList())
-
-fun <E : Any> allOf(specifications: Iterable<KSpecification<out E>?>): KSpecification<E>? =
-    of(Op.AND, specifications)
-
-fun <E : Any> anyOf(vararg specifications: KSpecification<out E>?): KSpecification<E>? =
-    anyOf(specifications.asList())
-
-fun <E : Any> anyOf(specifications: Iterable<KSpecification<out E>?>): KSpecification<E>? =
-    of(Op.OR, specifications)
-
-@JvmName("notSpecification")
-fun <E : Any> not(specification: KSpecification<out E>?): KSpecification<E>? =
-    specification?.let {
-        NotKSpecification(castEntityType(it.entityType()), it)
-    }
-
-infix fun <E : Any> KSpecification<E>.and(other: KSpecification<out E>): KSpecification<E> =
-    allOf(this, other)!!
-
-infix fun <E : Any> KSpecification<E>.or(other: KSpecification<out E>): KSpecification<E> =
-    anyOf(this, other)!!
-
-operator fun <E : Any> KSpecification<E>.not(): KSpecification<E> =
-    not(this)!!
-
-private fun <E : Any> of(
-    op: Op,
+internal fun <E : Any> compose(
+    operator: Operator,
     specifications: Iterable<KSpecification<out E>?>
 ): KSpecification<E>? {
     val filteredSpecifications = mutableListOf<KSpecification<out E>>()
@@ -55,18 +28,23 @@ private fun <E : Any> of(
     }
     return when (filteredSpecifications.size) {
         0 -> null
-        else -> CompositeKSpecification(castEntityType(entityType!!), op, filteredSpecifications)
+        else -> CompositeKSpecification(castEntityType(entityType!!), operator, filteredSpecifications)
     }
 }
 
-private enum class Op {
+internal fun <E : Any> negate(specification: KSpecification<out E>?): KSpecification<E>? =
+    specification?.let {
+        NotKSpecification(castEntityType(it.entityType()), it)
+    }
+
+internal enum class Operator {
     AND,
     OR
 }
 
 private class CompositeKSpecification<E : Any>(
     private val entityType: Class<E>,
-    private val op: Op,
+    private val operator: Operator,
     private val specifications: List<KSpecification<out E>>
 ) : KSpecification<E> {
 
@@ -77,7 +55,7 @@ private class CompositeKSpecification<E : Any>(
             capture(args, it)
         }.toTypedArray()
         args.applier.where(
-            if (op == Op.AND) {
+            if (operator == Operator.AND) {
                 Predicate.and(*predicates)
             } else {
                 Predicate.or(*predicates)

--- a/project/jimmer-sql-kotlin/src/test/dto/InheritanceSingleTableClient.dto
+++ b/project/jimmer-sql-kotlin/src/test/dto/InheritanceSingleTableClient.dto
@@ -18,6 +18,18 @@ KClientImplicitCatchAllView {
     }
 }
 
+KClientDefaultBranchFieldView {
+    id
+    #types {
+        default {
+            name
+        }
+        KOrganization class Organization {
+            taxCode
+        }
+    }
+}
+
 sealed KClientRuntimeView {
     id
     name

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/InheritanceSpecificationTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/InheritanceSpecificationTest.kt
@@ -2,9 +2,7 @@ package org.babyfish.jimmer.sql.kt.dto
 
 import org.babyfish.jimmer.runtime.ImmutableSpi
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
-import org.babyfish.jimmer.sql.kt.ast.query.specification.allOf
-import org.babyfish.jimmer.sql.kt.ast.query.specification.anyOf
-import org.babyfish.jimmer.sql.kt.ast.query.specification.not
+import org.babyfish.jimmer.sql.kt.ast.query.specification.KSpecification
 import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.model.inheritance.enumdiscriminator.KEnumClient
 import org.babyfish.jimmer.sql.kt.model.inheritance.enumdiscriminator.dto.KEnumClientSpecification
@@ -97,7 +95,7 @@ class InheritanceSpecificationTest : AbstractQueryTest() {
 
     @Test
     fun testNotSpecificationForLeafOnRootQuery() {
-        val specification = !KPersonSpecification(name = "Bob")
+        val specification = KSpecification.not(KPersonSpecification(name = "Bob"))
         executeAndExpect(
             sqlClient.createQuery(KClient::class) {
                 where(specification)
@@ -118,7 +116,7 @@ class InheritanceSpecificationTest : AbstractQueryTest() {
 
     @Test
     fun testOrSpecificationForInheritanceSiblings() {
-        val specification = anyOf(
+        val specification = KSpecification.or(
             listOf(
                 KPersonSpecification(name = "Acme"),
                 KOrganizationSpecification(name = "Bob")
@@ -146,7 +144,7 @@ class InheritanceSpecificationTest : AbstractQueryTest() {
 
     @Test
     fun testOrSpecificationCanUseSubtypeFieldsForInheritanceSiblings() {
-        val specification = anyOf(
+        val specification = KSpecification.or(
             KPersonSpecification(firstName = "Bob"),
             KOrganizationSpecification(taxCode = "UMB-001")
         )
@@ -173,9 +171,9 @@ class InheritanceSpecificationTest : AbstractQueryTest() {
 
     @Test
     fun testNestedAndOrSpecificationForInheritance() {
-        val specification = allOf(
+        val specification = KSpecification.and(
             KClientSpecification(name = "Bob"),
-            anyOf(
+            KSpecification.or(
                 KPersonSpecification(firstName = "Bob"),
                 KOrganizationSpecification(taxCode = "UMB-001")
             )

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/PolymorphicDtoViewTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/dto/PolymorphicDtoViewTest.kt
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.instantiable.dto
 import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.instantiable.dto.KInstantiableClientSimpleView
 import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.KClient
 import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.KClientProject
+import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.dto.KClientDefaultBranchFieldView
 import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.dto.KClientImplicitCatchAllView
 import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.dto.KClientProjectWithClientView
 import org.babyfish.jimmer.sql.kt.model.inheritance.singletable.dto.KClientRuntimeView
@@ -52,6 +53,24 @@ class PolymorphicDtoViewTest : AbstractQueryTest() {
                 assertEquals("Joined Root", view.name)
             }
         }
+    }
+
+    @Test
+    fun testDefaultBranchFields() {
+        val defaultBranch = KClientDefaultBranchFieldView.Default(
+            id = 20L,
+            name = "Default branch fields"
+        )
+        val view: KClientDefaultBranchFieldView = defaultBranch
+        assertEquals(20L, view.id)
+        assertEquals("Default branch fields", defaultBranch.name)
+
+        val organization = KClientDefaultBranchFieldView.Organization(
+            id = 21L,
+            taxCode = "T-21"
+        )
+        assertEquals(21L, organization.id)
+        assertEquals("T-21", organization.taxCode)
     }
 
     @Test

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
@@ -1,5 +1,7 @@
 package org.babyfish.jimmer.sql.ast.impl;
 
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.impl.associated.VirtualPredicate;
 import org.babyfish.jimmer.sql.ast.impl.associated.VirtualPredicateMergedResult;
@@ -20,10 +22,7 @@ import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.babyfish.jimmer.sql.runtime.TableUsedState;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsedState> implements RootTableResolver {
 
@@ -105,11 +104,18 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
         this.baseTableRenderFrame = baseTableRenderFrame.parent;
     }
 
-    public void pushJoinedTypeBranchUpdate(TableImplementor<?> table, @Nullable String rootAlias) {
+    public void pushJoinedTypeBranchUpdate(
+            TableImplementor<?> table,
+            ImmutableType stageType,
+            @Nullable String rootAlias,
+            Map<ImmutableType, String> stageAliasMap
+    ) {
         this.joinedTypeBranchUpdateFrame = new JoinedTypeBranchUpdateFrame(
                 joinedTypeBranchUpdateFrame,
                 table,
-                rootAlias
+                stageType,
+                rootAlias,
+                stageAliasMap
         );
     }
 
@@ -119,8 +125,18 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     public boolean isJoinedTypeBranchUpdateTarget(TableImplementor<?> table) {
         for (JoinedTypeBranchUpdateFrame frame = joinedTypeBranchUpdateFrame; frame != null; frame = frame.parent) {
-            if (frame.table == table) {
+            if (frame.table == table && frame.stageType == table.getImmutableType()) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isJoinedTypeBranchUpdateTargetStage(TableImplementor<?> table, ImmutableProp prop) {
+        for (JoinedTypeBranchUpdateFrame frame = joinedTypeBranchUpdateFrame; frame != null; frame = frame.parent) {
+            if (frame.table == table) {
+                ImmutableType stageType = TableImplementor.joinedStageType(prop, table.getImmutableType());
+                return stageType == frame.stageType;
             }
         }
         return false;
@@ -131,6 +147,20 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
         for (JoinedTypeBranchUpdateFrame frame = joinedTypeBranchUpdateFrame; frame != null; frame = frame.parent) {
             if (frame.table == table) {
                 return frame.rootAlias;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public String getJoinedTypeBranchUpdateAlias(TableImplementor<?> table, ImmutableProp prop) {
+        for (JoinedTypeBranchUpdateFrame frame = joinedTypeBranchUpdateFrame; frame != null; frame = frame.parent) {
+            if (frame.table == table) {
+                ImmutableType stageType = TableImplementor.joinedStageType(prop, table.getImmutableType());
+                if (stageType == frame.stageType) {
+                    return null;
+                }
+                return frame.stageAliasMap.get(stageType);
             }
         }
         return null;
@@ -566,17 +596,25 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
         final TableImplementor<?> table;
 
+        final ImmutableType stageType;
+
         @Nullable
         final String rootAlias;
+
+        final Map<ImmutableType, String> stageAliasMap;
 
         JoinedTypeBranchUpdateFrame(
                 JoinedTypeBranchUpdateFrame parent,
                 TableImplementor<?> table,
-                @Nullable String rootAlias
+                ImmutableType stageType,
+                @Nullable String rootAlias,
+                Map<ImmutableType, String> stageAliasMap
         ) {
             this.parent = parent;
             this.table = table;
+            this.stageType = stageType;
             this.rootAlias = rootAlias;
+            this.stageAliasMap = stageAliasMap;
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
@@ -5,7 +5,6 @@ import org.babyfish.jimmer.meta.InheritanceInfo;
 import org.babyfish.jimmer.meta.LogicalDeletedInfo;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.InheritanceType;
-import org.babyfish.jimmer.sql.JoinType;
 import org.babyfish.jimmer.sql.JoinedTableDissociateAction;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.PropExpression;
@@ -504,7 +503,7 @@ public class MutableDeleteImpl
             if (deleteJoin != null && deleteJoin.getFrom() == DeleteJoin.From.AS_JOIN) {
                 renderDeleteTarget(builder, table, targetType);
                 if (joinedTypeBranchTableRequired) {
-                    renderJoinedTypeBranchJoin(builder, table);
+                    MutationJoinRenderSupport.renderJoinedTypeBranchJoin(builder, table);
                 }
                 MutationJoinRenderSupport.renderUsedJoinsNormally(builder, table);
             } else {
@@ -517,7 +516,7 @@ public class MutableDeleteImpl
                 builder.enter(SqlBuilder.ScopeType.WHERE);
                 if (deleteJoin != null && deleteJoin.getFrom() == DeleteJoin.From.AS_USING) {
                     if (joinedTypeBranchTableRequired) {
-                        renderJoinedTypeBranchCondition(builder, table);
+                        MutationJoinRenderSupport.renderJoinedTypeBranchCondition(builder, table);
                     }
                     MutationJoinRenderSupport.renderUsedJoinConditions(builder, table);
                 }
@@ -547,7 +546,7 @@ public class MutableDeleteImpl
         builder.sql(MutationRender.alias(builder, table));
         if (updateJoin.getFrom() == UpdateJoin.From.UNNECESSARY) {
             if (joinedTypeBranchTableRequired) {
-                renderJoinedTypeBranchJoin(builder, table);
+                MutationJoinRenderSupport.renderJoinedTypeBranchJoin(builder, table);
             }
             MutationJoinRenderSupport.renderUsedJoinsNormally(builder, table);
         }
@@ -555,7 +554,7 @@ public class MutableDeleteImpl
         if (updateJoin.getFrom() == UpdateJoin.From.AS_JOIN) {
             builder.from().enter(SqlBuilder.ScopeType.COMMA);
             if (joinedTypeBranchTableRequired) {
-                renderJoinedTypeBranchFrom(builder, table);
+                MutationJoinRenderSupport.renderJoinedTypeBranchFrom(builder, table);
             }
             MutationJoinRenderSupport.renderUsedJoinsAsFrom(builder, table);
             builder.leave();
@@ -565,7 +564,7 @@ public class MutableDeleteImpl
             builder.enter(SqlBuilder.ScopeType.WHERE);
             if (updateJoin.getFrom() == UpdateJoin.From.AS_JOIN) {
                 if (joinedTypeBranchTableRequired) {
-                    renderJoinedTypeBranchCondition(builder, table);
+                    MutationJoinRenderSupport.renderJoinedTypeBranchCondition(builder, table);
                 }
                 MutationJoinRenderSupport.renderUsedJoinConditions(builder, table);
             }
@@ -584,7 +583,7 @@ public class MutableDeleteImpl
     ) {
         builder.sql(" using ").enter(SqlBuilder.ScopeType.COMMA);
         if (joinedTypeBranchTableRequired) {
-            renderJoinedTypeBranchFrom(builder, table);
+            MutationJoinRenderSupport.renderJoinedTypeBranchFrom(builder, table);
         }
         MutationJoinRenderSupport.renderUsedJoinsAsFrom(builder, table);
         builder.leave();
@@ -671,48 +670,6 @@ public class MutableDeleteImpl
             builder.sql(" ");
         }
         builder.sql(MutationRender.alias(builder, table));
-    }
-
-    private void renderJoinedTypeBranchJoin(SqlBuilder builder, TableImplementor<?> table) {
-        builder.join(JoinType.INNER);
-        renderJoinedTypeBranchFrom(builder, table);
-        builder.on();
-        renderJoinedTypeBranchCondition(builder, table);
-    }
-
-    private void renderJoinedTypeBranchFrom(SqlBuilder builder, TableImplementor<?> table) {
-        builder
-                .sql(table.getImmutableType().getTableName(getSqlClient().getMetadataStrategy()))
-                .sql(" ")
-                .sql(joinedTypeBranchAlias(builder, table));
-    }
-
-    private void renderJoinedTypeBranchCondition(SqlBuilder builder, TableImplementor<?> table) {
-        InheritanceInfo inheritanceInfo = table.getImmutableType().getInheritanceInfo();
-        ImmutableType rootType = inheritanceInfo.getRootType();
-        MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
-        ColumnDefinition rootDefinition = rootType.getIdProp().getStorage(strategy);
-        ColumnDefinition branchDefinition = table.getImmutableType().getIdProp().getStorage(strategy);
-        String rootAlias = MutationRender.alias(builder, table);
-        String branchAlias = joinedTypeBranchAlias(builder, table);
-        int size = rootDefinition.size();
-        builder.enter(SqlBuilder.ScopeType.AND);
-        for (int i = 0; i < size; i++) {
-            builder
-                    .separator()
-                    .sql(rootAlias)
-                    .sql(".")
-                    .sql(rootDefinition.name(i))
-                    .sql(" = ")
-                    .sql(branchAlias)
-                    .sql(".")
-                    .sql(branchDefinition.name(i));
-        }
-        builder.leave();
-    }
-
-    private String joinedTypeBranchAlias(SqlBuilder builder, TableImplementor<?> table) {
-        return TableImplementor.joinedTypeBranchAlias(builder, table);
     }
 
     private ImmutableType directDeleteTargetType(boolean logicalDeleted) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
@@ -13,7 +13,10 @@ import org.babyfish.jimmer.sql.ast.impl.*;
 import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsageCollector;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsages;
-import org.babyfish.jimmer.sql.ast.impl.table.*;
+import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
+import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
+import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
+import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
 import org.babyfish.jimmer.sql.ast.mutation.MutableUpdate;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.PropExpressionImplementor;
@@ -46,6 +49,8 @@ public class MutableUpdateImpl
     private TypeMatchMode typeMatchMode = TypeMatchMode.AUTO;
 
     private boolean typeMatchPredicateApplied;
+
+    private ImmutableType assignmentStageType;
 
     public MutableUpdateImpl(JSqlClientImplementor sqlClient, ImmutableType immutableType) {
         super(sqlClient, immutableType);
@@ -154,14 +159,33 @@ public class MutableUpdateImpl
                     "\""
             );
         }
-        if (!TableImplementor.isPropOwnedByStage(originalProp, updateType)) {
+        ImmutableType stageType = TableImplementor.joinedStageType(originalProp, updateType);
+        if (stageType == null) {
             throw new IllegalArgumentException(
                     "Cannot update property \"" +
                     target.prop +
                     "\" by createUpdate for joined inheritance type \"" +
                     updateType +
-                    "\" because it belongs to the physical table of \"" +
+                    "\" because it does not belong to the inheritance path of \"" +
                     originalProp.getDeclaringType() +
+                    "\""
+            );
+        }
+        ImmutableType prevStageType = assignmentStageType;
+        if (prevStageType == null) {
+            assignmentStageType = stageType;
+        } else if (prevStageType != stageType) {
+            throw new IllegalArgumentException(
+                    "Cannot update property \"" +
+                    target.prop +
+                    "\" by createUpdate for joined inheritance type \"" +
+                    updateType +
+                    "\" because all assignment targets must belong to the same physical table. " +
+                    "Updating columns in multiple physical tables by one createUpdate is not supported " +
+                    "for joined inheritance; previous assignments target physical table \"" +
+                    prevStageType +
+                    "\" and this property targets physical table \"" +
+                    stageType +
                     "\""
             );
         }
@@ -220,6 +244,9 @@ public class MutableUpdateImpl
             return resolvedMode == TypeMatchMode.EXACT;
         }
         if (inheritanceInfo.getStrategy() == InheritanceType.SINGLE_TABLE) {
+            return true;
+        }
+        if (physicalUpdateType() != type) {
             return true;
         }
         if (resolvedMode == TypeMatchMode.POLYMORPHIC) {
@@ -378,6 +405,16 @@ public class MutableUpdateImpl
         return (TableImplementor<?>) super.getTableLikeImplementor();
     }
 
+    private ImmutableType physicalUpdateType() {
+        ImmutableType stageType = assignmentStageType;
+        return stageType != null ? stageType : getTableLikeImplementor().getImmutableType();
+    }
+
+    private boolean isJoinedTypeBranchUpdate() {
+        TableImplementor<?> table = getTableLikeImplementor();
+        return table.isJoinedTypeBranchRoot() && physicalUpdateType() == table.getImmutableType();
+    }
+
     private void accept(@NotNull AstVisitor visitor, boolean visitAssignments) {
         AstContext astContext = visitor.getAstContext();
         freeze(astContext);
@@ -413,6 +450,7 @@ public class MutableUpdateImpl
         boolean joinedTypeBranchUpdatePushed = false;
         try {
             TableImplementor<?> table = getTableLikeImplementor();
+            ImmutableType physicalType = physicalUpdateType();
             Dialect dialect = getSqlClient().getDialect();
             VisitorImpl visitor = new VisitorImpl(builder.getAstContext(), dialect);
             this.accept(visitor);
@@ -420,60 +458,67 @@ public class MutableUpdateImpl
             tableUsages.applyUsedStatesTo(astContext);
             tableUsages.allocateAndBindAliases(astContext);
             UpdateJoin updateJoin = dialect.getUpdateJoin();
-            boolean joinedTypeBranchUpdate = table.isJoinedTypeBranchRoot();
-            boolean joinedTypeBranchRootRequired = visitor.isJoinedTypeBranchRootRequired();
-            if (joinedTypeBranchRootRequired && updateJoin == null) {
+            Map<ImmutableType, String> joinedTypeStageAliasMap =
+                    joinedTypeStageAliasMap(builder, visitor.joinedTypeStageTypes(), physicalType);
+            boolean joinedTypeStageJoinRequired = !joinedTypeStageAliasMap.isEmpty();
+            ImmutableType rootType = table.getImmutableType().getInheritanceInfo() != null ?
+                    table.getImmutableType().getInheritanceInfo().getRootType() :
+                    null;
+            if (joinedTypeStageJoinRequired && updateJoin == null) {
                 throw new ExecutionException(
                         "Table joins for update statement is forbidden by the current dialect, " +
                         "but joined inheritance update for \"" +
                         table.getImmutableType() +
-                        "\" requires joining the root table"
+                        "\" requires joining inheritance stage tables"
                 );
             }
-            if (joinedTypeBranchRootRequired && updateJoin.getFrom() == UpdateJoin.From.AS_ROOT) {
+            if (joinedTypeStageJoinRequired && updateJoin.getFrom() == UpdateJoin.From.AS_ROOT) {
                 throw new ExecutionException(
                         "The current dialect renders update joins from the root table, " +
                         "but joined inheritance update for \"" +
                         table.getImmutableType() +
-                        "\" requires a separate root table alias"
+                        "\" requires separate inheritance stage aliases"
                 );
             }
-            String joinedTypeBranchRootAlias = joinedTypeBranchRootRequired ?
-                    astContext.getTableAliasScope().allocateTableAlias(table) :
-                    null;
             if (aliasSource != null) {
                 astContext.getTableAliasScope().bindAlias(
                         aliasSource.realTable(astContext),
                         getTableLikeImplementor().realTable(astContext)
                 );
             }
-            if (joinedTypeBranchUpdate) {
-                astContext.pushJoinedTypeBranchUpdate(table, joinedTypeBranchRootAlias);
+            if (table.isJoinedTypeBranchRoot() &&
+                    (physicalType != table.getImmutableType() ||
+                            isJoinedTypeBranchUpdate() ||
+                            joinedTypeStageJoinRequired)) {
+                astContext.pushJoinedTypeBranchUpdate(
+                        table,
+                        physicalType,
+                        rootType != null ? joinedTypeStageAliasMap.get(rootType) : null,
+                        joinedTypeStageAliasMap
+                );
                 joinedTypeBranchUpdatePushed = true;
             }
             builder
                     .sql("update ")
-                    .sql(table.getImmutableType().getTableName(getSqlClient().getMetadataStrategy()));
+                    .sql(physicalType.getTableName(getSqlClient().getMetadataStrategy()));
 
             addAlias(builder);
 
             if (updateJoin != null && updateJoin.getFrom() == UpdateJoin.From.UNNECESSARY) {
-                if (joinedTypeBranchRootRequired) {
-                    renderJoinedTypeBranchRootJoin(builder, TableImplementor.RenderMode.NORMAL);
-                }
+                renderJoinedTypeStageJoins(builder, physicalType, joinedTypeStageAliasMap);
                 for (RealTable child : table.realTable(astContext)) {
                     child.renderTo(builder, false);
                 }
             }
 
             builder.enter(SqlBuilder.ScopeType.SET);
-            renderAssignments(builder);
+            renderAssignments(builder, joinedTypeStageJoinRequired);
             builder.leave();
 
-            renderTables(builder);
+            renderTables(builder, physicalType, joinedTypeStageAliasMap);
             renderDeeperJoins(builder);
 
-            renderWhereClause(builder, true, ids);
+            renderWhereClause(builder, true, ids, physicalType, joinedTypeStageAliasMap);
 
         } finally {
             if (joinedTypeBranchUpdatePushed) {
@@ -521,21 +566,21 @@ public class MutableUpdateImpl
                 builder.leave();
             } else {
                 table.renderTo(builder);
-                renderWhereClause(builder, false, null);
+                renderWhereClause(builder, false, null, null, Collections.emptyMap());
             }
         } finally {
             astContext.popStatement();
         }
     }
 
-    private void renderAssignments(SqlBuilder builder) {
+    private void renderAssignments(SqlBuilder builder, boolean joinedTypeStageJoinRequired) {
         TableImplementor<?> table = getTableLikeImplementor();
         UpdateJoin updateJoin = getSqlClient().getDialect().getUpdateJoin();
         boolean withTargetPrefix =
                 updateJoin != null &&
                 updateJoin.isJoinedTableUpdatable() &&
                 (MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext()) ||
-                        isJoinedTypeBranchRootUpdateRequired(builder));
+                        joinedTypeStageJoinRequired);
         for (Map.Entry<Target, Expression<?>> e : assignmentMap.entrySet()) {
             builder.separator();
             renderTarget(builder, e.getKey(), withTargetPrefix);
@@ -554,7 +599,6 @@ public class MutableUpdateImpl
     }
 
     private void renderTarget(SqlBuilder builder, Target target, boolean withPrefix) {
-        TableImplementor<?> impl = TableProxies.resolve(target.table, builder.getAstContext());
         MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
         ColumnDefinition definition;
         if (target.prop.isEmbedded(EmbeddedLevel.REFERENCE)) {
@@ -569,31 +613,31 @@ public class MutableUpdateImpl
         } else if (target.prop.isReference(TargetLevel.ENTITY)) {
             definition = target.prop.getStorage(strategy);
         } else {
-            definition = target.expr.getPartial(builder.getAstContext().getSqlClient().getMetadataStrategy());
+            EmbeddedColumns.Partial partial = target.expr.getPartial(strategy);
+            definition = partial != null ? partial : target.prop.getStorage(strategy);
         }
-        impl.renderSelection(
-                target.expr.getDeepestProp(),
-                true,
-                builder,
-                definition,
-                withPrefix
+        builder.definition(
+                withPrefix ? MutationRender.alias(builder, getTableLikeImplementor()) : null,
+                definition
         );
     }
 
-    private void renderTables(SqlBuilder builder) {
+    private void renderTables(
+            SqlBuilder builder,
+            @Nullable ImmutableType physicalType,
+            Map<ImmutableType, String> joinedTypeStageAliasMap
+    ) {
         TableImplementor<?> table = getTableLikeImplementor();
-        boolean joinedTypeBranchRootRequired = isJoinedTypeBranchRootUpdateRequired(builder);
+        boolean joinedTypeStageJoinRequired = !joinedTypeStageAliasMap.isEmpty();
         boolean usedChild = MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext());
-        if (joinedTypeBranchRootRequired || usedChild) {
+        if (joinedTypeStageJoinRequired || usedChild) {
             switch (getSqlClient().getDialect().getUpdateJoin().getFrom()) {
                 case AS_ROOT:
                     table.renderTo(builder);
                     break;
                 case AS_JOIN:
-                    builder.from().enter(",");
-                    if (joinedTypeBranchRootRequired) {
-                        renderJoinedTypeBranchRootJoin(builder, TableImplementor.RenderMode.FROM_ONLY);
-                    }
+                    builder.from().enter(SqlBuilder.ScopeType.COMMA);
+                    renderJoinedTypeStageFroms(builder, physicalType, joinedTypeStageAliasMap);
                     MutationJoinRenderSupport.renderUsedJoinsAsFrom(builder, table);
                     builder.leave();
             }
@@ -611,16 +655,22 @@ public class MutableUpdateImpl
         }
     }
 
-    private void renderWhereClause(SqlBuilder builder, boolean forUpdate, Collection<Object> ids) {
+    private void renderWhereClause(
+            SqlBuilder builder,
+            boolean forUpdate,
+            Collection<Object> ids,
+            @Nullable ImmutableType physicalType,
+            Map<ImmutableType, String> joinedTypeStageAliasMap
+    ) {
 
         TableImplementor<?> table = getTableLikeImplementor();
         UpdateJoin updateJoin = getSqlClient().getDialect().getUpdateJoin();
 
-        boolean hasJoinedTypeBranchRootCondition =
+        boolean hasJoinedTypeStageCondition =
                 forUpdate &&
                 updateJoin != null &&
                 updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
-                isJoinedTypeBranchRootUpdateRequired(builder);
+                !joinedTypeStageAliasMap.isEmpty();
 
         boolean hasTableCondition =
                 forUpdate &&
@@ -628,7 +678,7 @@ public class MutableUpdateImpl
                 updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
                 MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext());
 
-        if (!hasJoinedTypeBranchRootCondition &&
+        if (!hasJoinedTypeStageCondition &&
                 !hasTableCondition &&
                 ids == null &&
                 !unfrozenPredicates().iterator().hasNext()) {
@@ -642,12 +692,12 @@ public class MutableUpdateImpl
                     MutationRender.alias(builder, table),
                     table.getImmutableType().getIdProp().getStorage(getSqlClient().getMetadataStrategy()),
                     ids,
-                    builder
+                builder
             );
         }
 
-        if (hasJoinedTypeBranchRootCondition) {
-            renderJoinedTypeBranchRootJoin(builder, TableImplementor.RenderMode.WHERE_ONLY);
+        if (hasJoinedTypeStageCondition) {
+            renderJoinedTypeStageConditions(builder, physicalType, joinedTypeStageAliasMap);
         }
 
         if (hasTableCondition) {
@@ -665,66 +715,91 @@ public class MutableUpdateImpl
         builder.leave();
     }
 
-    private boolean isJoinedTypeBranchRootUpdateRequired(SqlBuilder builder) {
-        return builder.getAstContext().getJoinedTypeBranchUpdateRootAlias(getTableLikeImplementor()) != null;
+    private Map<ImmutableType, String> joinedTypeStageAliasMap(
+            SqlBuilder builder,
+            Collection<ImmutableType> stageTypes,
+            ImmutableType physicalType
+    ) {
+        if (stageTypes.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        TableImplementor<?> table = getTableLikeImplementor();
+        Map<ImmutableType, String> aliasMap = new LinkedHashMap<>();
+        for (ImmutableType stageType : stageTypes) {
+            if (stageType != physicalType) {
+                aliasMap.put(stageType, joinedTypeStageAlias(builder, table, stageType, physicalType));
+            }
+        }
+        return aliasMap;
     }
 
-    private void renderJoinedTypeBranchRootJoin(
+    private String joinedTypeStageAlias(
             SqlBuilder builder,
-            TableImplementor.RenderMode mode
+            TableImplementor<?> table,
+            ImmutableType stageType,
+            ImmutableType physicalType
+    ) {
+        ImmutableType type = table.getImmutableType();
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        if (stageType == inheritanceInfo.getRootType() && physicalType == type) {
+            return builder.getAstContext().getTableAliasScope().allocateTableAlias(table);
+        }
+        if (stageType == type) {
+            return MutationJoinRenderSupport.joinedTypeBranchAlias(builder, table);
+        }
+        String alias = MutationRender.alias(builder, table);
+        return alias +
+                (alias.endsWith("_") ? "_" : "__") +
+                stageType.getJavaClass().getSimpleName().toLowerCase(Locale.ROOT);
+    }
+
+    private void renderJoinedTypeStageJoins(
+            SqlBuilder builder,
+            ImmutableType physicalType,
+            Map<ImmutableType, String> aliasMap
     ) {
         TableImplementor<?> table = getTableLikeImplementor();
-        InheritanceInfo inheritanceInfo = table.getImmutableType().getInheritanceInfo();
-        ImmutableType rootType = inheritanceInfo.getRootType();
-        String rootAlias = builder.getAstContext().getJoinedTypeBranchUpdateRootAlias(table);
-        MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
-        switch (mode) {
-            case NORMAL:
-                builder
-                        .join(JoinType.INNER)
-                        .sql(rootType.getTableName(strategy))
-                        .sql(" ")
-                        .sql(rootAlias)
-                        .on();
-                break;
-            case FROM_ONLY:
-                builder
-                        .separator()
-                        .sql(rootType.getTableName(strategy))
-                        .sql(" ")
-                        .sql(rootAlias);
-                return;
-            case WHERE_ONLY:
-                builder.separator();
-                break;
-            default:
-                throw new AssertionError("Internal bug: Illegal render mode for joined type branch update root");
+        for (Map.Entry<ImmutableType, String> e : aliasMap.entrySet()) {
+            MutationJoinRenderSupport.renderJoinedTypeStageJoin(
+                    builder,
+                    table,
+                    physicalType,
+                    e.getKey(),
+                    e.getValue()
+            );
         }
-        renderJoinedTypeBranchRootJoinCondition(builder, rootAlias);
     }
 
-    private void renderJoinedTypeBranchRootJoinCondition(SqlBuilder builder, String rootAlias) {
-        TableImplementor<?> table = getTableLikeImplementor();
-        MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
-        ImmutableType type = table.getImmutableType();
-        ImmutableType rootType = type.getInheritanceInfo().getRootType();
-        ColumnDefinition rootDefinition = rootType.getIdProp().getStorage(strategy);
-        ColumnDefinition targetDefinition = type.getIdProp().getStorage(strategy);
-        String targetAlias = MutationRender.alias(builder, table);
-        int size = rootDefinition.size();
-        builder.enter(SqlBuilder.ScopeType.AND);
-        for (int i = 0; i < size; i++) {
-            builder
-                    .separator()
-                    .sql(rootAlias)
-                    .sql(".")
-                    .sql(rootDefinition.name(i))
-                    .sql(" = ")
-                    .sql(targetAlias)
-                    .sql(".")
-                    .sql(targetDefinition.name(i));
+    private void renderJoinedTypeStageFroms(
+            SqlBuilder builder,
+            @Nullable ImmutableType physicalType,
+            Map<ImmutableType, String> aliasMap
+    ) {
+        for (Map.Entry<ImmutableType, String> e : aliasMap.entrySet()) {
+            builder.separator();
+            MutationJoinRenderSupport.renderJoinedTypeStageFrom(builder, e.getKey(), e.getValue());
         }
-        builder.leave();
+    }
+
+    private void renderJoinedTypeStageConditions(
+            SqlBuilder builder,
+            @Nullable ImmutableType physicalType,
+            Map<ImmutableType, String> aliasMap
+    ) {
+        if (physicalType == null) {
+            return;
+        }
+        TableImplementor<?> table = getTableLikeImplementor();
+        for (Map.Entry<ImmutableType, String> e : aliasMap.entrySet()) {
+            builder.separator();
+            MutationJoinRenderSupport.renderJoinedTypeStageCondition(
+                    builder,
+                    table,
+                    physicalType,
+                    e.getKey(),
+                    e.getValue()
+            );
+        }
     }
 
     private static class Target {
@@ -786,7 +861,7 @@ public class MutableUpdateImpl
 
         private final Dialect dialect;
 
-        private boolean joinedTypeBranchRootRequired;
+        private final Set<ImmutableType> joinedTypeStageTypes = new LinkedHashSet<>();
 
         public VisitorImpl(AstContext astContext, Dialect dialect) {
             super(astContext);
@@ -796,36 +871,48 @@ public class MutableUpdateImpl
         @Override
         public void visitTableReference(RealTable table, @Nullable ImmutableProp prop, boolean rawId) {
             super.visitTableReference(table, prop, rawId);
-            collectJoinedTypeBranchRootRequirement(table, prop);
+            collectJoinedTypeStageRequirement(table, prop);
             if (dialect != null) {
                 validateTable(table);
             }
         }
 
-        boolean isJoinedTypeBranchRootRequired() {
-            return joinedTypeBranchRootRequired;
+        Collection<ImmutableType> joinedTypeStageTypes() {
+            return joinedTypeStageTypes;
         }
 
-        private void collectJoinedTypeBranchRootRequirement(RealTable table, @Nullable ImmutableProp prop) {
+        private void collectJoinedTypeStageRequirement(RealTable table, @Nullable ImmutableProp prop) {
             TableImplementor<?> updateTable = getTableLikeImplementor();
             if (!updateTable.isJoinedTypeBranchRoot()) {
                 return;
             }
+            ImmutableType updateType = updateTable.getImmutableType();
+            ImmutableType physicalType = physicalUpdateType();
             if (table.getTableLikeImplementor() == updateTable) {
-                if (prop == null || !prop.isId() && updateTable.isRootTableProp(prop)) {
-                    joinedTypeBranchRootRequired = true;
-                    return;
-                }
+                collectJoinedTypeStage(prop, updateType, physicalType);
+                return;
             }
             for (RealTable current = table; current.getParent() != null; current = current.getParent()) {
                 if (current.getParent().getTableLikeImplementor() == updateTable &&
                         current.getTableLikeImplementor() instanceof TableImplementor<?>) {
                     ImmutableProp joinProp = ((TableImplementor<?>) current.getTableLikeImplementor()).getJoinProp();
-                    if (joinProp != null && updateTable.isRootTableProp(joinProp)) {
-                        joinedTypeBranchRootRequired = true;
-                        return;
-                    }
+                    collectJoinedTypeStage(joinProp, updateType, physicalType);
+                    return;
                 }
+            }
+        }
+
+        private void collectJoinedTypeStage(
+                @Nullable ImmutableProp prop,
+                ImmutableType updateType,
+                ImmutableType physicalType
+        ) {
+            if (prop == null || prop.isId() || prop.toOriginal().isId()) {
+                return;
+            }
+            ImmutableType stageType = TableImplementor.joinedStageType(prop, updateType);
+            if (stageType != null && stageType != physicalType) {
+                joinedTypeStageTypes.add(stageType);
             }
         }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationJoinRenderSupport.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationJoinRenderSupport.java
@@ -1,10 +1,14 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.InheritanceInfo;
 import org.babyfish.jimmer.sql.JoinType;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
 import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
+import org.babyfish.jimmer.sql.meta.ColumnDefinition;
+import org.babyfish.jimmer.sql.meta.MetadataStrategy;
 import org.babyfish.jimmer.sql.runtime.SqlBuilder;
 import org.babyfish.jimmer.sql.runtime.TableUsedState;
 
@@ -60,5 +64,94 @@ final class MutationJoinRenderSupport {
         for (RealTable child : table.realTable(builder.getAstContext())) {
             child.renderJoinAsFrom(builder, TableImplementor.RenderMode.WHERE_ONLY);
         }
+    }
+
+    static void renderJoinedTypeBranchJoin(SqlBuilder builder, TableImplementor<?> table) {
+        builder.join(JoinType.INNER);
+        renderJoinedTypeBranchFrom(builder, table);
+        builder.on();
+        renderJoinedTypeBranchCondition(builder, table);
+    }
+
+    static void renderJoinedTypeBranchFrom(SqlBuilder builder, TableImplementor<?> table) {
+        builder
+                .sql(table.getImmutableType().getTableName(builder.sqlClient().getMetadataStrategy()))
+                .sql(" ")
+                .sql(joinedTypeBranchAlias(builder, table));
+    }
+
+    static void renderJoinedTypeBranchCondition(SqlBuilder builder, TableImplementor<?> table) {
+        InheritanceInfo inheritanceInfo = table.getImmutableType().getInheritanceInfo();
+        ImmutableType rootType = inheritanceInfo.getRootType();
+        MetadataStrategy strategy = builder.sqlClient().getMetadataStrategy();
+        ColumnDefinition rootDefinition = rootType.getIdProp().getStorage(strategy);
+        ColumnDefinition branchDefinition = table.getImmutableType().getIdProp().getStorage(strategy);
+        String rootAlias = MutationRender.alias(builder, table);
+        String branchAlias = joinedTypeBranchAlias(builder, table);
+        int size = rootDefinition.size();
+        builder.enter(SqlBuilder.ScopeType.AND);
+        for (int i = 0; i < size; i++) {
+            builder
+                    .separator()
+                    .sql(rootAlias)
+                    .sql(".")
+                    .sql(rootDefinition.name(i))
+                    .sql(" = ")
+                    .sql(branchAlias)
+                    .sql(".")
+                    .sql(branchDefinition.name(i));
+        }
+        builder.leave();
+    }
+
+    static String joinedTypeBranchAlias(SqlBuilder builder, TableImplementor<?> table) {
+        return TableImplementor.joinedTypeBranchAlias(builder, table);
+    }
+
+    static void renderJoinedTypeStageJoin(
+            SqlBuilder builder,
+            TableImplementor<?> table,
+            ImmutableType targetStageType,
+            ImmutableType stageType,
+            String stageAlias
+    ) {
+        builder.join(JoinType.INNER);
+        renderJoinedTypeStageFrom(builder, stageType, stageAlias);
+        builder.on();
+        renderJoinedTypeStageCondition(builder, table, targetStageType, stageType, stageAlias);
+    }
+
+    static void renderJoinedTypeStageFrom(SqlBuilder builder, ImmutableType stageType, String stageAlias) {
+        builder
+                .sql(stageType.getTableName(builder.sqlClient().getMetadataStrategy()))
+                .sql(" ")
+                .sql(stageAlias);
+    }
+
+    static void renderJoinedTypeStageCondition(
+            SqlBuilder builder,
+            TableImplementor<?> table,
+            ImmutableType targetStageType,
+            ImmutableType stageType,
+            String stageAlias
+    ) {
+        MetadataStrategy strategy = builder.sqlClient().getMetadataStrategy();
+        ColumnDefinition targetDefinition = targetStageType.getIdProp().getStorage(strategy);
+        ColumnDefinition stageDefinition = stageType.getIdProp().getStorage(strategy);
+        String targetAlias = MutationRender.alias(builder, table);
+        int size = targetDefinition.size();
+        builder.enter(SqlBuilder.ScopeType.AND);
+        for (int i = 0; i < size; i++) {
+            builder
+                    .separator()
+                    .sql(targetAlias)
+                    .sql(".")
+                    .sql(targetDefinition.name(i))
+                    .sql(" = ")
+                    .sql(stageAlias)
+                    .sql(".")
+                    .sql(stageDefinition.name(i));
+        }
+        builder.leave();
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
@@ -4,11 +4,7 @@ import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.lang.OldChain;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.InheritanceInfo;
-import org.babyfish.jimmer.sql.ast.Expression;
-import org.babyfish.jimmer.sql.ast.Predicate;
-import org.babyfish.jimmer.sql.ast.PropExpression;
-import org.babyfish.jimmer.sql.ast.Selection;
-import org.babyfish.jimmer.sql.ast.TypeMatchMode;
+import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
 import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
@@ -333,11 +329,11 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
                             "\""
             );
         }
-        return where((JSpecification<?, T>) specification);
+        return where((JSpecification<?, ?>) specification);
     }
 
     @Override
-    public MutableRootQuery<T> where(JSpecification<?, T> specification) {
+    public MutableRootQuery<T> where(JSpecification<?, ?> specification) {
         if (specification != null) {
             PredicateApplier applier = new PredicateApplier(this);
             applier.apply(specification);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableImpl.java
@@ -837,7 +837,7 @@ class TableImpl<E> extends AbstractDataManager<TableImpl.Key, TableLikeImplement
             Function<Integer, String> asBlock,
             boolean idViewAllowed
     ) {
-        if (renderJoinedTypeBranchUpdateRootSelection(prop, builder, optionalDefinition, asBlock)) {
+        if (renderJoinedTypeBranchUpdateSelection(prop, builder, optionalDefinition, asBlock)) {
             return;
         }
         realTableForRender(builder).renderSelection(
@@ -851,7 +851,7 @@ class TableImpl<E> extends AbstractDataManager<TableImpl.Key, TableLikeImplement
         );
     }
 
-    private boolean renderJoinedTypeBranchUpdateRootSelection(
+    private boolean renderJoinedTypeBranchUpdateSelection(
             ImmutableProp prop,
             AbstractSqlBuilder<?> builder,
             ColumnDefinition optionalDefinition,
@@ -861,13 +861,19 @@ class TableImpl<E> extends AbstractDataManager<TableImpl.Key, TableLikeImplement
         if (astContext == null || isTreated() || prop.isId() || prop.toOriginal().isId()) {
             return false;
         }
-        String rootAlias = astContext.getJoinedTypeBranchUpdateRootAlias(this);
-        if (rootAlias == null || !isRootTableProp(prop)) {
+        String alias = astContext.getJoinedTypeBranchUpdateAlias(this, prop);
+        if (alias == null) {
+            if (!astContext.isJoinedTypeBranchUpdateTargetStage(this, prop)) {
+                return false;
+            }
+            alias = builder.assertSimple().alias(realTableForRender(builder));
+        }
+        if (alias == null) {
             return false;
         }
         SqlTemplate template = prop.getSqlTemplate();
         if (template instanceof FormulaTemplate) {
-            builder.sql(((FormulaTemplate) template).toSql(rootAlias));
+            builder.sql(((FormulaTemplate) template).toSql(alias));
             if (asBlock != null) {
                 builder.sql(" ").sql(asBlock.apply(0));
             }
@@ -877,7 +883,7 @@ class TableImpl<E> extends AbstractDataManager<TableImpl.Key, TableLikeImplement
         ColumnDefinition definition = optionalDefinition != null ?
                 optionalDefinition :
                 prop.getStorage(strategy);
-        builder.definition(rootAlias, definition, asBlock);
+        builder.definition(alias, definition, asBlock);
         return true;
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableImplementor.java
@@ -257,6 +257,19 @@ public interface TableImplementor<E> extends TableEx<E>, Ast, TableSelection, Ta
         return isDeclaringTypeOwnedByStage(prop.toOriginal().getDeclaringType(), stageType);
     }
 
+    @Nullable
+    static ImmutableType joinedStageType(ImmutableProp prop, ImmutableType type) {
+        if (prop.isId() || prop.toOriginal().isId()) {
+            return type;
+        }
+        for (ImmutableType stageType = type; stageType != null; stageType = stageType.getPrimarySuperType()) {
+            if (stageType.isEntity() && isPropOwnedByStage(prop, stageType)) {
+                return stageType;
+            }
+        }
+        return null;
+    }
+
     static boolean isDeclaringTypeOwnedByStage(ImmutableType declaringType, ImmutableType stageType) {
         if (declaringType == stageType) {
             return true;

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/AbstractValueGetter.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/value/AbstractValueGetter.java
@@ -299,6 +299,11 @@ abstract class AbstractValueGetter implements ValueGetter, GetterMetadata {
             ImmutableProp columnProp,
             String columnName
     ) {
+        String updateAlias = joinedTypeBranchUpdateAlias(builder, tableImplementor, columnProp);
+        if (updateAlias != null) {
+            builder.sql(updateAlias).sql(".").sql(columnName);
+            return true;
+        }
         String rootAlias = joinedTypeBranchUpdateRootAlias(builder, tableImplementor, columnProp);
         if (rootAlias != null) {
             builder.sql(rootAlias).sql(".").sql(columnName);
@@ -310,6 +315,29 @@ abstract class AbstractValueGetter implements ValueGetter, GetterMetadata {
             return true;
         }
         return false;
+    }
+
+    @Nullable
+    private static String joinedTypeBranchUpdateAlias(
+            AbstractSqlBuilder<?> builder,
+            TableImplementor<?> tableImplementor,
+            ImmutableProp columnProp
+    ) {
+        AstContext astContext = builder.getAstContext();
+        if (astContext == null ||
+                columnProp.isId() ||
+                columnProp.toOriginal().isId() ||
+                tableImplementor.isTreated()) {
+            return null;
+        }
+        String alias = astContext.getJoinedTypeBranchUpdateAlias(tableImplementor, columnProp);
+        if (alias != null) {
+            return alias;
+        }
+        if (astContext.isJoinedTypeBranchUpdateTargetStage(tableImplementor, columnProp)) {
+            return builder.assertSimple().alias(tableImplementor.realTableForRender(builder));
+        }
+        return null;
     }
 
     @Nullable

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/MutableRootQuery.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/MutableRootQuery.java
@@ -26,7 +26,7 @@ public interface MutableRootQuery<T extends TableLike<?>> extends MutableQuery, 
     MutableRootQuery<T> where(Specification<?> specification);
 
     @OldChain
-    MutableRootQuery<T> where(JSpecification<?, T> specification);
+    MutableRootQuery<T> where(JSpecification<?, ?> specification);
 
     /**
      * This method is deprecated, using {@code Dynamic Predicates}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/JSpecification.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/JSpecification.java
@@ -2,10 +2,47 @@ package org.babyfish.jimmer.sql.ast.query.specification;
 
 import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.client.ApiIgnore;
+import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 
 @ApiIgnore
 public interface JSpecification<E, T extends TableLike<E>> extends Specification<E> {
+
+    @SafeVarargs
+    @Nullable
+    static <E> JSpecification<E, Table<E>> and(JSpecification<? extends E, ?>... specifications) {
+        return Specifications.compose(Specifications.Operator.AND, Arrays.asList(specifications));
+    }
+
+    @Nullable
+    static <E> JSpecification<E, Table<E>> and(
+            Iterable<? extends JSpecification<? extends E, ?>> specifications
+    ) {
+        return Specifications.compose(Specifications.Operator.AND, specifications);
+    }
+
+    @SafeVarargs
+    @Nullable
+    static <E> JSpecification<E, Table<E>> or(JSpecification<? extends E, ?>... specifications) {
+        return Specifications.compose(Specifications.Operator.OR, Arrays.asList(specifications));
+    }
+
+    @Nullable
+    static <E> JSpecification<E, Table<E>> or(
+            Iterable<? extends JSpecification<? extends E, ?>> specifications
+    ) {
+        return Specifications.compose(Specifications.Operator.OR, specifications);
+    }
+
+    @Nullable
+    static <E> JSpecification<E, Table<E>> not(
+            @Nullable JSpecification<? extends E, ?> specification
+    ) {
+        return Specifications.negate(specification);
+    }
 
     void applyTo(SpecificationArgs<E, T> args);
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/Specifications.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/specification/Specifications.java
@@ -1,7 +1,5 @@
 package org.babyfish.jimmer.sql.ast.query.specification;
 
-import org.babyfish.jimmer.Specification;
-import org.babyfish.jimmer.client.ApiIgnore;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.table.Table;
@@ -9,80 +7,34 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-@ApiIgnore
-public final class Specifications {
+final class Specifications {
 
     private Specifications() {
     }
 
-    @SafeVarargs
     @Nullable
-    public static <E> Specification<E> and(Specification<? extends E>... specifications) {
-        return allOf(Arrays.asList(specifications));
-    }
-
-    @Nullable
-    public static <E> Specification<E> and(Iterable<? extends Specification<? extends E>> specifications) {
-        return allOf(specifications);
-    }
-
-    @SafeVarargs
-    @Nullable
-    public static <E> Specification<E> allOf(Specification<? extends E>... specifications) {
-        return allOf(Arrays.asList(specifications));
-    }
-
-    @Nullable
-    public static <E> Specification<E> allOf(Iterable<? extends Specification<? extends E>> specifications) {
-        return of(Op.AND, specifications);
-    }
-
-    @SafeVarargs
-    @Nullable
-    public static <E> Specification<E> or(Specification<? extends E>... specifications) {
-        return anyOf(Arrays.asList(specifications));
-    }
-
-    @Nullable
-    public static <E> Specification<E> or(Iterable<? extends Specification<? extends E>> specifications) {
-        return anyOf(specifications);
-    }
-
-    @SafeVarargs
-    @Nullable
-    public static <E> Specification<E> anyOf(Specification<? extends E>... specifications) {
-        return anyOf(Arrays.asList(specifications));
-    }
-
-    @Nullable
-    public static <E> Specification<E> anyOf(Iterable<? extends Specification<? extends E>> specifications) {
-        return of(Op.OR, specifications);
-    }
-
-    @Nullable
-    public static <E> Specification<E> not(@Nullable Specification<? extends E> specification) {
+    static <E> JSpecification<E, Table<E>> negate(@Nullable JSpecification<? extends E, ?> specification) {
         if (specification == null) {
             return null;
         }
-        JSpecification<?, ?> implementor = asJSpecification(specification);
         return new NotSpecification<>(
                 castEntityType(specification.entityType()),
-                implementor
+                specification
         );
     }
 
     @Nullable
-    private static <E> Specification<E> of(
-            Op op,
-            Iterable<? extends Specification<? extends E>> specifications
+    static <E> JSpecification<E, Table<E>> compose(
+            Operator operator,
+            Iterable<? extends JSpecification<? extends E, ?>> specifications
     ) {
         List<JSpecification<?, ?>> implementors = new ArrayList<>();
         Class<?> entityType = null;
-        for (Specification<? extends E> specification : specifications) {
+        for (JSpecification<? extends E, ?> specification : specifications) {
             if (specification == null) {
                 continue;
             }
-            implementors.add(asJSpecification(specification));
+            implementors.add(specification);
             entityType = entityType == null ?
                     specification.entityType() :
                     commonEntityType(entityType, specification.entityType());
@@ -98,20 +50,9 @@ public final class Specifications {
         }
         return new CompositeSpecification<>(
                 castEntityType(entityType),
-                op,
+                operator,
                 implementors
         );
-    }
-
-    private static JSpecification<?, ?> asJSpecification(Specification<?> specification) {
-        if (!(specification instanceof JSpecification<?, ?>)) {
-            throw new IllegalArgumentException(
-                    "The specification must be instance of \"" +
-                            JSpecification.class.getName() +
-                            "\""
-            );
-        }
-        return (JSpecification<?, ?>) specification;
     }
 
     static void apply(PredicateApplier applier, JSpecification<?, ?> specification) {
@@ -172,7 +113,7 @@ public final class Specifications {
         return types;
     }
 
-    private enum Op {
+    enum Operator {
         AND,
         OR
     }
@@ -184,17 +125,17 @@ public final class Specifications {
 
         private final Class<E> entityType;
 
-        private final Op op;
+        private final Operator operator;
 
         private final List<JSpecification<?, ?>> specifications;
 
         private CompositeSpecification(
                 Class<E> entityType,
-                Op op,
+                Operator operator,
                 List<JSpecification<?, ?>> specifications
         ) {
             this.entityType = entityType;
-            this.op = op;
+            this.operator = operator;
             this.specifications = specifications;
         }
 
@@ -209,7 +150,7 @@ public final class Specifications {
             for (int i = 0; i < predicates.length; i++) {
                 predicates[i] = capture(args, specifications.get(i));
             }
-            args.where(op == Op.AND ? Predicate.and(predicates) : Predicate.or(predicates));
+            args.where(operator == Operator.AND ? Predicate.and(predicates) : Predicate.or(predicates));
         }
     }
 

--- a/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/inheritance/singletable/Client.dto
+++ b/project/jimmer-sql/src/test/dto/org/babyfish/jimmer/sql/model/inheritance/singletable/Client.dto
@@ -17,6 +17,18 @@ ClientDefaultView {
     }
 }
 
+ClientDefaultBranchFieldView {
+    id
+    #types {
+        default {
+            name
+        }
+        Organization {
+            taxCode
+        }
+    }
+}
+
 ClientImplicitDefaultView {
     id
     name

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/InheritanceSpecificationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/InheritanceSpecificationTest.java
@@ -1,9 +1,8 @@
 package org.babyfish.jimmer.sql.dto;
 
-import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.ast.TypeMatchMode;
-import org.babyfish.jimmer.sql.ast.query.specification.Specifications;
+import org.babyfish.jimmer.sql.ast.query.specification.JSpecification;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.model.inheritance.enumdiscriminator.EnumClientTable;
 import org.babyfish.jimmer.sql.model.inheritance.enumdiscriminator.dto.EnumClientSpecification;
@@ -62,7 +61,7 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         executeAndExpect(
                 getSqlClient()
                         .createQuery(table)
-                        .where(Specifications.allOf(Arrays.asList(nameSpecification, firstNameSpecification)))
+                        .where(JSpecification.and(Arrays.asList(nameSpecification, firstNameSpecification)))
                         .select(table.id()),
                 ctx -> {
                     ctx.sql(
@@ -134,7 +133,7 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         executeAndExpect(
                 getSqlClient()
                         .createQuery(table)
-                        .where(Specifications.not(specification))
+                        .where(JSpecification.not(specification))
                         .select(table.id()),
                 ctx -> {
                     ctx.sql(
@@ -155,7 +154,7 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         executeAndExpect(
                 getSqlClient()
                         .createQuery(table)
-                        .where(Specifications.not(specification))
+                        .where(JSpecification.not(specification))
                         .orderBy(table.id())
                         .select(table.id()),
                 ctx -> {
@@ -177,7 +176,7 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         personSpecification.setName("Acme");
         OrganizationSpecification organizationSpecification = new OrganizationSpecification();
         organizationSpecification.setName("Bob");
-        Specification<Client> specification = Specifications.or(
+        JSpecification<Client, ?> specification = JSpecification.or(
                 personSpecification,
                 organizationSpecification
         );
@@ -208,7 +207,7 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         personSpecification.setFirstName("Bob");
         OrganizationSpecification organizationSpecification = new OrganizationSpecification();
         organizationSpecification.setTaxCode("UMB-001");
-        Specification<Client> specification = Specifications.or(
+        JSpecification<Client, ?> specification = JSpecification.or(
                 personSpecification,
                 organizationSpecification
         );
@@ -246,9 +245,9 @@ public class InheritanceSpecificationTest extends AbstractQueryTest {
         OrganizationSpecification organizationSpecification = new OrganizationSpecification();
         organizationSpecification.setTaxCode("UMB-001");
 
-        Specification<Client> specification = Specifications.allOf(
+        JSpecification<Client, ?> specification = JSpecification.and(
                 clientSpecification,
-                Specifications.or(personSpecification, organizationSpecification)
+                JSpecification.or(personSpecification, organizationSpecification)
         );
         executeAndExpect(
                 getSqlClient()

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/PolymorphicDtoGenerationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dto/PolymorphicDtoGenerationTest.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.model.inheritance.joinedtable.dto.ClientExhaustiv
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.instantiable.dto.InstantiableClientDefaultView;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.instantiable.dto.InstantiableClientExhaustiveView;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.instantiable.dto.InstantiableClientSimpleView;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.dto.ClientDefaultBranchFieldView;
 import org.babyfish.jimmer.sql.model.inheritance.singletable.dto.ClientDefaultView;
 import org.babyfish.jimmer.sql.model.inheritance.singletable.dto.ClientImplicitCatchAllView;
 import org.babyfish.jimmer.sql.model.inheritance.singletable.dto.ClientImplicitDefaultView;
@@ -59,6 +60,27 @@ public class PolymorphicDtoGenerationTest {
         organization.setName("Org");
         organization.setTaxCode("T-2");
         Assertions.assertEquals("T-2", organization.getTaxCode());
+    }
+
+    @Test
+    public void testAbstractRootWithDefaultBranchFields() throws NoSuchMethodException {
+        Assertions.assertThrows(
+                NoSuchMethodException.class,
+                () -> ClientDefaultBranchFieldView.class.getMethod("getName")
+        );
+
+        ClientDefaultBranchFieldView.Default defaultBranch = new ClientDefaultBranchFieldView.Default();
+        defaultBranch.setId(20L);
+        defaultBranch.setName("Default branch fields");
+
+        ClientDefaultBranchFieldView view = defaultBranch;
+        Assertions.assertEquals(20L, view.getId());
+        Assertions.assertEquals("Default branch fields", defaultBranch.getName());
+
+        ClientDefaultBranchFieldView.Organization organization = new ClientDefaultBranchFieldView.Organization();
+        organization.setId(21L);
+        organization.setTaxCode("T-21");
+        Assertions.assertEquals("T-21", organization.getTaxCode());
     }
 
     @Test

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceDMLTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceDMLTest.java
@@ -45,21 +45,51 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUpdateDerivedTypeCannotSetRootProp() {
+    public void testUpdateDerivedTypeCanSetRootProp() {
+        executeAndExpectRowCount(
+                sqlOnlyUpdateJoinClient(1)
+                        .createUpdate(OrganizationTable.class, (u, organization) -> {
+                    u.set(organization.name(), "Globex+");
+                    u.where(organization.taxCode().eq("GLOBEX-001"));
+                }),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "update JOINED_CLIENT tb_1_ " +
+                                        "set NAME = ? " +
+                                        "from JOINED_ORGANIZATION tb_1__sub " +
+                                        "where tb_1_.ID = tb_1__sub.ID " +
+                                        "and tb_1__sub.TAX_CODE = ? " +
+                                        "and tb_1_.CLIENT_TYPE = ?"
+                        );
+                        it.variables("Globex+", "GLOBEX-001", "ORG");
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateDerivedTypeCannotSetPropsOfTwoPhysicalTables() {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
                 () -> getLambdaClient().createUpdate(OrganizationTable.class, (u, organization) -> {
                     u.set(organization.name(), "Globex+");
+                    u.set(organization.taxCode(), "GLOBEX-002");
                     u.where(organization.id().eq(200L));
                 })
         );
         assertEquals(
                 "Cannot update property \"" +
-                        "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization.name" +
+                        "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization.taxCode" +
                         "\" by createUpdate for joined inheritance type \"" +
                         "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization" +
-                        "\" because it belongs to the physical table of \"" +
+                        "\" because all assignment targets must belong to the same physical table. " +
+                        "Updating columns in multiple physical tables by one createUpdate is not supported " +
+                        "for joined inheritance; previous assignments target physical table \"" +
                         "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Client" +
+                        "\" and this property targets physical table \"" +
+                        "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization" +
                         "\"",
                 ex.getMessage()
         );
@@ -183,7 +213,7 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
                                 "update JOINED_ORGANIZATION tb_1_ " +
                                         "set TAX_CODE = ? " +
                                         "from JOINED_CLIENT tb_2_ " +
-                                        "where tb_2_.ID = tb_1_.ID " +
+                                        "where tb_1_.ID = tb_2_.ID " +
                                         "and tb_2_.NAME = ? " +
                                         "and tb_1_.TAX_CODE = ?"
                         );
@@ -208,33 +238,13 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
                                 "update JOINED_ORGANIZATION tb_1_ " +
                                         "set TAX_CODE = ? " +
                                         "from JOINED_CLIENT tb_2_ " +
-                                        "where tb_2_.ID = tb_1_.ID " +
+                                        "where tb_1_.ID = tb_2_.ID " +
                                         "and tb_2_.NAME is not null"
                         );
                         it.variables("GLOBEX-002");
                     });
                     ctx.rowCount(1);
                 }
-        );
-    }
-
-    @Test
-    public void testUpdateDerivedTypeCannotUseRootPropInWhereForAsRootUpdateJoin() {
-        executeAndExpectRowCount(
-                sqlOnlyUpdateJoinClient(1, UpdateJoin.From.AS_ROOT)
-                        .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.taxCode(), "GLOBEX-002");
-                    u.where(organization.name().isNotNull());
-                }),
-                ctx -> ctx.throwable(it -> {
-                    it.type(ExecutionException.class);
-                    it.message(
-                            "The current dialect renders update joins from the root table, " +
-                                    "but joined inheritance update for \"" +
-                                    "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization" +
-                                    "\" requires a separate root table alias"
-                    );
-                })
         );
     }
 
@@ -273,7 +283,7 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
                                 "update JOINED_ORGANIZATION tb_1_ " +
                                         "set TAX_CODE = ? " +
                                         "from JOINED_CLIENT tb_2_ " +
-                                        "where tb_2_.ID = tb_1_.ID " +
+                                        "where tb_1_.ID = tb_2_.ID " +
                                         "and tb_2_.CLIENT_TYPE = ?"
                         );
                         it.variables("ORG-UPDATED", "ORG");
@@ -305,12 +315,8 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
     }
 
     private LambdaClient sqlOnlyUpdateJoinClient(int rowCount) {
-        return sqlOnlyUpdateJoinClient(rowCount, UpdateJoin.From.AS_JOIN);
-    }
-
-    private LambdaClient sqlOnlyUpdateJoinClient(int rowCount, UpdateJoin.From from) {
         return getLambdaClient(it -> {
-            it.setDialect(new H2UpdateJoinDialect(from));
+            it.setDialect(new H2UpdateJoinDialect());
             it.setExecutor(new Executor() {
                 @Override
                 @SuppressWarnings("unchecked")
@@ -336,15 +342,9 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
 
     private static class H2UpdateJoinDialect extends H2Dialect {
 
-        private final UpdateJoin.From from;
-
-        H2UpdateJoinDialect(UpdateJoin.From from) {
-            this.from = from;
-        }
-
         @Override
         public UpdateJoin getUpdateJoin() {
-            return new UpdateJoin(false, from);
+            return new UpdateJoin(false, UpdateJoin.From.AS_JOIN);
         }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/MultiLevelJoinedInheritanceMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/MultiLevelJoinedInheritanceMutationTest.java
@@ -1,19 +1,25 @@
 package org.babyfish.jimmer.sql.mutation.inheritance.joinedtable;
 
+import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.mutation.AffectedTable;
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode;
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
-import org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Asset;
-import org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Car;
-import org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.CarDraft;
-import org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Vehicle;
+import org.babyfish.jimmer.sql.dialect.H2Dialect;
+import org.babyfish.jimmer.sql.dialect.UpdateJoin;
+import org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.*;
+import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.Executor;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiLevelJoinedInheritanceMutationTest extends AbstractMutationTest {
 
@@ -125,5 +131,91 @@ public class MultiLevelJoinedInheritanceMutationTest extends AbstractMutationTes
                     ctx.value("null; [TRUCK, Joined Truck, Volvo, null, 12000, null]");
                 }
         );
+    }
+
+    @Test
+    public void testCreateUpdateLeafCanSetIntermediateProp() {
+        executeAndExpectRowCount(
+                sqlOnlyUpdateJoinClient(1)
+                        .createUpdate(CarTable.class, (u, car) -> {
+                            u.set(car.manufacturer(), "Honda");
+                            u.where(car.seatCount().eq(5));
+                        }),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "update ML_JOINED_VEHICLE tb_1_ " +
+                                        "set MANUFACTURER = ? " +
+                                        "from ML_JOINED_CAR tb_1__sub, ML_JOINED_ASSET tb_1__asset " +
+                                        "where tb_1_.ID = tb_1__sub.ID " +
+                                        "and tb_1_.ID = tb_1__asset.ID " +
+                                        "and tb_1__sub.SEAT_COUNT = ? " +
+                                        "and tb_1__asset.ASSET_TYPE = ?"
+                        );
+                        it.variables("Honda", 5, "CAR");
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    @Test
+    public void testCreateUpdateLeafCannotSetIntermediateAndLeafPropsTogether() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> getLambdaClient().createUpdate(CarTable.class, (u, car) -> {
+                    u.set(car.manufacturer(), "Honda");
+                    u.set(car.seatCount(), 4);
+                    u.where(car.id().eq(800L));
+                })
+        );
+        assertEquals(
+                "Cannot update property \"" +
+                        "org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Car.seatCount" +
+                        "\" by createUpdate for joined inheritance type \"" +
+                        "org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Car" +
+                        "\" because all assignment targets must belong to the same physical table. " +
+                        "Updating columns in multiple physical tables by one createUpdate is not supported " +
+                        "for joined inheritance; previous assignments target physical table \"" +
+                        "org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Vehicle" +
+                        "\" and this property targets physical table \"" +
+                        "org.babyfish.jimmer.sql.model.inheritance.multilevel.joinedtable.Car" +
+                        "\"",
+                ex.getMessage()
+        );
+    }
+
+    private LambdaClient sqlOnlyUpdateJoinClient(int rowCount) {
+        return getLambdaClient(it -> {
+            it.setDialect(new H2UpdateJoinDialect());
+            it.setExecutor(new Executor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <R> R execute(Args<R> args) {
+                    getExecutions().add(Execution.simple(args.sql, args.purpose, args.variables));
+                    return (R) Integer.valueOf(rowCount);
+                }
+
+                @Override
+                public BatchContext executeBatch(
+                        Connection con,
+                        String sql,
+                        ImmutableProp generatedIdProp,
+                        ExecutionPurpose purpose,
+                        JSqlClientImplementor sqlClient,
+                        boolean constraintViolationTranslatable
+                ) {
+                    throw new AssertionError("Batch execution is not expected");
+                }
+            });
+        });
+    }
+
+    private static class H2UpdateJoinDialect extends H2Dialect {
+
+        @Override
+        public UpdateJoin getUpdateJoin() {
+            return new UpdateJoin(false, UpdateJoin.From.AS_JOIN);
+        }
     }
 }


### PR DESCRIPTION
# Summary

- improves generated specification composition API;
- extends low-level `createUpdate` for joined inheritance.

## Specification API

`JSpecification` and `KSpecification` now expose composition helpers directly:

- `and(...)`
- `or(...)`
- `not(...)`

Both vararg and `Iterable` forms are supported. `null` specifications are
ignored, empty composition returns `null`, and composed specifications keep
their inheritance type predicates correctly.

This makes common cases such as:

```java
JSpecification.and(clientSpec, JSpecification.or(personSpec, orgSpec))
```

available without exposing public helper classes or requiring users to know
internal specification plumbing.

The method names are also added to generated-property reserved names to avoid
Kotlin/API surface conflicts.

## Joined Inheritance `createUpdate`

`createUpdate` for `JOINED` inheritance can now update an ancestor or
intermediate physical table through a more specific semantic table.

Examples:

- `createUpdate(Organization).set(name, ...)` updates the root `Client` table
  while filtering through `Organization` fields;
- `createUpdate(Car).set(manufacturer, ...)` updates the intermediate
  `Vehicle` table while filtering through `Car` fields.

The rule is:

- `WHERE` remains normal query-table logic and can reference root,
  intermediate, leaf, joined, treated, and discriminator fields;
- all `SET` targets in one statement must belong to one physical joined
  inheritance stage;
- discriminator assignment is still forbidden for joined inheritance;
- assigning fields from multiple physical stages in one statement is rejected.

This is different from ordinary MySQL-style update joins. MySQL multi-table
assignment is already supported for normal update joins. This PR adds
joined-inheritance support for choosing one physical inheritance stage from the
assigned props; it does not add assigning several inheritance stages in the same
`createUpdate`.