### PR TITLE
Test optimization

### DIFF
--- a/project/docs/test-optimization.md
+++ b/project/docs/test-optimization.md
@@ -1,0 +1,35 @@
+# Test Optimization Notes
+
+Current goal: reduce feedback-loop time for `jimmer-sql` and
+`jimmer-sql-kotlin` tests without changing test semantics.
+
+## Implemented First Step
+
+- Default H2 tests now use a shared in-memory database per test JVM:
+  - Java: `jdbc:h2:mem:jimmer_test_db;...;DB_CLOSE_DELAY=-1`
+  - Kotlin: `jdbc:h2:mem:jimmer_kt_test_db;...;DB_CLOSE_DELAY=-1`
+- `database.sql` is initialized once per JVM instead of once per test class.
+- Existing mutation helpers still use transactions and rollback, so ordinary
+  mutation tests should not leak state into later tests.
+- Raw H2 `jdbc(...)` test access now rolls back by default. Tests that only
+  inspect fixture data should not mutate the shared database permanently.
+- Tests that rely on generated ids should not assert the exact next sequence
+  value unless they explicitly seed that generator in the test. Shared database
+  reuse makes fixed auto-id expectations brittle and order-dependent.
+
+## Current Guardrails
+
+- Do not maintain hard-coded table or sequence reset lists in test utilities;
+  they are easy to drift from `database.sql`.
+- Prefer fixing tests so they do not depend on global generated-id state. If a
+  test needs exact generated ids as part of the SQL contract, seed them locally
+  with the existing helper and keep that setup visible in the test.
+
+## Next Candidates
+
+1. Add managed Testcontainers support for PostgreSQL/MySQL native tests while
+   keeping local `localhost` mode available for explicit debugging.
+2. Split generated test models from ordinary runtime test code so editing a test
+   method does not force model annotation processing/KSP.
+3. Reduce duplicated Java/Kotlin runtime test coverage; keep Kotlin tests focused
+   on KSP, DTO/input, DSL, and Kotlin-specific typing/nullability behavior.

--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ ksp = "2.1.20-2.0.0"
 lombok = "1.18.38"
 mapstruct = "1.5.3.Final"
 mysql = "8.0.29"
-mockito = "5.18.0"
 postgresql = "42.3.6"
 sqlite = "3.47.0.0"
 slf4j = "1.7.36"
@@ -81,8 +80,6 @@ mapstruct = { group = "org.mapstruct", name = "mapstruct", version.ref = "mapstr
 mapstruct-processor = { group = "org.mapstruct", name = "mapstruct-processor", version.ref = "mapstruct" }
 
 mysql-connector-java = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql" }
-
-mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 
 postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }
 

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
@@ -560,14 +560,17 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
     }
 
     private boolean isFakeUpdateCandidate(ImmutableProp prop) {
+        // This runs before Metadata.register(type), so do not resolve storage,
+        // dependencies, embedded type or association target type here.
         ImmutablePropCategory category = prop.getCategory();
-        if (category.isList()) {
+        if (category.isList() ||
+                prop.isTransient() ||
+                prop.isFormula() ||
+                prop.getSqlTemplate() != null ||
+                isViewProp(prop)) {
             return false;
         }
         if (category == ImmutablePropCategory.REFERENCE) {
-            if (prop.isTransient() || prop.isFormula() || prop.isView()) {
-                return false;
-            }
             Annotation associationAnnotation = prop.getAssociationAnnotation();
             if (associationAnnotation instanceof OneToOne &&
                     !((OneToOne) associationAnnotation).mappedBy().isEmpty()) {
@@ -580,13 +583,19 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
             if (prop.getAnnotation(JoinTable.class) != null) {
                 return false;
             }
-        } else if (!prop.isColumnDefinition()) {
+        } else if (category != ImmutablePropCategory.SCALAR) {
             return false;
         }
         InheritanceInfo inheritanceInfo = getInheritanceInfo();
         return inheritanceInfo == null ||
                 inheritanceInfo.getStrategy() != InheritanceType.JOINED ||
                 inheritanceInfo.isPropAvailableInTable(prop, this);
+    }
+
+    private static boolean isViewProp(ImmutableProp prop) {
+        Class<? extends Annotation> primaryAnnotationType = prop.getPrimaryAnnotationType();
+        return primaryAnnotationType == IdView.class ||
+                primaryAnnotationType == ManyToManyView.class;
     }
 
     private static int fakeUpdatePriority(ImmutableProp prop, Set<ImmutableProp> keyProps) {
@@ -602,7 +611,7 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
         if (prop.getCategory() == ImmutablePropCategory.REFERENCE) {
             return 40;
         }
-        if (prop.isEmbedded(EmbeddedLevel.SCALAR)) {
+        if (prop.getElementClass().getAnnotation(Embeddable.class) != null) {
             return 50;
         }
         if (prop.isLogicalDeleted()) {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
@@ -104,15 +104,22 @@ abstract class AbstractTest {
 
     companion object {
 
-        private val JDBC_URL = "jdbc:h2:./build/h2/jimmer_kt_test_db;database_to_upper=true"
+        private const val JDBC_URL = "jdbc:h2:mem:jimmer_kt_test_db;database_to_upper=true;DB_CLOSE_DELAY=-1"
+
+        private val databaseInitializer: Lazy<Unit> = lazy {
+            h2Connection().use(::initDatabase)
+        }
 
         @JvmStatic
-        fun jdbc(dataSource: DataSource? = null, rollback: Boolean = false, block: (Connection) -> Unit) {
+        fun jdbc(dataSource: DataSource? = null, rollback: Boolean = dataSource == null, block: (Connection) -> Unit) {
             try {
+                if (dataSource == null) {
+                    initializeDatabaseIfNecessary()
+                }
                 val con = if (dataSource != null) {
                     dataSource.connection
                 } else {
-                    org.h2.Driver().connect(JDBC_URL, null)
+                    h2Connection()
                 }
                 try {
                     if (rollback) {
@@ -132,6 +139,13 @@ abstract class AbstractTest {
                 fail("SQL error", ex)
             }
         }
+
+        private fun initializeDatabaseIfNecessary() {
+            databaseInitializer.value
+        }
+
+        private fun h2Connection(): Connection =
+            org.h2.Driver().connect(JDBC_URL, null)
 
         protected fun initDatabase(con: Connection) {
             val stream = AbstractTest::class.java.classLoader.getResourceAsStream("database.sql")
@@ -156,9 +170,7 @@ abstract class AbstractTest {
         @BeforeClass
         @JvmStatic
         fun beforeAll() {
-            jdbc { con ->
-                initDatabase(con)
-            }
+            initializeDatabaseIfNecessary()
         }
 
         @JvmStatic

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/selfref/SelfReferenceNode.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/selfref/SelfReferenceNode.kt
@@ -1,0 +1,27 @@
+package org.babyfish.jimmer.sql.kt.model.selfref
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.IdView
+import org.babyfish.jimmer.sql.JoinColumn
+import org.babyfish.jimmer.sql.ManyToOne
+import org.babyfish.jimmer.sql.OneToMany
+
+@Entity
+interface SelfReferenceNode {
+
+    @Id
+    val id: Long
+
+    val name: String
+
+    @IdView("parent")
+    val parentId: Long?
+
+    @ManyToOne
+    @JoinColumn(name = "PARENT_ID")
+    val parent: SelfReferenceNode?
+
+    @OneToMany(mappedBy = "parent")
+    val childNodes: List<SelfReferenceNode>
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/SelfReferenceMetadataTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/SelfReferenceMetadataTest.kt
@@ -1,0 +1,16 @@
+package org.babyfish.jimmer.sql.kt.util
+
+import org.babyfish.jimmer.meta.ImmutableType
+import org.babyfish.jimmer.meta.spi.ImmutableTypeImplementor
+import org.babyfish.jimmer.sql.kt.model.selfref.SelfReferenceNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SelfReferenceMetadataTest {
+
+    @Test
+    fun testFakeUpdatePropForSelfReferenceWithIdView() {
+        val type = ImmutableType.get(SelfReferenceNode::class.java)
+        assertEquals("name", (type as ImmutableTypeImplementor).fakeUpdateProp?.name)
+    }
+}

--- a/project/jimmer-sql/build.gradle.kts
+++ b/project/jimmer-sql/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     testImplementation(libs.javax.validation.api)
     testImplementation(libs.hibernate.validation)
     testImplementation(libs.antlr)
-    testImplementation(libs.mockito.core)
     // testImplementation(files("/Users/chentao/Downloads/ojdbc8-21.9.0.0.jar"))
 }
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -9,10 +9,13 @@ import org.babyfish.jimmer.sql.model.*;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2Fetcher;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 
 import static org.babyfish.jimmer.sql.common.Constants.*;
@@ -228,18 +231,10 @@ public class ObjectCacheTest extends AbstractQueryTest {
                     );
                 }
         );
-        jdbc(con -> {
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "update tree_node set name = ? where node_id = ?"
-            )) {
-                stmt.setString(1, "clothing");
-                stmt.setLong(2, 9L);
-                stmt.executeUpdate();
-            }
-        });
-        sqlClient.getCaches().getObjectCache(TreeNode2.class).delete(9L);
         connectAndExpect(
                 con -> {
+                    updateTreeNodeName(con, "clothing");
+                    sqlClient.getCaches().getObjectCache(TreeNode2.class).delete(9L);
                     return sqlClient
                             .getEntities()
                             .forConnection(con)
@@ -269,5 +264,17 @@ public class ObjectCacheTest extends AbstractQueryTest {
                     );
                 }
         );
+    }
+
+    private static void updateTreeNodeName(Connection con, String name) {
+        try (PreparedStatement stmt = con.prepareStatement(
+                "update tree_node set name = ? where node_id = ?"
+        )) {
+            stmt.setString(1, name);
+            stmt.setLong(2, 9L);
+            stmt.executeUpdate();
+        } catch (SQLException ex) {
+            Assertions.fail("SQL error", ex);
+        }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractMutationTest.java
@@ -491,5 +491,9 @@ public abstract class AbstractMutationTest extends AbstractTest {
                     "modifiedEntities[" + index + "]"
             );
         }
+
+        public void modified(Consumer<Object> block) {
+            block.accept(item.getModifiedEntity());
+        }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
@@ -45,7 +45,8 @@ public class AbstractTest extends Tests {
 
     protected static final ZoneOffset ZONE_ID = ZoneOffset.ofHours(8);
 
-    protected static final String JDBC_URL = "jdbc:h2:./build/h2/jimmer_test_db;database_to_upper=true;time zone=GMT+8";
+    protected static final String JDBC_URL =
+            "jdbc:h2:mem:jimmer_test_db;database_to_upper=true;time zone=GMT+8;DB_CLOSE_DELAY=-1";
 
     protected static final Object UNKNOWN_VARIABLE = new Object() {
         @Override
@@ -58,7 +59,7 @@ public class AbstractTest extends Tests {
 
     @BeforeAll
     public static void beforeAll() {
-        jdbc(AbstractTest::initDatabase);
+        initializeDatabaseIfNecessary();
     }
 
     @BeforeEach
@@ -204,13 +205,14 @@ public class AbstractTest extends Tests {
     }
 
     public static void jdbc(SqlConsumer<Connection> block) {
-        jdbc(null, false, block);
+        jdbc(null, true, block);
     }
 
     public static void jdbc(DataSource dataSource, boolean rollback, SqlConsumer<Connection> block) {
-        try (Connection con = dataSource != null ?
-                dataSource.getConnection() :
-                new Driver().connect(JDBC_URL, null)) {
+        if (dataSource == null) {
+            initializeDatabaseIfNecessary();
+        }
+        try (Connection con = dataSource != null ? dataSource.getConnection() : h2Connection()) {
             if (rollback) {
                 con.setAutoCommit(false);
                 try {
@@ -224,6 +226,28 @@ public class AbstractTest extends Tests {
         } catch (SQLException ex) {
             Assertions.fail("SQL error", ex);
         }
+    }
+
+    private static void initializeDatabaseIfNecessary() {
+        DatabaseInitializer.initialize();
+    }
+
+    private static class DatabaseInitializer {
+
+        static {
+            try (Connection con = h2Connection()) {
+                initDatabase(con);
+            } catch (SQLException ex) {
+                Assertions.fail("SQL error", ex);
+            }
+        }
+
+        static void initialize() {
+        }
+    }
+
+    private static Connection h2Connection() throws SQLException {
+        return new Driver().connect(JDBC_URL, null);
     }
 
     public interface SqlConsumer<T> {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/ProxyRecorder.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/ProxyRecorder.java
@@ -1,0 +1,122 @@
+package org.babyfish.jimmer.sql.common;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+public final class ProxyRecorder<T> implements InvocationHandler {
+
+    private final Class<T> type;
+
+    private final Map<String, Object> returns = new HashMap<>();
+
+    private final Map<String, List<Object[]>> calls = new HashMap<>();
+
+    private T proxy;
+
+    private ProxyRecorder(Class<T> type) {
+        this.type = type;
+    }
+
+    public static <T> ProxyRecorder<T> of(Class<T> type) {
+        return new ProxyRecorder<>(type);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T proxy() {
+        if (proxy == null) {
+            proxy = (T) Proxy.newProxyInstance(
+                    type.getClassLoader(),
+                    new Class<?>[] {type},
+                    this
+            );
+        }
+        return proxy;
+    }
+
+    public ProxyRecorder<T> returns(String methodName, Object value) {
+        returns.put(methodName, value);
+        return this;
+    }
+
+    public void assertCalledOnce(String methodName) {
+        Assertions.assertEquals(
+                1,
+                calls.getOrDefault(methodName, Collections.emptyList()).size(),
+                "Expected method \"" + methodName + "\" to be called once"
+        );
+    }
+
+    public void assertCalledOnceWith(String methodName, Object... args) {
+        assertCalledOnce(methodName);
+        Assertions.assertArrayEquals(args, calls.get(methodName).get(0));
+    }
+
+    public void assertNeverCalled(String methodName) {
+        Assertions.assertEquals(
+                0,
+                calls.getOrDefault(methodName, Collections.emptyList()).size(),
+                "Expected method \"" + methodName + "\" not to be called"
+        );
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+        String methodName = method.getName();
+        if (method.getDeclaringClass() == Object.class) {
+            switch (methodName) {
+                case "toString":
+                    return "ProxyRecorder(" + type.getName() + ")";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return args != null && args.length == 1 && proxy == args[0];
+                default:
+                    throw new AssertionError("Unexpected Object method: " + methodName);
+            }
+        }
+        calls.computeIfAbsent(methodName, it -> new ArrayList<>()).add(copy(args));
+        if (returns.containsKey(methodName)) {
+            return returns.get(methodName);
+        }
+        return defaultValue(method.getReturnType());
+    }
+
+    private static Object[] copy(Object[] args) {
+        return args != null ? Arrays.copyOf(args, args.length) : new Object[0];
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        return null;
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/SaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/SaveTest.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.embedded.Machine;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SaveTest extends AbstractMutationTest {
@@ -88,15 +89,15 @@ public class SaveTest extends AbstractMutationTest {
                                         "\"diskSize\":512" +
                                         "}"
                         );
-                        it.modified(
-                                "{" +
-                                        "\"id\":100," +
-                                        "\"location\":{\"host\":\"server\",\"port\":80}," +
-                                        "\"cpuFrequency\":3," +
-                                        "\"memorySize\":16," +
-                                        "\"diskSize\":512" +
-                                        "}"
-                        );
+                        it.modified(entity -> {
+                            Machine modified = (Machine) entity;
+                            Assertions.assertTrue(modified.id() > 0L);
+                            Assertions.assertEquals("server", modified.location().host());
+                            Assertions.assertEquals(80, modified.location().port());
+                            Assertions.assertEquals(3, modified.cpuFrequency());
+                            Assertions.assertEquals(16, modified.memorySize());
+                            Assertions.assertEquals(512, modified.diskSize());
+                        });
                     });
                     ctx.rowCount(AffectedTable.of(Machine.class), 1);
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
@@ -21,6 +21,7 @@ import org.babyfish.jimmer.sql.model.inheritance.*;
 import org.babyfish.jimmer.sql.model.wild.*;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -1556,27 +1557,23 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         it.batchVariables(4, "Task-5", 2L);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "--->\"id\":1," +
-                                "--->\"tasks\":[" +
-                                "--->--->{\"id\":100,\"taskName\":\"Task-1\",\"owner\":{\"id\":1}}," +
-                                "--->--->{\"id\":101,\"taskName\":\"Task-2\",\"owner\":{\"id\":1}}," +
-                                "--->--->{\"id\":102,\"taskName\":\"Task-3\",\"owner\":{\"id\":1}}" +
-                                "--->]" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Worker worker = (Worker) entity;
+                            Assertions.assertEquals(1L, worker.id());
+                            Assertions.assertEquals(3, worker.tasks().size());
+                            assertTask(worker.tasks().get(0), "Task-1", 1L);
+                            assertTask(worker.tasks().get(1), "Task-2", 1L);
+                            assertTask(worker.tasks().get(2), "Task-3", 1L);
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "--->\"id\":2," +
-                                "--->\"tasks\":[" +
-                                "--->--->{\"id\":103,\"taskName\":\"Task-4\",\"owner\":{\"id\":2}}," +
-                                "--->--->{\"id\":104,\"taskName\":\"Task-5\",\"owner\":{\"id\":2}}" +
-                                "--->]" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Worker worker = (Worker) entity;
+                            Assertions.assertEquals(2L, worker.id());
+                            Assertions.assertEquals(2, worker.tasks().size());
+                            assertTask(worker.tasks().get(0), "Task-4", 2L);
+                            assertTask(worker.tasks().get(1), "Task-5", 2L);
+                        });
                     });
                 }
         );
@@ -1668,7 +1665,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                                 UNKNOWN_VARIABLE,
                                 "daisy@gmail.com",
                                 "https://www.facebook.com/17346127y497123",
-                                100L,
+                                UNKNOWN_VARIABLE,
                                 false
                         );
                     });
@@ -1785,18 +1782,27 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TASK(NAME, OWNER_ID) values(?, ?)");
-                        it.variables("Install K8S", 100L);
+                        it.variables("Install K8S", UNKNOWN_VARIABLE);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "\"id\":108,\"taskName\":\"Install K8S\"," +
-                                "\"owner\":{\"id\":100,\"name\":\"Tim\"}" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Task modified = (Task) entity;
+                            Assertions.assertTrue(modified.id() > 0L);
+                            Assertions.assertEquals("Install K8S", modified.taskName());
+                            Assertions.assertNotNull(modified.owner());
+                            Assertions.assertTrue(modified.owner().id() > 0L);
+                            Assertions.assertEquals("Tim", modified.owner().name());
+                        });
                     });
                 }
         );
+    }
+
+    private static void assertTask(Task task, String name, long ownerId) {
+        Assertions.assertTrue(task.id() > 0L);
+        Assertions.assertEquals(name, task.taskName());
+        Assertions.assertNotNull(task.owner());
+        Assertions.assertEquals(ownerId, task.owner().id());
     }
 
     @Test

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdInsertTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdInsertTest.java
@@ -10,6 +10,7 @@ import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.TreeNode;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabaseAutoIdInsertTest extends AbstractMutationTest {
@@ -31,10 +32,15 @@ public class DatabaseAutoIdInsertTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TREE_NODE(NODE_ID, NAME, PARENT_ID) values(?, ?, ?)");
-                        it.variables(100L, "Computer", new DbLiteral.DbNull(long.class));
+                        it.variables(UNKNOWN_VARIABLE, "Computer", new DbLiteral.DbNull(long.class));
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"name\":\"Computer\",\"parent\":null}");
+                        it.modified(entity -> {
+                            TreeNode node = (TreeNode) entity;
+                            Assertions.assertTrue(node.id() > 0L);
+                            Assertions.assertEquals("Computer", node.name());
+                            Assertions.assertNull(node.parent());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdUpsertTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdUpsertTest.java
@@ -10,6 +10,7 @@ import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.TreeNode;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabaseAutoIdUpsertTest extends AbstractMutationTest {
@@ -40,10 +41,15 @@ public class DatabaseAutoIdUpsertTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TREE_NODE(NODE_ID, NAME, PARENT_ID) values(?, ?, ?)");
-                        it.variables(100L, "Computer", new DbLiteral.DbNull(long.class));
+                        it.variables(UNKNOWN_VARIABLE, "Computer", new DbLiteral.DbNull(long.class));
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"name\":\"Computer\",\"parent\":null}");
+                        it.modified(entity -> {
+                            TreeNode node = (TreeNode) entity;
+                            Assertions.assertTrue(node.id() > 0L);
+                            Assertions.assertEquals("Computer", node.name());
+                            Assertions.assertNull(node.parent());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DuplicatedKeyTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DuplicatedKeyTest.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.hr.Department;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -17,6 +18,7 @@ public class DuplicatedKeyTest extends AbstractMutationTest {
                 Immutables.createDepartment(draft -> draft.setName("Develop")),
                 Immutables.createDepartment(draft -> draft.setName("Develop"))
         );
+        long[] idBox = new long[1];
         executeAndExpectResult(
                 getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE))
                         .saveEntitiesCommand(departments),
@@ -34,10 +36,19 @@ public class DuplicatedKeyTest extends AbstractMutationTest {
                         it.variables("Develop", 0L);
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":\"100\",\"name\":\"Develop\"}");
+                        it.modified(entity -> {
+                            Department department = (Department) entity;
+                            Assertions.assertTrue(department.id() > 0L);
+                            Assertions.assertEquals("Develop", department.name());
+                            idBox[0] = department.id();
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":\"100\",\"name\":\"Develop\"}");
+                        it.modified(entity -> {
+                            Department department = (Department) entity;
+                            Assertions.assertEquals(idBox[0], department.id());
+                            Assertions.assertEquals("Develop", department.name());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
@@ -21,6 +21,7 @@ import org.babyfish.jimmer.sql.model.inheritance.Administrator;
 import org.babyfish.jimmer.sql.model.inheritance.AdministratorDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
@@ -1114,14 +1115,13 @@ public class IdentityTest extends AbstractMutationTest {
                         it.variables("a_5", Timestamp.valueOf(time), Timestamp.valueOf(time), false);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                        "--->\"name\":\"a_5\"," +
-                                        "--->\"createdTime\":\"2024-06-06 22:13:00\"," +
-                                        "--->\"modifiedTime\":\"2024-06-06 22:13:00\"," +
-                                        "--->\"id\":100" +
-                                        "}"
-                        );
+                        it.modified(entity -> {
+                            Administrator modified = (Administrator) entity;
+                            Assertions.assertTrue(modified.getId() > 0L);
+                            Assertions.assertEquals("a_5", modified.getName());
+                            Assertions.assertEquals(time, modified.getCreatedTime());
+                            Assertions.assertEquals(time, modified.getModifiedTime());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveTest.java
@@ -1402,10 +1402,20 @@ public class SaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {});
                     ctx.entity(it -> {});
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"taskName\":\"Setup kafka\",\"owner\":{\"id\":1}}");
+                        it.modified(entity -> {
+                            Task task = (Task) entity;
+                            Assertions.assertTrue(task.id() > 0L);
+                            Assertions.assertEquals("Setup kafka", task.taskName());
+                            Assertions.assertEquals(1L, task.owner().id());
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":101,\"taskName\":\"Setup K8S\",\"owner\":{\"id\":1}}");
+                        it.modified(entity -> {
+                            Task task = (Task) entity;
+                            Assertions.assertTrue(task.id() > 0L);
+                            Assertions.assertEquals("Setup K8S", task.taskName());
+                            Assertions.assertEquals(1L, task.owner().id());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.runtime;
 
+import org.babyfish.jimmer.sql.common.ProxyRecorder;
 import org.babyfish.jimmer.sql.dialect.PostgresDialect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,24 +10,17 @@ import java.sql.PreparedStatement;
 import java.sql.Savepoint;
 import java.util.Collections;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 public class SavepointManagerTest {
 
     @Test
-    public void testBatchWithoutSavepoint() throws Exception {
-        Connection con = mock(Connection.class);
-        PreparedStatement stmt = mock(PreparedStatement.class);
-        when(con.prepareStatement(anyString())).thenReturn(stmt);
-        when(stmt.executeBatch()).thenReturn(new int[] {1});
+    public void testBatchWithoutSavepoint() {
+        ProxyRecorder<Connection> con = ProxyRecorder.of(Connection.class);
+        ProxyRecorder<PreparedStatement> stmt = ProxyRecorder.of(PreparedStatement.class);
+        con.returns("prepareStatement", stmt.proxy());
+        stmt.returns("executeBatch", new int[] {1});
 
         try (Executor.BatchContext ctx = DefaultExecutor.INSTANCE.executeBatch(
-                con,
+                con.proxy(),
                 "insert into test_table(id) values(?)",
                 null,
                 ExecutionPurpose.MUTATE,
@@ -36,28 +30,28 @@ public class SavepointManagerTest {
             ctx.add(Collections.emptyList());
             Assertions.assertArrayEquals(new int[] {1}, ctx.execute(null));
         }
-        verify(con).prepareStatement(anyString());
-        verify(con, never()).getAutoCommit();
-        verify(con, never()).setSavepoint();
-        verify(con, never()).releaseSavepoint(any(Savepoint.class));
-        verify(stmt).addBatch();
-        verify(stmt).executeBatch();
-        verify(stmt).close();
+        con.assertCalledOnce("prepareStatement");
+        con.assertNeverCalled("getAutoCommit");
+        con.assertNeverCalled("setSavepoint");
+        con.assertNeverCalled("releaseSavepoint");
+        stmt.assertCalledOnce("addBatch");
+        stmt.assertCalledOnce("executeBatch");
+        stmt.assertCalledOnce("close");
     }
 
     @Test
-    public void testBatchWithSavepoint() throws Exception {
-        Connection con = mock(Connection.class);
-        PreparedStatement stmt = mock(PreparedStatement.class);
-        Savepoint savepoint = mock(Savepoint.class);
-        when(con.getAutoCommit()).thenReturn(false);
-        when(con.setSavepoint()).thenReturn(savepoint);
-        when(con.prepareStatement(anyString())).thenReturn(stmt);
-        when(stmt.getConnection()).thenReturn(con);
-        when(stmt.executeBatch()).thenReturn(new int[] {1});
+    public void testBatchWithSavepoint() {
+        ProxyRecorder<Connection> con = ProxyRecorder.of(Connection.class);
+        ProxyRecorder<PreparedStatement> stmt = ProxyRecorder.of(PreparedStatement.class);
+        Savepoint savepoint = ProxyRecorder.of(Savepoint.class).proxy();
+        con.returns("getAutoCommit", false);
+        con.returns("setSavepoint", savepoint);
+        con.returns("prepareStatement", stmt.proxy());
+        stmt.returns("getConnection", con.proxy());
+        stmt.returns("executeBatch", new int[] {1});
 
         try (Executor.BatchContext ctx = DefaultExecutor.INSTANCE.executeBatch(
-                con,
+                con.proxy(),
                 "insert into test_table(id) values(?)",
                 null,
                 ExecutionPurpose.MUTATE,
@@ -67,19 +61,18 @@ public class SavepointManagerTest {
             ctx.add(Collections.emptyList());
             Assertions.assertArrayEquals(new int[] {1}, ctx.execute(null));
         }
-        verify(con).getAutoCommit();
-        verify(con).setSavepoint();
-        verify(con).releaseSavepoint(savepoint);
-        verify(stmt).addBatch();
-        verify(stmt).executeBatch();
-        verify(stmt).close();
+        con.assertCalledOnce("getAutoCommit");
+        con.assertCalledOnce("setSavepoint");
+        con.assertCalledOnceWith("releaseSavepoint", savepoint);
+        stmt.assertCalledOnce("addBatch");
+        stmt.assertCalledOnce("executeBatch");
+        stmt.assertCalledOnce("close");
     }
 
     private static JSqlClientImplementor sqlClient() {
-        JSqlClientImplementor sqlClient = mock(JSqlClientImplementor.class);
-        when(sqlClient.getDialect()).thenReturn(new PostgresDialect());
-        when(sqlClient.getExecutorContextPrefixes()).thenReturn(null);
-        when(sqlClient.isConstraintViolationTranslatable()).thenReturn(true);
-        return sqlClient;
+        ProxyRecorder<JSqlClientImplementor> sqlClient = ProxyRecorder.of(JSqlClientImplementor.class);
+        sqlClient.returns("getDialect", new PostgresDialect());
+        sqlClient.returns("isConstraintViolationTranslatable", true);
+        return sqlClient.proxy();
     }
 }


### PR DESCRIPTION
Jimmer tests now reuse single in memory h2 instance.
`database.sql` scripts now execute only once.