### PR TITLE
Update Returning And Streamable Results

### DIFF
--- a/project/docs/test-optimization.md
+++ b/project/docs/test-optimization.md
@@ -1,0 +1,35 @@
+# Test Optimization Notes
+
+Current goal: reduce feedback-loop time for `jimmer-sql` and
+`jimmer-sql-kotlin` tests without changing test semantics.
+
+## Implemented First Step
+
+- Default H2 tests now use a shared in-memory database per test JVM:
+  - Java: `jdbc:h2:mem:jimmer_test_db;...;DB_CLOSE_DELAY=-1`
+  - Kotlin: `jdbc:h2:mem:jimmer_kt_test_db;...;DB_CLOSE_DELAY=-1`
+- `database.sql` is initialized once per JVM instead of once per test class.
+- Existing mutation helpers still use transactions and rollback, so ordinary
+  mutation tests should not leak state into later tests.
+- Raw H2 `jdbc(...)` test access now rolls back by default. Tests that only
+  inspect fixture data should not mutate the shared database permanently.
+- Tests that rely on generated ids should not assert the exact next sequence
+  value unless they explicitly seed that generator in the test. Shared database
+  reuse makes fixed auto-id expectations brittle and order-dependent.
+
+## Current Guardrails
+
+- Do not maintain hard-coded table or sequence reset lists in test utilities;
+  they are easy to drift from `database.sql`.
+- Prefer fixing tests so they do not depend on global generated-id state. If a
+  test needs exact generated ids as part of the SQL contract, seed them locally
+  with the existing helper and keep that setup visible in the test.
+
+## Next Candidates
+
+1. Add managed Testcontainers support for PostgreSQL/MySQL native tests while
+   keeping local `localhost` mode available for explicit debugging.
+2. Split generated test models from ordinary runtime test code so editing a test
+   method does not force model annotation processing/KSP.
+3. Reduce duplicated Java/Kotlin runtime test coverage; keep Kotlin tests focused
+   on KSP, DTO/input, DSL, and Kotlin-specific typing/nullability behavior.

--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ ksp = "2.1.20-2.0.0"
 lombok = "1.18.38"
 mapstruct = "1.5.3.Final"
 mysql = "8.0.29"
-mockito = "5.18.0"
 postgresql = "42.3.6"
 sqlite = "3.47.0.0"
 slf4j = "1.7.36"
@@ -81,8 +80,6 @@ mapstruct = { group = "org.mapstruct", name = "mapstruct", version.ref = "mapstr
 mapstruct-processor = { group = "org.mapstruct", name = "mapstruct-processor", version.ref = "mapstruct" }
 
 mysql-connector-java = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql" }
-
-mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 
 postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }
 

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutableTypeImpl.java
@@ -560,14 +560,17 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
     }
 
     private boolean isFakeUpdateCandidate(ImmutableProp prop) {
+        // This runs before Metadata.register(type), so do not resolve storage,
+        // dependencies, embedded type or association target type here.
         ImmutablePropCategory category = prop.getCategory();
-        if (category.isList()) {
+        if (category.isList() ||
+                prop.isTransient() ||
+                prop.isFormula() ||
+                prop.getSqlTemplate() != null ||
+                isViewProp(prop)) {
             return false;
         }
         if (category == ImmutablePropCategory.REFERENCE) {
-            if (prop.isTransient() || prop.isFormula() || prop.isView()) {
-                return false;
-            }
             Annotation associationAnnotation = prop.getAssociationAnnotation();
             if (associationAnnotation instanceof OneToOne &&
                     !((OneToOne) associationAnnotation).mappedBy().isEmpty()) {
@@ -580,13 +583,19 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
             if (prop.getAnnotation(JoinTable.class) != null) {
                 return false;
             }
-        } else if (!prop.isColumnDefinition()) {
+        } else if (category != ImmutablePropCategory.SCALAR) {
             return false;
         }
         InheritanceInfo inheritanceInfo = getInheritanceInfo();
         return inheritanceInfo == null ||
                 inheritanceInfo.getStrategy() != InheritanceType.JOINED ||
                 inheritanceInfo.isPropAvailableInTable(prop, this);
+    }
+
+    private static boolean isViewProp(ImmutableProp prop) {
+        Class<? extends Annotation> primaryAnnotationType = prop.getPrimaryAnnotationType();
+        return primaryAnnotationType == IdView.class ||
+                primaryAnnotationType == ManyToManyView.class;
     }
 
     private static int fakeUpdatePriority(ImmutableProp prop, Set<ImmutableProp> keyProps) {
@@ -602,7 +611,7 @@ class ImmutableTypeImpl extends AbstractImmutableTypeImpl implements ImmutableTy
         if (prop.getCategory() == ImmutablePropCategory.REFERENCE) {
             return 40;
         }
-        if (prop.isEmbedded(EmbeddedLevel.SCALAR)) {
+        if (prop.getElementClass().getAnnotation(Embeddable.class) != null) {
             return 50;
         }
         if (prop.isLogicalDeleted()) {

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/JSpringSqlClient.java
@@ -166,6 +166,8 @@ class JSpringSqlClient extends JLazyInitializationSqlClient {
         builder.setDefaultEnumStrategy(properties.getDefaultEnumStrategy());
         builder.setDefaultBatchSize(properties.getDefaultBatchSize());
         builder.setDefaultListBatchSize(properties.getDefaultListBatchSize());
+        builder.setDefaultJdbcFetchSize(properties.getDefaultJdbcFetchSize());
+        builder.setDefaultJdbcQueryTimeout(properties.getDefaultJdbcQueryTimeout());
         builder.setInListPaddingEnabled(properties.isInListPaddingEnabled());
         builder.setExpandedInListPaddingEnabled(properties.isExpandedInListPaddingEnabled());
         builder.setDissociationLogicalDeleteEnabled(properties.isDissociationLogicalDeleteEnabled());

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerProperties.java
@@ -60,6 +60,9 @@ public class JimmerProperties {
 
     private final int defaultListBatchSize;
 
+    @NotNull
+    private final Jdbc jdbc;
+
     private final boolean inListPaddingEnabled;
 
     private final boolean expandedInListPaddingEnabled;
@@ -119,6 +122,7 @@ public class JimmerProperties {
             @Nullable String defaultSchema,
             @Nullable Integer defaultBatchSize,
             @Nullable Integer defaultListBatchSize,
+            @Nullable Jdbc jdbc,
             boolean inListPaddingEnabled,
             boolean expandedInListPaddingEnabled,
             boolean dissociationLogicalDeleteEnabled,
@@ -242,6 +246,7 @@ public class JimmerProperties {
                 defaultListBatchSize != null ?
                         defaultListBatchSize :
                         JSqlClient.Builder.DEFAULT_LIST_BATCH_SIZE;
+        this.jdbc = jdbc != null ? jdbc : new Jdbc(null, null);
         this.inListPaddingEnabled = inListPaddingEnabled;
         this.expandedInListPaddingEnabled = expandedInListPaddingEnabled;
         this.dissociationLogicalDeleteEnabled = dissociationLogicalDeleteEnabled;
@@ -433,6 +438,21 @@ public class JimmerProperties {
         return defaultTypeChangeAllowed;
     }
 
+    @Nullable
+    public Integer getDefaultJdbcFetchSize() {
+        return jdbc.getDefaultFetchSize();
+    }
+
+    @Nullable
+    public Integer getDefaultJdbcQueryTimeout() {
+        return jdbc.getDefaultQueryTimeout();
+    }
+
+    @NotNull
+    public Jdbc getJdbc() {
+        return jdbc;
+    }
+
     public boolean isDefaultSaveReturningEnabled() {
         return defaultSaveReturningEnabled;
     }
@@ -510,6 +530,7 @@ public class JimmerProperties {
                 ", defaultSchema='" + defaultSchema + '\'' +
                 ", defaultBatchSize=" + defaultBatchSize +
                 ", defaultListBatchSize=" + defaultListBatchSize +
+                ", jdbc=" + jdbc +
                 ", inListPaddingEnabled=" + inListPaddingEnabled +
                 ", expandedInListPaddingEnabled=" + expandedInListPaddingEnabled +
                 ", dissociationLogicalDeleteEnabled=" + dissociationLogicalDeleteEnabled +
@@ -530,6 +551,39 @@ public class JimmerProperties {
                 ", errorTranslator=" + errorTranslator +
                 ", client=" + client +
                 '}';
+    }
+
+    @ConstructorBinding
+    public static class Jdbc {
+
+        @Nullable
+        private final Integer defaultFetchSize;
+
+        @Nullable
+        private final Integer defaultQueryTimeout;
+
+        public Jdbc(@Nullable Integer defaultFetchSize, @Nullable Integer defaultQueryTimeout) {
+            this.defaultFetchSize = defaultFetchSize;
+            this.defaultQueryTimeout = defaultQueryTimeout;
+        }
+
+        @Nullable
+        public Integer getDefaultFetchSize() {
+            return defaultFetchSize;
+        }
+
+        @Nullable
+        public Integer getDefaultQueryTimeout() {
+            return defaultQueryTimeout;
+        }
+
+        @Override
+        public String toString() {
+            return "Jdbc{" +
+                    "defaultFetchSize=" + defaultFetchSize +
+                    ", defaultQueryTimeout=" + defaultQueryTimeout +
+                    '}';
+        }
     }
 
     @Deprecated

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/support/SpringConnectionManager.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/support/SpringConnectionManager.java
@@ -60,6 +60,32 @@ public class SpringConnectionManager implements DataSourceAwareConnectionManager
     }
 
     @Override
+    public final ConnectionScope open(@Nullable Connection con) {
+        if (con != null) {
+            return ConnectionScope.userConnection(con);
+        }
+        Connection newConnection = DataSourceUtils.getConnection(dataSource);
+        return new ConnectionScope() {
+
+            private boolean closed;
+
+            @Override
+            public Connection connection() {
+                return newConnection;
+            }
+
+            @Override
+            public void close() {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                DataSourceUtils.releaseConnection(newConnection, dataSource);
+            }
+        };
+    }
+
+    @Override
     public final <R> R executeTransaction(Propagation propagation, Function<Connection, R> block) {
         DataSourceTransactionManager tm = transactionManager();
         TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition(behavior(propagation)));

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/SpringJavaTest.java
@@ -76,6 +76,8 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
         "jimmer.database-validation-mode=ERROR",
         "jimmer.dialect=org.babyfish.jimmer.sql.dialect.H2Dialect",
         "jimmer.in-list-to-any-equality-enabled=true",
+        "jimmer.jdbc.default-fetch-size=128",
+        "jimmer.jdbc.default-query-timeout=64",
         "spring.application.name=java-client"
 })
 @SpringBootConfiguration
@@ -252,6 +254,10 @@ public class SpringJavaTest extends AbstractTest {
                 "/my-ts.zip",
                 jimmerProperties.getClient().getTs().getPath()
         );
+        Assertions.assertEquals(128, jimmerProperties.getDefaultJdbcFetchSize());
+        Assertions.assertEquals(128, sqlClient.getDefaultJdbcFetchSize());
+        Assertions.assertEquals(64, jimmerProperties.getDefaultJdbcQueryTimeout());
+        Assertions.assertEquals(64, sqlClient.getDefaultJdbcQueryTimeout());
     }
 
     @Test

--- a/project/jimmer-sql-kotlin/build.gradle.kts
+++ b/project/jimmer-sql-kotlin/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(projects.jimmerSql)
 
     testImplementation(libs.kotlin.test)
+    testImplementation(testFixtures(projects.jimmerSql))
     kspTest(projects.jimmerKsp)
 
     testImplementation(libs.bundles.jackson)

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
@@ -11,6 +11,7 @@ import org.babyfish.jimmer.sql.exception.TooManyResultsException
 import org.babyfish.jimmer.sql.fetcher.DtoMetadata
 import org.babyfish.jimmer.sql.fetcher.Fetcher
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.query.*
 import org.babyfish.jimmer.sql.kt.ast.table.*
@@ -72,8 +73,8 @@ interface KSqlClient : KSaveOperations {
 
     fun <E : Any, R> createUpdateReturning(
         entityType: KClass<E>,
-        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
-    ): KExecutable<List<R>>
+        block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R>
 
     fun <E : Any> createDelete(
         entityType: KClass<E>,
@@ -101,7 +102,7 @@ interface KSqlClient : KSaveOperations {
     fun <E : Any, R> executeUpdateReturning(
         entityType: KClass<E>,
         con: Connection? = null,
-        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+        block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
     ): List<R> = createUpdateReturning(entityType, block).execute(con)
 
     fun <E : Any> executeDelete(

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
@@ -3,7 +3,6 @@ package org.babyfish.jimmer.sql.kt
 import org.babyfish.jimmer.View
 import org.babyfish.jimmer.lang.NewChain
 import org.babyfish.jimmer.sql.JSqlClient
-import org.babyfish.jimmer.sql.JoinType
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
 import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
@@ -37,29 +36,29 @@ interface KSqlClient : KSaveOperations {
     ): KConfigurableRootQuery<KNonNullTable<E>, R> =
         queries.forEntity(entityType, block)
 
-    fun <B: KNonNullBaseTable<*>, R> createQuery(
+    fun <B : KNonNullBaseTable<*>, R> createQuery(
         symbol: KBaseTableSymbol<B>,
         block: KMutableRootQuery<B>.() -> KConfigurableRootQuery<B, R>
     ): KConfigurableRootQuery<B, R>
 
-    fun <E: Any, B: KNonNullBaseTable<*>> createBaseQuery(
+    fun <E : Any, B : KNonNullBaseTable<*>> createBaseQuery(
         entityType: KClass<E>,
         block: KMutableBaseQuery<E>.() -> KConfigurableBaseQuery<B>
     ): KConfigurableBaseQuery<B>
 
-    fun <B: KNonNullBaseTable<*>, R: KNonNullBaseTable<*>> createBaseQuery(
+    fun <B : KNonNullBaseTable<*>, R : KNonNullBaseTable<*>> createBaseQuery(
         symbol: KBaseTableSymbol<B>,
         block: KMutableBaseTableQuery<B>.() -> KConfigurableBaseQuery<R>
     ): KConfigurableBaseQuery<R>
 
-    fun <E: Any, B: KNonNullBaseTable<*>> createBaseQuery(
+    fun <E : Any, B : KNonNullBaseTable<*>> createBaseQuery(
         entityType: KClass<E>,
         recursiveRef: KRecursiveRef<B>,
         joinBlock: KPropsWeakJoinFun<KNonNullTable<E>, B>,
         block: KMutableRecursiveBaseQuery<E, B>.() -> KConfigurableBaseQuery<B>
     ): KConfigurableBaseQuery<B>
 
-    fun <E: Any, B: KNonNullBaseTable<*>> createBaseQuery(
+    fun <E : Any, B : KNonNullBaseTable<*>> createBaseQuery(
         entityType: KClass<E>,
         recursiveRef: KRecursiveRef<B>,
         weakJoinType: KClass<out KPropsWeakJoin<KNonNullTable<E>, B>>,
@@ -70,6 +69,11 @@ interface KSqlClient : KSaveOperations {
         entityType: KClass<E>,
         block: KMutableUpdate<E>.() -> Unit
     ): KExecutable<Int>
+
+    fun <E : Any, R> createUpdateReturning(
+        entityType: KClass<E>,
+        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+    ): KExecutable<List<R>>
 
     fun <E : Any> createDelete(
         entityType: KClass<E>,
@@ -93,6 +97,12 @@ interface KSqlClient : KSaveOperations {
         con: Connection? = null,
         block: KMutableUpdate<E>.() -> Unit
     ): Int = createUpdate(entityType, block).execute(con)
+
+    fun <E : Any, R> executeUpdateReturning(
+        entityType: KClass<E>,
+        con: Connection? = null,
+        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+    ): List<R> = createUpdateReturning(entityType, block).execute(con)
 
     fun <E : Any> executeDelete(
         entityType: KClass<E>,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.View
 import org.babyfish.jimmer.sql.association.Association
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.constant
 import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.query.*
@@ -51,8 +52,8 @@ inline fun <reified E : Any> KSqlClient.createUpdate(
     this.createUpdate(E::class, block)
 
 inline fun <reified E : Any, R> KSqlClient.createUpdateReturning(
-    noinline block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
-): KExecutable<List<R>> =
+    noinline block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
+): KSelectionExecutable<R> =
     this.createUpdateReturning(E::class, block)
 
 inline fun <reified E : Any> KSqlClient.createDelete(
@@ -87,7 +88,7 @@ inline fun <reified E : Any> KSqlClient.executeUpdate(
 
 inline fun <reified E : Any, R> KSqlClient.executeUpdateReturning(
     con: Connection? = null,
-    noinline block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+    noinline block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
 ): List<R> =
     this.executeUpdateReturning(E::class, con, block)
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
@@ -5,10 +5,7 @@ import org.babyfish.jimmer.sql.association.Association
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.constant
-import org.babyfish.jimmer.sql.kt.ast.mutation.KDeleteCommandDsl
-import org.babyfish.jimmer.sql.kt.ast.mutation.KDeleteResult
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
+import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.query.*
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
@@ -53,6 +50,11 @@ inline fun <reified E : Any> KSqlClient.createUpdate(
 ): KExecutable<Int> =
     this.createUpdate(E::class, block)
 
+inline fun <reified E : Any, R> KSqlClient.createUpdateReturning(
+    noinline block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+): KExecutable<List<R>> =
+    this.createUpdateReturning(E::class, block)
+
 inline fun <reified E : Any> KSqlClient.createDelete(
     noinline block: KMutableDelete<E>.() -> Unit
 ): KExecutable<Int> =
@@ -82,6 +84,12 @@ inline fun <reified E : Any> KSqlClient.executeUpdate(
     noinline block: KMutableUpdate<E>.() -> Unit
 ): Int =
     this.executeUpdate(E::class, con, block)
+
+inline fun <reified E : Any, R> KSqlClient.executeUpdateReturning(
+    con: Connection? = null,
+    noinline block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+): List<R> =
+    this.executeUpdateReturning(E::class, con, block)
 
 inline fun <reified E : Any> KSqlClient.executeDelete(
     con: Connection? = null,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/KJdbcOptionsDsl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/KJdbcOptionsDsl.kt
@@ -1,0 +1,19 @@
+package org.babyfish.jimmer.sql.kt.ast
+
+import org.babyfish.jimmer.kt.DslScope
+import org.babyfish.jimmer.sql.ast.JdbcConfigurable
+
+@DslScope
+class KJdbcOptionsDsl internal constructor(
+    private val target: JdbcConfigurable<*>
+) {
+
+    var fetchSize: Int? = null
+
+    var queryTimeout: Int? = null
+
+    internal fun apply() {
+        fetchSize?.let(target::jdbcFetchSize)
+        queryTimeout?.let(target::jdbcQueryTimeout)
+    }
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/KSelectionExecutable.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/KSelectionExecutable.kt
@@ -1,0 +1,9 @@
+package org.babyfish.jimmer.sql.kt.ast
+
+import java.sql.Connection
+import java.util.stream.Stream
+
+interface KSelectionExecutable<R> : KExecutable<List<R>> {
+
+    fun stream(con: Connection? = null): Stream<R>
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdate.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdate.kt
@@ -7,26 +7,26 @@ import org.babyfish.jimmer.sql.kt.ast.query.KFilterable
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
 
 @DslScope
-interface KMutableUpdate<E: Any> : KFilterable<KNonNullTableEx<E>> {
+interface KMutableUpdate<E : Any> : KFilterable<KNonNullTableEx<E>> {
 
     fun setTypeMatchMode(mode: TypeMatchMode)
 
-    fun <X: Any> set(
+    fun <X : Any> set(
         path: KNonNullPropExpression<X>,
         value: KNonNullExpression<X>
     )
 
-    fun <X: Any> set(
+    fun <X : Any> set(
         path: KNonNullPropExpression<X>,
         value: X
     )
 
-    fun <X: Any> set(
+    fun <X : Any> set(
         path: KNullablePropExpression<X>,
         value: KExpression<X>
     )
 
-    fun <X: Any> set(
+    fun <X : Any> set(
         path: KNullableExpression<X>,
         value: X?
     )

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdate.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdate.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.kt.ast.mutation
 
 import org.babyfish.jimmer.kt.DslScope
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
+import org.babyfish.jimmer.sql.kt.ast.KJdbcOptionsDsl
 import org.babyfish.jimmer.sql.kt.ast.expression.*
 import org.babyfish.jimmer.sql.kt.ast.query.KFilterable
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
@@ -10,6 +11,8 @@ import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
 interface KMutableUpdate<E : Any> : KFilterable<KNonNullTableEx<E>> {
 
     fun setTypeMatchMode(mode: TypeMatchMode)
+
+    fun jdbc(block: KJdbcOptionsDsl.() -> Unit)
 
     fun <X : Any> set(
         path: KNonNullPropExpression<X>,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdateReturning.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpdateReturning.kt
@@ -1,0 +1,6 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation
+
+import org.babyfish.jimmer.kt.DslScope
+
+@DslScope
+interface KMutableUpdateReturning<E : Any> : KMutableUpdate<E>, KReturningSelectable

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KReturningSelectable.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KReturningSelectable.kt
@@ -1,0 +1,81 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation
+
+import org.babyfish.jimmer.sql.ast.Selection
+import org.babyfish.jimmer.sql.ast.tuple.*
+import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.runtime.TupleMapper
+
+interface KReturningSelectable {
+
+    fun <T> returning(selection: Selection<T>): KExecutable<List<T>>
+
+    fun <T1, T2> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>
+    ): KExecutable<List<Tuple2<T1, T2>>>
+
+    fun <T1, T2, T3> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>
+    ): KExecutable<List<Tuple3<T1, T2, T3>>>
+
+    fun <T1, T2, T3, T4> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>
+    ): KExecutable<List<Tuple4<T1, T2, T3, T4>>>
+
+    fun <T1, T2, T3, T4, T5> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>
+    ): KExecutable<List<Tuple5<T1, T2, T3, T4, T5>>>
+
+    fun <T1, T2, T3, T4, T5, T6> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>
+    ): KExecutable<List<Tuple6<T1, T2, T3, T4, T5, T6>>>
+
+    fun <T1, T2, T3, T4, T5, T6, T7> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>
+    ): KExecutable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>>
+
+    fun <T1, T2, T3, T4, T5, T6, T7, T8> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>,
+        selection8: Selection<T8>
+    ): KExecutable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>>
+
+    fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>,
+        selection8: Selection<T8>,
+        selection9: Selection<T9>
+    ): KExecutable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>>
+
+    fun <T> returning(mapper: TupleMapper<T>): KExecutable<List<T>>
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KReturningSelectable.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KReturningSelectable.kt
@@ -2,30 +2,30 @@ package org.babyfish.jimmer.sql.kt.ast.mutation
 
 import org.babyfish.jimmer.sql.ast.Selection
 import org.babyfish.jimmer.sql.ast.tuple.*
-import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.runtime.TupleMapper
 
 interface KReturningSelectable {
 
-    fun <T> returning(selection: Selection<T>): KExecutable<List<T>>
+    fun <T> returning(selection: Selection<T>): KSelectionExecutable<T>
 
     fun <T1, T2> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>
-    ): KExecutable<List<Tuple2<T1, T2>>>
+    ): KSelectionExecutable<Tuple2<T1, T2>>
 
     fun <T1, T2, T3> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>,
         selection3: Selection<T3>
-    ): KExecutable<List<Tuple3<T1, T2, T3>>>
+    ): KSelectionExecutable<Tuple3<T1, T2, T3>>
 
     fun <T1, T2, T3, T4> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>,
         selection3: Selection<T3>,
         selection4: Selection<T4>
-    ): KExecutable<List<Tuple4<T1, T2, T3, T4>>>
+    ): KSelectionExecutable<Tuple4<T1, T2, T3, T4>>
 
     fun <T1, T2, T3, T4, T5> returning(
         selection1: Selection<T1>,
@@ -33,7 +33,7 @@ interface KReturningSelectable {
         selection3: Selection<T3>,
         selection4: Selection<T4>,
         selection5: Selection<T5>
-    ): KExecutable<List<Tuple5<T1, T2, T3, T4, T5>>>
+    ): KSelectionExecutable<Tuple5<T1, T2, T3, T4, T5>>
 
     fun <T1, T2, T3, T4, T5, T6> returning(
         selection1: Selection<T1>,
@@ -42,7 +42,7 @@ interface KReturningSelectable {
         selection4: Selection<T4>,
         selection5: Selection<T5>,
         selection6: Selection<T6>
-    ): KExecutable<List<Tuple6<T1, T2, T3, T4, T5, T6>>>
+    ): KSelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>>
 
     fun <T1, T2, T3, T4, T5, T6, T7> returning(
         selection1: Selection<T1>,
@@ -52,7 +52,7 @@ interface KReturningSelectable {
         selection5: Selection<T5>,
         selection6: Selection<T6>,
         selection7: Selection<T7>
-    ): KExecutable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>>
+    ): KSelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>>
 
     fun <T1, T2, T3, T4, T5, T6, T7, T8> returning(
         selection1: Selection<T1>,
@@ -63,7 +63,7 @@ interface KReturningSelectable {
         selection6: Selection<T6>,
         selection7: Selection<T7>,
         selection8: Selection<T8>
-    ): KExecutable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>>
+    ): KSelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>
 
     fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> returning(
         selection1: Selection<T1>,
@@ -75,7 +75,7 @@ interface KReturningSelectable {
         selection7: Selection<T7>,
         selection8: Selection<T8>,
         selection9: Selection<T9>
-    ): KExecutable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>>
+    ): KSelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
 
-    fun <T> returning(mapper: TupleMapper<T>): KExecutable<List<T>>
+    fun <T> returning(mapper: TupleMapper<T>): KSelectionExecutable<T>
 }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpdateImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpdateImpl.kt
@@ -7,7 +7,8 @@ import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpdateImpl
 import org.babyfish.jimmer.sql.ast.tuple.*
 import org.babyfish.jimmer.sql.kt.KSubQueries
 import org.babyfish.jimmer.sql.kt.KWildSubQueries
-import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KJdbcOptionsDsl
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.*
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.NonNullPropExpressionImpl
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.NullablePropExpressionImpl
@@ -16,7 +17,7 @@ import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
 import org.babyfish.jimmer.sql.kt.ast.query.Where
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
 import org.babyfish.jimmer.sql.kt.ast.table.impl.KNonNullTableExImpl
-import org.babyfish.jimmer.sql.kt.impl.KExecutableImpl
+import org.babyfish.jimmer.sql.kt.impl.KSelectionExecutableImpl
 import org.babyfish.jimmer.sql.kt.impl.KSubQueriesImpl
 import org.babyfish.jimmer.sql.kt.impl.KWildSubQueriesImpl
 import org.babyfish.jimmer.sql.runtime.TupleMapper
@@ -34,6 +35,12 @@ internal class KMutableUpdateImpl<E : Any>(
 
     override fun setTypeMatchMode(mode: TypeMatchMode) {
         javaUpdate.setTypeMatchMode(mode)
+    }
+
+    override fun jdbc(block: KJdbcOptionsDsl.() -> Unit) {
+        val dsl = KJdbcOptionsDsl(javaUpdate)
+        dsl.block()
+        dsl.apply()
     }
 
     override fun where(vararg predicates: KNonNullExpression<Boolean>?) {
@@ -79,29 +86,29 @@ internal class KMutableUpdateImpl<E : Any>(
         )
     }
 
-    override fun <T> returning(selection: Selection<T>): KExecutable<List<T>> =
-        KExecutableImpl(javaUpdate.returning(selection))
+    override fun <T> returning(selection: Selection<T>): KSelectionExecutable<T> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection))
 
     override fun <T1, T2> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>
-    ): KExecutable<List<Tuple2<T1, T2>>> =
-        KExecutableImpl(javaUpdate.returning(selection1, selection2))
+    ): KSelectionExecutable<Tuple2<T1, T2>> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection1, selection2))
 
     override fun <T1, T2, T3> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>,
         selection3: Selection<T3>
-    ): KExecutable<List<Tuple3<T1, T2, T3>>> =
-        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3))
+    ): KSelectionExecutable<Tuple3<T1, T2, T3>> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection1, selection2, selection3))
 
     override fun <T1, T2, T3, T4> returning(
         selection1: Selection<T1>,
         selection2: Selection<T2>,
         selection3: Selection<T3>,
         selection4: Selection<T4>
-    ): KExecutable<List<Tuple4<T1, T2, T3, T4>>> =
-        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4))
+    ): KSelectionExecutable<Tuple4<T1, T2, T3, T4>> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4))
 
     override fun <T1, T2, T3, T4, T5> returning(
         selection1: Selection<T1>,
@@ -109,8 +116,8 @@ internal class KMutableUpdateImpl<E : Any>(
         selection3: Selection<T3>,
         selection4: Selection<T4>,
         selection5: Selection<T5>
-    ): KExecutable<List<Tuple5<T1, T2, T3, T4, T5>>> =
-        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5))
+    ): KSelectionExecutable<Tuple5<T1, T2, T3, T4, T5>> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5))
 
     override fun <T1, T2, T3, T4, T5, T6> returning(
         selection1: Selection<T1>,
@@ -119,8 +126,8 @@ internal class KMutableUpdateImpl<E : Any>(
         selection4: Selection<T4>,
         selection5: Selection<T5>,
         selection6: Selection<T6>
-    ): KExecutable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> =
-        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5, selection6))
+    ): KSelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>> =
+        KSelectionExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5, selection6))
 
     override fun <T1, T2, T3, T4, T5, T6, T7> returning(
         selection1: Selection<T1>,
@@ -130,8 +137,8 @@ internal class KMutableUpdateImpl<E : Any>(
         selection5: Selection<T5>,
         selection6: Selection<T6>,
         selection7: Selection<T7>
-    ): KExecutable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> =
-        KExecutableImpl(
+    ): KSelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>> =
+        KSelectionExecutableImpl(
             javaUpdate.returning(
                 selection1,
                 selection2,
@@ -152,8 +159,8 @@ internal class KMutableUpdateImpl<E : Any>(
         selection6: Selection<T6>,
         selection7: Selection<T7>,
         selection8: Selection<T8>
-    ): KExecutable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> =
-        KExecutableImpl(
+    ): KSelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> =
+        KSelectionExecutableImpl(
             javaUpdate.returning(
                 selection1,
                 selection2,
@@ -176,8 +183,8 @@ internal class KMutableUpdateImpl<E : Any>(
         selection7: Selection<T7>,
         selection8: Selection<T8>,
         selection9: Selection<T9>
-    ): KExecutable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> =
-        KExecutableImpl(
+    ): KSelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> =
+        KSelectionExecutableImpl(
             javaUpdate.returning(
                 selection1,
                 selection2,
@@ -191,8 +198,8 @@ internal class KMutableUpdateImpl<E : Any>(
             )
         )
 
-    override fun <T> returning(mapper: TupleMapper<T>): KExecutable<List<T>> =
-        KExecutableImpl(javaUpdate.returning(mapper))
+    override fun <T> returning(mapper: TupleMapper<T>): KSelectionExecutable<T> =
+        KSelectionExecutableImpl(javaUpdate.returning(mapper))
 
     override val subQueries: KSubQueries<KNonNullTableEx<E>> =
         KSubQueriesImpl(javaUpdate, table)

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpdateImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpdateImpl.kt
@@ -1,24 +1,29 @@
 package org.babyfish.jimmer.sql.kt.ast.mutation.impl
 
 import org.babyfish.jimmer.sql.ast.Expression
-import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpdateImpl
+import org.babyfish.jimmer.sql.ast.Selection
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
+import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpdateImpl
+import org.babyfish.jimmer.sql.ast.tuple.*
 import org.babyfish.jimmer.sql.kt.KSubQueries
 import org.babyfish.jimmer.sql.kt.KWildSubQueries
+import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.*
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.NonNullPropExpressionImpl
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.NullablePropExpressionImpl
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.toJavaPredicate
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
 import org.babyfish.jimmer.sql.kt.ast.query.Where
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
 import org.babyfish.jimmer.sql.kt.ast.table.impl.KNonNullTableExImpl
+import org.babyfish.jimmer.sql.kt.impl.KExecutableImpl
 import org.babyfish.jimmer.sql.kt.impl.KSubQueriesImpl
 import org.babyfish.jimmer.sql.kt.impl.KWildSubQueriesImpl
+import org.babyfish.jimmer.sql.runtime.TupleMapper
 
-internal class KMutableUpdateImpl<E: Any>(
+internal class KMutableUpdateImpl<E : Any>(
     private val javaUpdate: MutableUpdateImpl
-): KMutableUpdate<E> {
+) : KMutableUpdateReturning<E> {
 
     override val table: KNonNullTableEx<E> =
         KNonNullTableExImpl(javaUpdate.getTable())
@@ -73,6 +78,121 @@ internal class KMutableUpdateImpl<E: Any>(
             }
         )
     }
+
+    override fun <T> returning(selection: Selection<T>): KExecutable<List<T>> =
+        KExecutableImpl(javaUpdate.returning(selection))
+
+    override fun <T1, T2> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>
+    ): KExecutable<List<Tuple2<T1, T2>>> =
+        KExecutableImpl(javaUpdate.returning(selection1, selection2))
+
+    override fun <T1, T2, T3> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>
+    ): KExecutable<List<Tuple3<T1, T2, T3>>> =
+        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3))
+
+    override fun <T1, T2, T3, T4> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>
+    ): KExecutable<List<Tuple4<T1, T2, T3, T4>>> =
+        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4))
+
+    override fun <T1, T2, T3, T4, T5> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>
+    ): KExecutable<List<Tuple5<T1, T2, T3, T4, T5>>> =
+        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5))
+
+    override fun <T1, T2, T3, T4, T5, T6> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>
+    ): KExecutable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> =
+        KExecutableImpl(javaUpdate.returning(selection1, selection2, selection3, selection4, selection5, selection6))
+
+    override fun <T1, T2, T3, T4, T5, T6, T7> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>
+    ): KExecutable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> =
+        KExecutableImpl(
+            javaUpdate.returning(
+                selection1,
+                selection2,
+                selection3,
+                selection4,
+                selection5,
+                selection6,
+                selection7
+            )
+        )
+
+    override fun <T1, T2, T3, T4, T5, T6, T7, T8> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>,
+        selection8: Selection<T8>
+    ): KExecutable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> =
+        KExecutableImpl(
+            javaUpdate.returning(
+                selection1,
+                selection2,
+                selection3,
+                selection4,
+                selection5,
+                selection6,
+                selection7,
+                selection8
+            )
+        )
+
+    override fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> returning(
+        selection1: Selection<T1>,
+        selection2: Selection<T2>,
+        selection3: Selection<T3>,
+        selection4: Selection<T4>,
+        selection5: Selection<T5>,
+        selection6: Selection<T6>,
+        selection7: Selection<T7>,
+        selection8: Selection<T8>,
+        selection9: Selection<T9>
+    ): KExecutable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> =
+        KExecutableImpl(
+            javaUpdate.returning(
+                selection1,
+                selection2,
+                selection3,
+                selection4,
+                selection5,
+                selection6,
+                selection7,
+                selection8,
+                selection9
+            )
+        )
+
+    override fun <T> returning(mapper: TupleMapper<T>): KExecutable<List<T>> =
+        KExecutableImpl(javaUpdate.returning(mapper))
 
     override val subQueries: KSubQueries<KNonNullTableEx<E>> =
         KSubQueriesImpl(javaUpdate, table)

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableRootQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableRootQuery.kt
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.kt.ast.query
 import org.babyfish.jimmer.Specification
 import org.babyfish.jimmer.kt.DslScope
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
+import org.babyfish.jimmer.sql.kt.ast.KJdbcOptionsDsl
 import org.babyfish.jimmer.sql.kt.ast.query.specification.KSpecification
 import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
 import org.babyfish.jimmer.sql.kt.ast.table.KPropsLike
@@ -11,6 +12,8 @@ import org.babyfish.jimmer.sql.kt.ast.table.KPropsLike
 interface KMutableRootQuery<P: KPropsLike> : KMutableQuery<P>, KRootSelectable<P> {
 
     fun typeMatchMode(mode: TypeMatchMode)
+
+    fun jdbc(block: KJdbcOptionsDsl.() -> Unit)
 
     interface ForEntity<E: Any> : KMutableRootQuery<KNonNullTable<E>> {
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KTypedRootQuery.kt
@@ -1,11 +1,9 @@
 package org.babyfish.jimmer.sql.kt.ast.query
 
-import org.babyfish.jimmer.sql.exception.EmptyResultException
-import org.babyfish.jimmer.sql.exception.TooManyResultsException
-import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import java.sql.Connection
 
-interface KTypedRootQuery<R> : KExecutable<List<R>> {
+interface KTypedRootQuery<R> : KSelectionExecutable<R> {
 
     infix fun union(other: KTypedRootQuery<R>): KTypedRootQuery<R>
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KConfigurableRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KConfigurableRootQueryImpl.kt
@@ -2,13 +2,9 @@ package org.babyfish.jimmer.sql.kt.ast.query.impl
 
 import org.babyfish.jimmer.Slice
 import org.babyfish.jimmer.sql.ast.impl.query.ConfigurableRootQueryImpl
-import org.babyfish.jimmer.sql.ast.impl.query.PageSource
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl
-import org.babyfish.jimmer.sql.ast.query.ConfigurableRootQuery
-import org.babyfish.jimmer.sql.ast.query.LockMode
-import org.babyfish.jimmer.sql.ast.query.LockWait
-import org.babyfish.jimmer.sql.ast.query.MutableRootQuery
-import org.babyfish.jimmer.sql.ast.query.PageFactory
+import org.babyfish.jimmer.sql.ast.impl.query.PageSource
+import org.babyfish.jimmer.sql.ast.query.*
 import org.babyfish.jimmer.sql.ast.table.BaseTable
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike
 import org.babyfish.jimmer.sql.kt.ast.query.KConfigurableRootQuery

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableRootQueryImpl.kt
@@ -15,6 +15,7 @@ import org.babyfish.jimmer.sql.ast.table.spi.TableLike
 import org.babyfish.jimmer.sql.ast.tuple.*
 import org.babyfish.jimmer.sql.kt.KSubQueries
 import org.babyfish.jimmer.sql.kt.KWildSubQueries
+import org.babyfish.jimmer.sql.kt.ast.KJdbcOptionsDsl
 import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.impl.toJavaPredicate
@@ -50,6 +51,12 @@ internal abstract class KMutableRootQueryImpl<P: KPropsLike>(
 
     override fun typeMatchMode(mode: TypeMatchMode) {
         javaQuery.typeMatchMode(mode)
+    }
+
+    override fun jdbc(block: KJdbcOptionsDsl.() -> Unit) {
+        val dsl = KJdbcOptionsDsl(javaQuery)
+        dsl.block()
+        dsl.apply()
     }
 
     override fun orderBy(vararg expressions: KExpression<*>?) {

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KTypedRootQueryImpl.kt
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.kt.ast.query.impl
 import org.babyfish.jimmer.sql.ast.query.TypedRootQuery
 import org.babyfish.jimmer.sql.kt.ast.query.KTypedRootQuery
 import java.sql.Connection
+import java.util.stream.Stream
 
 internal open class KTypedRootQueryImpl<R>(
     private val _javaQuery: TypedRootQuery<R>
@@ -33,6 +34,9 @@ internal open class KTypedRootQueryImpl<R>(
 
     override fun execute(con: Connection?): List<R> =
         _javaQuery.execute(con)
+
+    override fun stream(con: Connection?): Stream<R> =
+        _javaQuery.stream(con)
 
     override fun <X> map(con: Connection?, mapper: (R) -> X): List<X> =
         _javaQuery.map(con, mapper)

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/cfg/KSqlClientDsl.kt
@@ -60,6 +60,14 @@ class KSqlClientDsl constructor(
         javaBuilder.setDefaultListBatchSize(size)
     }
 
+    fun setDefaultJdbcFetchSize(fetchSize: Int?) {
+        javaBuilder.setDefaultJdbcFetchSize(fetchSize)
+    }
+
+    fun setDefaultJdbcQueryTimeout(queryTimeout: Int?) {
+        javaBuilder.setDefaultJdbcQueryTimeout(queryTimeout)
+    }
+
     fun setInListPaddingEnabled(enabled: Boolean) {
         javaBuilder.setInListPaddingEnabled(enabled)
     }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
 import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
@@ -69,8 +70,8 @@ abstract class AbstractKSqlClientDelegate : KSqlClientImplementor {
 
     override fun <E : Any, R> createUpdateReturning(
         entityType: KClass<E>,
-        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
-    ): KExecutable<List<R>> =
+        block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> =
         sqlClient().createUpdateReturning(entityType, block)
 
     override fun <E : Any> createDelete(

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
@@ -1,12 +1,12 @@
 package org.babyfish.jimmer.sql.kt.di
 
-import org.babyfish.jimmer.sql.JoinType
 import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
 import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
 import org.babyfish.jimmer.sql.kt.ast.query.*
 import org.babyfish.jimmer.sql.kt.ast.table.*
 import org.babyfish.jimmer.sql.kt.filter.KFilterDsl
@@ -66,6 +66,12 @@ abstract class AbstractKSqlClientDelegate : KSqlClientImplementor {
         block: KMutableUpdate<E>.() -> Unit
     ): KExecutable<Int> =
         sqlClient().createUpdate(entityType, block)
+
+    override fun <E : Any, R> createUpdateReturning(
+        entityType: KClass<E>,
+        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+    ): KExecutable<List<R>> =
+        sqlClient().createUpdateReturning(entityType, block)
 
     override fun <E : Any> createDelete(
         entityType: KClass<E>,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSelectionExecutableImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSelectionExecutableImpl.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.sql.kt.impl
+
+import org.babyfish.jimmer.sql.ast.SelectionExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
+import java.sql.Connection
+import java.util.stream.Stream
+
+internal class KSelectionExecutableImpl<R>(
+    private val javaExecutable: SelectionExecutable<R>
+) : KSelectionExecutable<R> {
+
+    override fun execute(con: Connection?): List<R> =
+        javaExecutable.execute(con)
+
+    override fun stream(con: Connection?): Stream<R> =
+        javaExecutable.stream(con)
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
@@ -20,6 +20,7 @@ import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
 import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableDeleteImpl
 import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableUpdateImpl
 import org.babyfish.jimmer.sql.kt.ast.query.*
@@ -152,6 +153,14 @@ internal class KSqlClientImpl(
         val update = MutableUpdateImpl(javaClient, ImmutableType.get(entityType.java))
         block(KMutableUpdateImpl(update))
         return KExecutableImpl(update)
+    }
+
+    override fun <E : Any, R> createUpdateReturning(
+        entityType: KClass<E>,
+        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
+    ): KExecutable<List<R>> {
+        val update = MutableUpdateImpl(javaClient, ImmutableType.get(entityType.java))
+        return block(KMutableUpdateImpl(update))
     }
 
     override fun <E : Any> createDelete(

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
@@ -18,6 +18,7 @@ import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
 import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
 import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
@@ -157,8 +158,8 @@ internal class KSqlClientImpl(
 
     override fun <E : Any, R> createUpdateReturning(
         entityType: KClass<E>,
-        block: KMutableUpdateReturning<E>.() -> KExecutable<List<R>>
-    ): KExecutable<List<R>> {
+        block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> {
         val update = MutableUpdateImpl(javaClient, ImmutableType.get(entityType.java))
         return block(KMutableUpdateImpl(update))
     }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/common/AbstractTest.kt
@@ -104,15 +104,22 @@ abstract class AbstractTest {
 
     companion object {
 
-        private val JDBC_URL = "jdbc:h2:./build/h2/jimmer_kt_test_db;database_to_upper=true"
+        private const val JDBC_URL = "jdbc:h2:mem:jimmer_kt_test_db;database_to_upper=true;DB_CLOSE_DELAY=-1"
+
+        private val databaseInitializer: Lazy<Unit> = lazy {
+            h2Connection().use(::initDatabase)
+        }
 
         @JvmStatic
-        fun jdbc(dataSource: DataSource? = null, rollback: Boolean = false, block: (Connection) -> Unit) {
+        fun jdbc(dataSource: DataSource? = null, rollback: Boolean = dataSource == null, block: (Connection) -> Unit) {
             try {
+                if (dataSource == null) {
+                    initializeDatabaseIfNecessary()
+                }
                 val con = if (dataSource != null) {
                     dataSource.connection
                 } else {
-                    org.h2.Driver().connect(JDBC_URL, null)
+                    h2Connection()
                 }
                 try {
                     if (rollback) {
@@ -132,6 +139,13 @@ abstract class AbstractTest {
                 fail("SQL error", ex)
             }
         }
+
+        private fun initializeDatabaseIfNecessary() {
+            databaseInitializer.value
+        }
+
+        private fun h2Connection(): Connection =
+            org.h2.Driver().connect(JDBC_URL, null)
 
         protected fun initDatabase(con: Connection) {
             val stream = AbstractTest::class.java.classLoader.getResourceAsStream("database.sql")
@@ -156,9 +170,7 @@ abstract class AbstractTest {
         @BeforeClass
         @JvmStatic
         fun beforeAll() {
-            jdbc { con ->
-                initDatabase(con)
-            }
+            initializeDatabaseIfNecessary()
         }
 
         @JvmStatic

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/selfref/SelfReferenceNode.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/selfref/SelfReferenceNode.kt
@@ -1,0 +1,27 @@
+package org.babyfish.jimmer.sql.kt.model.selfref
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.IdView
+import org.babyfish.jimmer.sql.JoinColumn
+import org.babyfish.jimmer.sql.ManyToOne
+import org.babyfish.jimmer.sql.OneToMany
+
+@Entity
+interface SelfReferenceNode {
+
+    @Id
+    val id: Long
+
+    val name: String
+
+    @IdView("parent")
+    val parentId: Long?
+
+    @ManyToOne
+    @JoinColumn(name = "PARENT_ID")
+    val parent: SelfReferenceNode?
+
+    @OneToMany(mappedBy = "parent")
+    val childNodes: List<SelfReferenceNode>
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/DMLTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/DMLTest.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.kt.mutation
 
 import org.babyfish.jimmer.sql.ast.mutation.QueryReason
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
+import org.babyfish.jimmer.sql.ast.tuple.Tuple2
 import org.babyfish.jimmer.sql.dialect.H2Dialect
 import org.babyfish.jimmer.sql.kt.ast.expression.*
 import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
@@ -18,6 +19,7 @@ import org.babyfish.jimmer.sql.kt.model.inheritance.Administrator
 import org.babyfish.jimmer.sql.kt.model.inheritance.name
 import org.junit.Test
 import java.math.BigDecimal
+import kotlin.test.assertEquals
 
 class DMLTest : AbstractMutationTest() {
 
@@ -48,6 +50,35 @@ class DMLTest : AbstractMutationTest() {
                 rowCount(2)
             }
         }
+    }
+
+    @Test
+    fun testUpdateReturning() {
+        lateinit var rows: List<Tuple2<Long, String>>
+        connectAndExpect({ con ->
+            sqlClient { setDialect(H2Dialect()) }.executeUpdateReturning(Book::class, con) {
+                set(table.name, "Learning GraphQL+")
+                where(table.id eq 1L)
+                returning(table.id, table.name)
+            }.also {
+                rows = it
+            }
+        }) {
+            statement {
+                sql(
+                    """select ID, NAME 
+                        |from final table (
+                        |--->update BOOK tb_1_ 
+                        |--->set NAME = ? 
+                        |--->where tb_1_.ID = ?
+                        |)""".trimMargin()
+                )
+                variables("Learning GraphQL+", 1L)
+            }
+        }
+        assertEquals(1, rows.size)
+        assertEquals(1L, rows[0]._1)
+        assertEquals("Learning GraphQL+", rows[0]._2)
     }
 
     @Test

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/DMLTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/DMLTest.kt
@@ -82,6 +82,23 @@ class DMLTest : AbstractMutationTest() {
     }
 
     @Test
+    fun testUpdateReturningStream() {
+        lateinit var rows: List<Tuple2<Long, String>>
+        connectAndExpect({ con ->
+            sqlClient { setDialect(H2Dialect()) }.createUpdateReturning(Book::class) {
+                set(table.name, "Learning GraphQL+")
+                where(table.id eq 1L)
+                returning(table.id, table.name)
+            }.stream(con).use {
+                rows = it.toList()
+            }
+        }) {}
+        assertEquals(1, rows.size)
+        assertEquals(1L, rows[0]._1)
+        assertEquals("Learning GraphQL+", rows[0]._2)
+    }
+
+    @Test
     fun testUpdateWithFilter() {
         executeAndExpectRowCount(
             sqlClient.createUpdate(Administrator::class) {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/QueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/QueryTest.kt
@@ -15,7 +15,10 @@ import org.babyfish.jimmer.sql.kt.model.classic.author.fullName2
 import org.babyfish.jimmer.sql.kt.model.classic.author.lastName
 import org.babyfish.jimmer.sql.kt.model.classic.book.*
 import org.babyfish.jimmer.sql.kt.model.classic.store.*
+import org.babyfish.jimmer.support.JdbcRecorder
 import java.math.BigDecimal
+import java.util.stream.Collectors
+import kotlin.test.assertEquals
 import kotlin.test.Test
 import kotlin.test.expect
 
@@ -64,6 +67,66 @@ class QueryTest : AbstractQueryTest() {
                     it.toString()
                 }
             }
+        }
+    }
+
+    @Test
+    fun testStream() {
+        connectAndExpect({ con ->
+            sqlClient.createQuery(Book::class) {
+                where(table.name eq "Learning GraphQL")
+                orderBy(table.edition)
+                select(table.edition, table.name)
+            }.stream(con).use {
+                it.collect(Collectors.toList())
+            }
+        }) {
+            rows {
+                expect(
+                    "[Tuple2(_1=1, _2=Learning GraphQL), " +
+                        "Tuple2(_1=2, _2=Learning GraphQL), " +
+                        "Tuple2(_1=3, _2=Learning GraphQL)]"
+                ) {
+                    it.toString()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testJdbcOptionsDsl() {
+        jdbc { con ->
+            val recorder = JdbcRecorder(con)
+            sqlClient.createQuery(Book::class) {
+                jdbc {
+                    fetchSize = 128
+                    queryTimeout = 16
+                }
+                where(table.id eq 1L)
+                select(table.id, table.name)
+            }.execute(recorder.connection())
+            assertEquals("[128]", recorder.fetchSizes().toString())
+            assertEquals("[16]", recorder.queryTimeouts().toString())
+        }
+    }
+
+    @Test
+    fun testJdbcOptionsDslNullMeansUnspecified() {
+        jdbc { con ->
+            val recorder = JdbcRecorder(con)
+            sqlClient {
+                setDefaultJdbcFetchSize(256)
+                setDefaultJdbcQueryTimeout(32)
+            }.createQuery(Book::class) {
+                jdbc {
+                    fetchSize = null
+                    queryTimeout = null
+                }
+                where(table.id eq 1L)
+                select(table.id, table.name)
+            }.execute(recorder.connection())
+            assertEquals("[256]", recorder.fetchSizes().toString())
+            assertEquals("[32]", recorder.queryTimeouts().toString())
         }
     }
 

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/SelfReferenceMetadataTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/SelfReferenceMetadataTest.kt
@@ -1,0 +1,16 @@
+package org.babyfish.jimmer.sql.kt.util
+
+import org.babyfish.jimmer.meta.ImmutableType
+import org.babyfish.jimmer.meta.spi.ImmutableTypeImplementor
+import org.babyfish.jimmer.sql.kt.model.selfref.SelfReferenceNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SelfReferenceMetadataTest {
+
+    @Test
+    fun testFakeUpdatePropForSelfReferenceWithIdView() {
+        val type = ImmutableType.get(SelfReferenceNode::class.java)
+        assertEquals("name", (type as ImmutableTypeImplementor).fakeUpdateProp?.name)
+    }
+}

--- a/project/jimmer-sql/build.gradle.kts
+++ b/project/jimmer-sql/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-convention`
+    `java-test-fixtures`
     antlr
 }
 

--- a/project/jimmer-sql/build.gradle.kts
+++ b/project/jimmer-sql/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     testImplementation(libs.javax.validation.api)
     testImplementation(libs.hibernate.validation)
     testImplementation(libs.antlr)
-    testImplementation(libs.mockito.core)
     // testImplementation(files("/Users/chentao/Downloads/ojdbc8-21.9.0.0.jar"))
 }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
@@ -129,6 +129,12 @@ public interface JSqlClient extends SubQueryProvider, SaveOperations {
 
     Caches getCaches();
 
+    @Nullable
+    Integer getDefaultJdbcFetchSize();
+
+    @Nullable
+    Integer getDefaultJdbcQueryTimeout();
+
     JsonCodec<?> getJsonCodec();
 
     Filters getFilters();
@@ -410,6 +416,12 @@ public interface JSqlClient extends SubQueryProvider, SaveOperations {
 
         @OldChain
         Builder setDefaultListBatchSize(int size);
+
+        @OldChain
+        Builder setDefaultJdbcFetchSize(@Nullable Integer fetchSize);
+
+        @OldChain
+        Builder setDefaultJdbcQueryTimeout(@Nullable Integer queryTimeout);
 
         @OldChain
         Builder setInListPaddingEnabled(boolean enabled);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
@@ -16,6 +16,7 @@ import org.babyfish.jimmer.sql.ast.impl.query.*;
 import org.babyfish.jimmer.sql.ast.impl.table.JWeakJoinLambdaFactory;
 import org.babyfish.jimmer.sql.ast.impl.table.WeakJoinHandle;
 import org.babyfish.jimmer.sql.ast.impl.table.WeakJoinLambda;
+import org.babyfish.jimmer.sql.ast.impl.util.JdbcOptionValidator;
 import org.babyfish.jimmer.sql.ast.mutation.MutableDelete;
 import org.babyfish.jimmer.sql.ast.mutation.MutableUpdate;
 import org.babyfish.jimmer.sql.ast.query.MutableBaseQuery;
@@ -94,6 +95,12 @@ class JSqlClientImpl implements JSqlClientImplementor {
     private final int defaultBatchSize;
 
     private final int defaultListBatchSize;
+
+    @Nullable
+    private final Integer defaultJdbcFetchSize;
+
+    @Nullable
+    private final Integer defaultJdbcQueryTimeout;
 
     private final boolean inListPaddingEnabled;
 
@@ -180,6 +187,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
             ScalarProviderManager scalarProviderManager,
             int defaultBatchSize,
             int defaultListBatchSize,
+            @Nullable Integer defaultJdbcFetchSize,
+            @Nullable Integer defaultJdbcQueryTimeout,
             boolean inListPaddingEnabled,
             boolean expandedInListPaddingEnabled,
             int offsetOptimizingThreshold,
@@ -236,6 +245,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
         this.scalarProviderManager = scalarProviderManager;
         this.defaultBatchSize = defaultBatchSize;
         this.defaultListBatchSize = defaultListBatchSize;
+        this.defaultJdbcFetchSize = defaultJdbcFetchSize;
+        this.defaultJdbcQueryTimeout = defaultJdbcQueryTimeout;
         this.inListPaddingEnabled = inListPaddingEnabled;
         this.expandedInListPaddingEnabled = expandedInListPaddingEnabled;
         this.offsetOptimizingThreshold = offsetOptimizingThreshold;
@@ -397,6 +408,18 @@ class JSqlClientImpl implements JSqlClientImplementor {
     @Override
     public int getDefaultListBatchSize() {
         return defaultListBatchSize;
+    }
+
+    @Override
+    @Nullable
+    public Integer getDefaultJdbcFetchSize() {
+        return defaultJdbcFetchSize;
+    }
+
+    @Override
+    @Nullable
+    public Integer getDefaultJdbcQueryTimeout() {
+        return defaultJdbcQueryTimeout;
     }
 
     @Override
@@ -731,6 +754,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 scalarProviderManager,
                 defaultBatchSize,
                 defaultListBatchSize,
+                defaultJdbcFetchSize,
+                defaultJdbcQueryTimeout,
                 inListPaddingEnabled,
                 expandedInListPaddingEnabled,
                 offsetOptimizingThreshold,
@@ -791,6 +816,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 scalarProviderManager,
                 defaultBatchSize,
                 defaultListBatchSize,
+                defaultJdbcFetchSize,
+                defaultJdbcQueryTimeout,
                 inListPaddingEnabled,
                 expandedInListPaddingEnabled,
                 offsetOptimizingThreshold,
@@ -846,6 +873,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 scalarProviderManager,
                 defaultBatchSize,
                 defaultListBatchSize,
+                defaultJdbcFetchSize,
+                defaultJdbcQueryTimeout,
                 inListPaddingEnabled,
                 expandedInListPaddingEnabled,
                 offsetOptimizingThreshold,
@@ -904,6 +933,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 scalarProviderManager,
                 defaultBatchSize,
                 defaultListBatchSize,
+                defaultJdbcFetchSize,
+                defaultJdbcQueryTimeout,
                 inListPaddingEnabled,
                 expandedInListPaddingEnabled,
                 offsetOptimizingThreshold,
@@ -1096,6 +1127,12 @@ class JSqlClientImpl implements JSqlClientImplementor {
         private int defaultBatchSize = DEFAULT_BATCH_SIZE;
 
         private int defaultListBatchSize = DEFAULT_LIST_BATCH_SIZE;
+
+        @Nullable
+        private Integer defaultJdbcFetchSize;
+
+        @Nullable
+        private Integer defaultJdbcQueryTimeout;
 
         private boolean inListPaddingEnabled;
 
@@ -1538,6 +1575,22 @@ class JSqlClientImpl implements JSqlClientImplementor {
                 throw new IllegalStateException("size cannot be less than 1");
             }
             defaultListBatchSize = size;
+            return this;
+        }
+
+        @Override
+        @OldChain
+        public JSqlClient.Builder setDefaultJdbcFetchSize(@Nullable Integer fetchSize) {
+            JdbcOptionValidator.validateDefaultFetchSize(fetchSize);
+            defaultJdbcFetchSize = fetchSize;
+            return this;
+        }
+
+        @Override
+        @OldChain
+        public JSqlClient.Builder setDefaultJdbcQueryTimeout(@Nullable Integer queryTimeout) {
+            JdbcOptionValidator.validateDefaultQueryTimeout(queryTimeout);
+            defaultJdbcQueryTimeout = queryTimeout;
             return this;
         }
 
@@ -2016,6 +2069,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                     scalarProviderManager,
                     defaultBatchSize,
                     defaultListBatchSize,
+                    defaultJdbcFetchSize,
+                    defaultJdbcQueryTimeout,
                     inListPaddingEnabled,
                     expandedInListPaddingEnabled,
                     offsetOptimizingThreshold,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
@@ -2120,8 +2120,8 @@ class JSqlClientImpl implements JSqlClientImplementor {
                                                 "please specify the `inputNotNull` of " +
                                                 (
                                                         prop.getAssociationAnnotation().annotationType() == OneToOne.class ?
-                                                        OneToOne.class :
-                                                        ManyToOne.class
+                                                                OneToOne.class :
+                                                                ManyToOne.class
                                                 ).getName() +
                                                 "; If you want to make a promise at the business level that " +
                                                 "the association is not null to declare non-null reference, " +

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/JdbcConfigurable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/JdbcConfigurable.java
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.ast;
+
+import org.babyfish.jimmer.lang.OldChain;
+import org.jetbrains.annotations.Nullable;
+
+public interface JdbcConfigurable<S extends JdbcConfigurable<S>> {
+
+    @OldChain
+    S jdbcFetchSize(@Nullable Integer fetchSize);
+
+    @OldChain
+    S jdbcQueryTimeout(@Nullable Integer queryTimeout);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/SelectionExecutable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/SelectionExecutable.java
@@ -1,0 +1,14 @@
+package org.babyfish.jimmer.sql.ast;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.stream.Stream;
+
+public interface SelectionExecutable<R> extends Executable<List<R>> {
+
+    default Stream<R> stream() {
+        return stream(null);
+    }
+
+    Stream<R> stream(Connection con);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
@@ -5,10 +5,7 @@ import org.babyfish.jimmer.meta.*;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.InheritanceType;
 import org.babyfish.jimmer.sql.JoinType;
-import org.babyfish.jimmer.sql.ast.Expression;
-import org.babyfish.jimmer.sql.ast.Predicate;
-import org.babyfish.jimmer.sql.ast.PropExpression;
-import org.babyfish.jimmer.sql.ast.TypeMatchMode;
+import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.impl.*;
 import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
@@ -21,7 +18,7 @@ import org.babyfish.jimmer.sql.ast.table.TableEx;
 import org.babyfish.jimmer.sql.ast.table.spi.PropExpressionImplementor;
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
 import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
-import org.babyfish.jimmer.sql.ast.tuple.Tuple3;
+import org.babyfish.jimmer.sql.ast.tuple.*;
 import org.babyfish.jimmer.sql.dialect.Dialect;
 import org.babyfish.jimmer.sql.dialect.UpdateJoin;
 import org.babyfish.jimmer.sql.event.TriggerType;
@@ -43,15 +40,10 @@ public class MutableUpdateImpl
     private final boolean triggerIgnored;
 
     private final Map<Target, Expression<?>> assignmentMap = new LinkedHashMap<>();
-
-    private TableLikeImplementor<?> aliasSource;
-
-    private TypeMatchMode typeMatchMode = TypeMatchMode.AUTO;
-
-    private boolean typeMatchPredicateApplied;
-
     private final Set<ImmutableType> assignmentStageTypes = new LinkedHashSet<>();
-
+    private TableLikeImplementor<?> aliasSource;
+    private TypeMatchMode typeMatchMode = TypeMatchMode.AUTO;
+    private boolean typeMatchPredicateApplied;
     private ImmutableType primaryAssignmentStageType;
 
     public MutableUpdateImpl(JSqlClientImplementor sqlClient, ImmutableType immutableType) {
@@ -112,7 +104,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public MutableUpdate setTypeMatchMode(TypeMatchMode mode) {
+    public MutableUpdateImpl setTypeMatchMode(TypeMatchMode mode) {
         validateMutable();
         this.typeMatchMode = mode != null ? mode : TypeMatchMode.AUTO;
         return this;
@@ -120,7 +112,7 @@ public class MutableUpdateImpl
 
     @SuppressWarnings("unchecked")
     @Override
-    public <X> MutableUpdate set(PropExpression<X> path, X value) {
+    public <X> MutableUpdateImpl set(PropExpression<X> path, X value) {
         if (value != null) {
             return set(path, Expression.any().value(value));
         }
@@ -131,12 +123,12 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <X> MutableUpdate set(PropExpression<X> path, Expression<X> value) {
+    public <X> MutableUpdateImpl set(PropExpression<X> path, Expression<X> value) {
         validateMutable();
         Target target = Target.of(path, getSqlClient().getMetadataStrategy());
         if (target.table != this.getTable() &&
-            target.table != this.getTableLikeImplementor() &&
-            getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY) {
+                target.table != this.getTableLikeImplementor() &&
+                getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY) {
             throw new IllegalArgumentException(
                     "Only the primary table can be deleted when transaction trigger is supported"
             );
@@ -150,9 +142,9 @@ public class MutableUpdateImpl
         if (!joinedTableUpdatable && (target.table != getTable() && target.table != getTableLikeImplementor())) {
             throw new IllegalArgumentException(
                     "The current dialect '" +
-                    getSqlClient().getDialect().getClass().getName() +
-                    "' indicates that " +
-                    "only the columns of current table can be updated"
+                            getSqlClient().getDialect().getClass().getName() +
+                            "' indicates that " +
+                            "only the columns of current table can be updated"
             );
         }
         if (assignmentMap.put(target, value) != null) {
@@ -172,22 +164,22 @@ public class MutableUpdateImpl
         if (originalProp == inheritanceInfo.getDiscriminatorProp(updateType).toOriginal()) {
             throw new IllegalArgumentException(
                     "The discriminator property \"" +
-                    target.prop +
-                    "\" cannot be updated by createUpdate for joined inheritance type \"" +
-                    updateType +
-                    "\""
+                            target.prop +
+                            "\" cannot be updated by createUpdate for joined inheritance type \"" +
+                            updateType +
+                            "\""
             );
         }
         ImmutableType stageType = inheritanceInfo.getTableTypeForProp(originalProp, updateType);
         if (stageType == null) {
             throw new IllegalArgumentException(
                     "Cannot update property \"" +
-                    target.prop +
-                    "\" by createUpdate for joined inheritance type \"" +
-                    updateType +
-                    "\" because it does not belong to the inheritance path of \"" +
-                    originalProp.getDeclaringType() +
-                    "\""
+                            target.prop +
+                            "\" by createUpdate for joined inheritance type \"" +
+                            updateType +
+                            "\" because it does not belong to the inheritance path of \"" +
+                            originalProp.getDeclaringType() +
+                            "\""
             );
         }
         if (!assignmentStageTypes.isEmpty() &&
@@ -196,16 +188,16 @@ public class MutableUpdateImpl
             MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
             throw new IllegalArgumentException(
                     "Cannot update property \"" +
-                    target.prop +
-                    "\" by createUpdate for joined inheritance type \"" +
-                    updateType +
-                    "\" because all assignment targets must belong to the same physical table. " +
-                    "Current assignment targets table \"" +
-                    stageType.getTableName(strategy) +
-                    "\" but previous assignments target table \"" +
-                    primaryAssignmentStageType.getTableName(strategy) +
-                    "\". Updating columns in multiple database tables by one createUpdate " +
-                    "for joined inheritance requires a dialect that supports multi-table update assignment"
+                            target.prop +
+                            "\" by createUpdate for joined inheritance type \"" +
+                            updateType +
+                            "\" because all assignment targets must belong to the same physical table. " +
+                            "Current assignment targets table \"" +
+                            stageType.getTableName(strategy) +
+                            "\" but previous assignments target table \"" +
+                            primaryAssignmentStageType.getTableName(strategy) +
+                            "\". Updating columns in multiple database tables by one createUpdate " +
+                            "for joined inheritance requires a dialect that supports multi-table update assignment"
             );
         }
         assignmentStageTypes.add(stageType);
@@ -223,7 +215,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public MutableUpdate where(Predicate... predicates) {
+    public MutableUpdateImpl where(Predicate... predicates) {
         updateQuery.where(predicates);
         return this;
     }
@@ -318,6 +310,119 @@ public class MutableUpdateImpl
                 .execute(con, this::executeImpl);
     }
 
+    @Override
+    public <R> Executable<List<R>> returning(Selection<R> selection) {
+        return returning(Collections.singletonList(selection), null);
+    }
+
+    @Override
+    public <T1, T2> Executable<List<Tuple2<T1, T2>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2
+    ) {
+        return returning(Arrays.asList(selection1, selection2), null);
+    }
+
+    @Override
+    public <T1, T2, T3> Executable<List<Tuple3<T1, T2, T3>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4> Executable<List<Tuple4<T1, T2, T3, T4>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5> Executable<List<Tuple5<T1, T2, T3, T4, T5>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4, selection5), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6> Executable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4, selection5, selection6), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7> Executable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4, selection5, selection6, selection7), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8> Executable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7,
+            Selection<T8> selection8
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4, selection5, selection6, selection7, selection8), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9> Executable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7,
+            Selection<T8> selection8,
+            Selection<T9> selection9
+    ) {
+        return returning(Arrays.asList(selection1, selection2, selection3, selection4, selection5, selection6, selection7, selection8, selection9), null);
+    }
+
+    @Override
+    public <R> Executable<List<R>> returning(TupleMapper<R> mapper) {
+        return returning(mapper.getSelections(), mapper);
+    }
+
+    private <R> Executable<List<R>> returning(
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator
+    ) {
+        validateMutable();
+        if (selections.isEmpty()) {
+            throw new IllegalArgumentException("The update-returning selection list cannot be empty");
+        }
+        return new UpdateReturningExecutable<>(selections, tupleCreator);
+    }
+
     private int executeImpl(Connection con) {
 
         if (assignmentMap.isEmpty()) {
@@ -336,6 +441,78 @@ public class MutableUpdateImpl
 
         renderTo(builder);
         return executeUpdateSql(builder, con);
+    }
+
+    private <R> List<R> executeReturningImpl(
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator
+    ) {
+
+        if (assignmentMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Dialect dialect = getSqlClient().getDialect();
+        if (!dialect.isUpdateReturningSupported()) {
+            throw new ExecutionException(
+                    "The update-returning statement is not supported by \"" +
+                            dialect.getClass().getName() +
+                            "\""
+            );
+        }
+
+        if (getSqlClient().isTargetTransferable()) {
+            Executor.validateMutationConnection(con);
+        }
+
+        SqlBuilder builder = createFilteredBuilder();
+
+        if (!triggerIgnored && getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY) {
+            return executeReturningWithTrigger(builder, con, selections, tupleCreator);
+        }
+
+        renderReturningTo(builder, null, selections);
+        return executeReturningSql(builder, con, selections, tupleCreator);
+    }
+
+    private <R> List<R> executeReturningWithTrigger(
+            SqlBuilder builder,
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator
+    ) {
+        Map<Object, ImmutableSpi> oldRowMap = selectRowsForTrigger(builder, con);
+        if (oldRowMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        builder = new SqlBuilder(new AstContext(getSqlClient()));
+        renderReturningTo(builder, oldRowMap.keySet(), selections);
+        List<R> rows = executeReturningSql(builder, con, selections, tupleCreator);
+        if (!rows.isEmpty()) {
+            submitTrigger(con, oldRowMap);
+        }
+        return rows;
+    }
+
+    private <R> List<R> executeReturningSql(
+            SqlBuilder builder,
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator
+    ) {
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = builder.build();
+        return Selectors.select(
+                getSqlClient(),
+                con,
+                sqlResult.get_1(),
+                sqlResult.get_2(),
+                sqlResult.get_3(),
+                selections,
+                tupleCreator,
+                getPurpose()
+        );
     }
 
     private SqlBuilder createFilteredBuilder() {
@@ -433,6 +610,16 @@ public class MutableUpdateImpl
         renderTo(builder, null);
     }
 
+    private void renderReturningTo(
+            SqlBuilder builder,
+            Collection<Object> ids,
+            List<Selection<?>> selections
+    ) {
+        getSqlClient().getDialect().updateReturning(
+                new UpdateReturningContextImpl(builder, ids, selections)
+        );
+    }
+
     void shareRootAliasWith(TableLikeImplementor<?> source) {
         this.aliasSource = source;
     }
@@ -486,6 +673,14 @@ public class MutableUpdateImpl
     }
 
     private void renderTo(@NotNull SqlBuilder builder, Collection<Object> ids) {
+        renderTo(builder, ids, null);
+    }
+
+    private void renderTo(
+            @NotNull SqlBuilder builder,
+            Collection<Object> ids,
+            @Nullable List<Selection<?>> returningSelections
+    ) {
         AstContext astContext = builder.getAstContext();
         astContext.pushStatement(updateQuery);
         boolean joinedTypeBranchUpdatePushed = false;
@@ -507,8 +702,8 @@ public class MutableUpdateImpl
             boolean joinedTypeStageJoinRequired = !joinedTypeStageAliasMap.isEmpty();
             boolean idSubQueryRequired =
                     ids == null &&
-                    updateJoin == null &&
-                    (joinedTypeStageJoinRequired || usedChild);
+                            updateJoin == null &&
+                            (joinedTypeStageJoinRequired || usedChild);
             ImmutableType rootType = table.getImmutableType().getInheritanceInfo() != null ?
                     table.getImmutableType().getInheritanceInfo().getRootType() :
                     null;
@@ -516,19 +711,19 @@ public class MutableUpdateImpl
                 if (!dialect.isTableOfSubQueryMutable()) {
                     throw new ExecutionException(
                             "Table joins for update statement is forbidden by the current dialect, " +
-                            "and the current dialect does not support using the updated table in a subquery. " +
-                            "Cannot render portable id-subquery update for \"" +
-                            table.getImmutableType() +
-                            "\""
+                                    "and the current dialect does not support using the updated table in a subquery. " +
+                                    "Cannot render portable id-subquery update for \"" +
+                                    table.getImmutableType() +
+                                    "\""
                     );
                 }
                 if (assignmentSourceRequiresExtraTable()) {
                     throw new ExecutionException(
                             "Table joins for update statement is forbidden by the current dialect, " +
-                            "but an assignment value of update statement for \"" +
-                            table.getImmutableType() +
-                            "\" requires another table. Portable id-subquery update can only move " +
-                            "predicate joins into the id subquery, not assignment value joins."
+                                    "but an assignment value of update statement for \"" +
+                                    table.getImmutableType() +
+                                    "\" requires another table. Portable id-subquery update can only move " +
+                                    "predicate joins into the id subquery, not assignment value joins."
                     );
                 }
                 ImmutableType subQueryBaseType = rootType != null ? rootType : table.getImmutableType();
@@ -541,9 +736,9 @@ public class MutableUpdateImpl
                     updateJoin.getFrom() == UpdateJoin.From.AS_ROOT) {
                 throw new ExecutionException(
                         "The current dialect renders update joins from the root table, " +
-                        "but joined inheritance update for \"" +
-                        table.getImmutableType() +
-                        "\" requires separate inheritance stage aliases"
+                                "but joined inheritance update for \"" +
+                                table.getImmutableType() +
+                                "\" requires separate inheritance stage aliases"
                 );
             }
             if (aliasSource != null) {
@@ -594,6 +789,11 @@ public class MutableUpdateImpl
                     idSubQueryStageAliasMap,
                     idSubQueryRequired
             );
+
+            if (returningSelections != null) {
+                builder.sql(" returning ");
+                renderReturningSelections(builder, returningSelections, physicalType, true);
+            }
 
         } finally {
             if (joinedTypeBranchUpdatePushed) {
@@ -666,9 +866,9 @@ public class MutableUpdateImpl
         UpdateJoin updateJoin = getSqlClient().getDialect().getUpdateJoin();
         boolean withTargetPrefix =
                 updateJoin != null &&
-                updateJoin.isJoinedTableUpdatable() &&
-                (MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext()) ||
-                        joinedTypeStageJoinRequired);
+                        updateJoin.isJoinedTableUpdatable() &&
+                        (MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext()) ||
+                                joinedTypeStageJoinRequired);
         for (Map.Entry<Target, Expression<?>> e : assignmentMap.entrySet()) {
             builder.separator();
             renderTarget(builder, e.getKey(), withTargetPrefix, physicalType, joinedTypeStageAliasMap);
@@ -764,7 +964,7 @@ public class MutableUpdateImpl
         TableImplementor<?> table = getTableLikeImplementor();
         UpdateJoin updateJoin = getSqlClient().getDialect().getUpdateJoin();
         if (updateJoin != null &&
-            updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
+                updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
                 MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext())
         ) {
             MutationJoinRenderSupport.renderDeeperJoinsAsFrom(builder, table);
@@ -786,15 +986,15 @@ public class MutableUpdateImpl
 
         boolean hasJoinedTypeStageCondition =
                 forUpdate &&
-                updateJoin != null &&
-                updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
-                !joinedTypeStageAliasMap.isEmpty();
+                        updateJoin != null &&
+                        updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
+                        !joinedTypeStageAliasMap.isEmpty();
 
         boolean hasTableCondition =
                 forUpdate &&
-                updateJoin != null &&
-                updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
-                MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext());
+                        updateJoin != null &&
+                        updateJoin.getFrom() == UpdateJoin.From.AS_JOIN &&
+                        MutationJoinRenderSupport.hasUsedChild(table, builder.getAstContext());
 
         if (!hasJoinedTypeStageCondition &&
                 !hasTableCondition &&
@@ -811,7 +1011,7 @@ public class MutableUpdateImpl
                     MutationRender.alias(builder, table),
                     table.getImmutableType().getIdProp().getStorage(getSqlClient().getMetadataStrategy()),
                     ids,
-                builder
+                    builder
             );
         }
 
@@ -949,6 +1149,119 @@ public class MutableUpdateImpl
         }
     }
 
+    private void renderReturningSelections(
+            SqlBuilder builder,
+            List<Selection<?>> selections,
+            ImmutableType physicalType,
+            boolean withPrefix
+    ) {
+        builder.enter(SqlBuilder.ScopeType.COMMA);
+        try {
+            for (Selection<?> selection : selections) {
+                builder.separator();
+                PropExpressionImplementor<?> propExpression =
+                        returningPropExpression(builder.getAstContext(), selection, physicalType);
+                if (withPrefix) {
+                    propExpression.renderTo(builder, true);
+                } else {
+                    renderReturningColumnWithoutPrefix(builder, propExpression);
+                }
+            }
+        } finally {
+            builder.leave();
+        }
+    }
+
+    private PropExpressionImplementor<?> returningPropExpression(
+            AstContext astContext,
+            Selection<?> selection,
+            ImmutableType physicalType
+    ) {
+        Ast ast = Ast.from(selection, astContext);
+        if (!(ast instanceof PropExpressionImplementor<?>)) {
+            throw new IllegalArgumentException(
+                    "The update-returning selection \"" +
+                            selection +
+                            "\" is not supported. Only column property selections of the updated table are supported."
+            );
+        }
+        PropExpressionImplementor<?> propExpression = (PropExpressionImplementor<?>) ast;
+        Table<?> selectionTable = propExpression.getTable();
+        if (selectionTable != getTable() && selectionTable != getTableLikeImplementor()) {
+            throw new IllegalArgumentException(
+                    "The update-returning selection \"" +
+                            selection +
+                            "\" is not supported because it does not belong to the updated table \"" +
+                            getTableLikeImplementor().getImmutableType() +
+                            "\""
+            );
+        }
+        ImmutableProp prop = propExpression.getProp();
+        if (!prop.isColumnDefinition()) {
+            throw new IllegalArgumentException(
+                    "The update-returning selection \"" +
+                            selection +
+                            "\" is not supported because property \"" +
+                            prop +
+                            "\" is not mapped by physical columns"
+            );
+        }
+        validateReturningStage(prop, physicalType);
+        return propExpression;
+    }
+
+    private void validateReturningStage(ImmutableProp prop, ImmutableType physicalType) {
+        TableImplementor<?> table = getTableLikeImplementor();
+        ImmutableType updateType = table.getImmutableType();
+        InheritanceInfo inheritanceInfo = updateType.getInheritanceInfo();
+        if (inheritanceInfo == null || inheritanceInfo.getStrategy() != InheritanceType.JOINED) {
+            return;
+        }
+        if (assignmentStageTypes.size() > 1) {
+            throw new IllegalArgumentException(
+                    "The update-returning statement for joined inheritance type \"" +
+                            updateType +
+                            "\" cannot be used when assignments target multiple physical tables"
+            );
+        }
+        ImmutableProp originalProp = prop.toOriginal();
+        ImmutableType stageType = originalProp.isId() ?
+                physicalType :
+                inheritanceInfo.getTableTypeForProp(originalProp, updateType);
+        if (stageType != physicalType) {
+            MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
+            throw new IllegalArgumentException(
+                    "The update-returning property \"" +
+                            prop +
+                            "\" must belong to the same physical table as the update target. " +
+                            "The property belongs to table \"" +
+                            (stageType != null ? stageType.getTableName(strategy) : originalProp.getDeclaringType().getTableName(strategy)) +
+                            "\" but the update target table is \"" +
+                            physicalType.getTableName(strategy) +
+                            "\""
+            );
+        }
+    }
+
+    private void renderReturningColumnWithoutPrefix(
+            SqlBuilder builder,
+            PropExpressionImplementor<?> propExpression
+    ) {
+        MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
+        EmbeddedColumns.Partial partial = propExpression.getPartial(strategy);
+        TableSelection tableSelection = TableProxies.resolve(
+                propExpression.getTable(),
+                builder.getAstContext()
+        );
+        tableSelection.renderSelection(
+                propExpression.getProp(),
+                propExpression.isRawId(),
+                builder,
+                propExpression.getPath() != null ? partial : null,
+                false
+        );
+    }
+
     private static class Target {
 
         final Table<?> table;
@@ -969,8 +1282,8 @@ public class MutableUpdateImpl
             if (partial != null && partial.isEmbedded()) {
                 throw new IllegalArgumentException(
                         "The property \"" +
-                        implementor +
-                        "\" is embedded, it cannot be used as the assignment target of update statement"
+                                implementor +
+                                "\" is embedded, it cannot be used as the assignment target of update statement"
                 );
             }
             Table<?> targetTable = implementor.getTable();
@@ -1001,6 +1314,74 @@ public class MutableUpdateImpl
         @Override
         public int hashCode() {
             return expr.hashCode();
+        }
+    }
+
+    private class UpdateReturningExecutable<R> implements Executable<List<R>> {
+
+        private final List<Selection<?>> selections;
+
+        private final TupleCreator<R> tupleCreator;
+
+        private UpdateReturningExecutable(List<Selection<?>> selections, TupleCreator<R> tupleCreator) {
+            this.selections = selections;
+            this.tupleCreator = tupleCreator;
+        }
+
+        @Override
+        public List<R> execute(Connection con) {
+            return getSqlClient()
+                    .getConnectionManager()
+                    .execute(con, it -> executeReturningImpl(it, selections, tupleCreator));
+        }
+    }
+
+    private class UpdateReturningContextImpl implements Dialect.UpdateReturningContext {
+
+        private final SqlBuilder builder;
+
+        private final Collection<Object> ids;
+
+        private final List<Selection<?>> selections;
+
+        private UpdateReturningContextImpl(
+                SqlBuilder builder,
+                Collection<Object> ids,
+                List<Selection<?>> selections
+        ) {
+            this.builder = builder;
+            this.ids = ids;
+            this.selections = selections;
+        }
+
+        @Override
+        public Dialect.UpdateReturningContext sql(String sql) {
+            builder.sql(sql);
+            return this;
+        }
+
+        @Override
+        public Dialect.UpdateReturningContext appendUpdateStatement() {
+            renderTo(builder, ids);
+            return this;
+        }
+
+        @Override
+        public Dialect.UpdateReturningContext appendUpdateStatementWithReturning() {
+            renderTo(builder, ids, selections);
+            return this;
+        }
+
+        @Override
+        public Dialect.UpdateReturningContext appendReturningColumns() {
+            AstContext astContext = builder.getAstContext();
+            astContext.pushStatement(updateQuery);
+            try {
+                renderReturningSelections(builder, selections, physicalUpdateType(), false);
+            } finally {
+                astContext.popStatement();
+            }
+            return this;
         }
     }
 
@@ -1071,24 +1452,24 @@ public class MutableUpdateImpl
                 if (table.getParent() != null && dialect.getUpdateJoin() == null) {
                     throw new ExecutionException(
                             "Table joins for update statement is forbidden by the current dialect, " +
-                            "but there is a join '" +
-                            table.getTableLikeImplementor() +
-                            "'."
+                                    "but there is a join '" +
+                                    table.getTableLikeImplementor() +
+                                    "'."
                     );
                 }
                 if (table.getParent() != null &&
-                    table.getParent().getParent() == null &&
-                    dialect.getUpdateJoin() != null &&
-                    dialect.getUpdateJoin().getFrom() == UpdateJoin.From.AS_JOIN) {
+                        table.getParent().getParent() == null &&
+                        dialect.getUpdateJoin() != null &&
+                        dialect.getUpdateJoin().getFrom() == UpdateJoin.From.AS_JOIN) {
                     Lazy<String> reason = new Lazy<>(() ->
                             "because current dialect '" +
-                            dialect.getClass().getName() +
-                            "' " +
-                            "indicates that the first level table joins in update statement " +
-                            "must be rendered as 'from' clause, " +
-                            "but there is a first level table join whose join type is outer: '" +
-                            table.getTableLikeImplementor() +
-                            "'."
+                                    dialect.getClass().getName() +
+                                    "' " +
+                                    "indicates that the first level table joins in update statement " +
+                                    "must be rendered as 'from' clause, " +
+                                    "but there is a first level table join whose join type is outer: '" +
+                                    table.getTableLikeImplementor() +
+                                    "'."
                     );
                     TableLikeImplementor<?> implementor = table.getTableLikeImplementor();
                     if (implementor instanceof TableImplementor<?>) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpdateImpl.java
@@ -12,6 +12,7 @@ import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsageCollector;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsages;
 import org.babyfish.jimmer.sql.ast.impl.table.*;
+import org.babyfish.jimmer.sql.ast.impl.util.JdbcOptionValidator;
 import org.babyfish.jimmer.sql.ast.mutation.MutableUpdate;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.TableEx;
@@ -30,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
 import java.util.*;
+import java.util.stream.Stream;
 
 public class MutableUpdateImpl
         extends AbstractMutableStatementImpl
@@ -43,6 +45,7 @@ public class MutableUpdateImpl
     private final Set<ImmutableType> assignmentStageTypes = new LinkedHashSet<>();
     private TableLikeImplementor<?> aliasSource;
     private TypeMatchMode typeMatchMode = TypeMatchMode.AUTO;
+    private JdbcOptions jdbcOptions = JdbcOptions.EMPTY;
     private boolean typeMatchPredicateApplied;
     private ImmutableType primaryAssignmentStageType;
 
@@ -107,6 +110,22 @@ public class MutableUpdateImpl
     public MutableUpdateImpl setTypeMatchMode(TypeMatchMode mode) {
         validateMutable();
         this.typeMatchMode = mode != null ? mode : TypeMatchMode.AUTO;
+        return this;
+    }
+
+    @Override
+    public MutableUpdateImpl jdbcFetchSize(@Nullable Integer fetchSize) {
+        validateMutable();
+        JdbcOptionValidator.validateLocalFetchSize(fetchSize);
+        jdbcOptions = jdbcOptions.fetchSize(fetchSize);
+        return this;
+    }
+
+    @Override
+    public MutableUpdateImpl jdbcQueryTimeout(@Nullable Integer queryTimeout) {
+        validateMutable();
+        JdbcOptionValidator.validateLocalQueryTimeout(queryTimeout);
+        jdbcOptions = jdbcOptions.queryTimeout(queryTimeout);
         return this;
     }
 
@@ -311,12 +330,12 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <R> Executable<List<R>> returning(Selection<R> selection) {
+    public <R> SelectionExecutable<R> returning(Selection<R> selection) {
         return returning(Collections.singletonList(selection), null);
     }
 
     @Override
-    public <T1, T2> Executable<List<Tuple2<T1, T2>>> returning(
+    public <T1, T2> SelectionExecutable<Tuple2<T1, T2>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2
     ) {
@@ -324,7 +343,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3> Executable<List<Tuple3<T1, T2, T3>>> returning(
+    public <T1, T2, T3> SelectionExecutable<Tuple3<T1, T2, T3>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3
@@ -333,7 +352,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4> Executable<List<Tuple4<T1, T2, T3, T4>>> returning(
+    public <T1, T2, T3, T4> SelectionExecutable<Tuple4<T1, T2, T3, T4>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -343,7 +362,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4, T5> Executable<List<Tuple5<T1, T2, T3, T4, T5>>> returning(
+    public <T1, T2, T3, T4, T5> SelectionExecutable<Tuple5<T1, T2, T3, T4, T5>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -354,7 +373,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6> Executable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> returning(
+    public <T1, T2, T3, T4, T5, T6> SelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -366,7 +385,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7> Executable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> returning(
+    public <T1, T2, T3, T4, T5, T6, T7> SelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -379,7 +398,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8> Executable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> returning(
+    public <T1, T2, T3, T4, T5, T6, T7, T8> SelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -393,7 +412,7 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9> Executable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> returning(
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9> SelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -408,11 +427,11 @@ public class MutableUpdateImpl
     }
 
     @Override
-    public <R> Executable<List<R>> returning(TupleMapper<R> mapper) {
+    public <R> SelectionExecutable<R> returning(TupleMapper<R> mapper) {
         return returning(mapper.getSelections(), mapper);
     }
 
-    private <R> Executable<List<R>> returning(
+    private <R> SelectionExecutable<R> returning(
             List<Selection<?>> selections,
             TupleCreator<R> tupleCreator
     ) {
@@ -420,7 +439,7 @@ public class MutableUpdateImpl
         if (selections.isEmpty()) {
             throw new IllegalArgumentException("The update-returning selection list cannot be empty");
         }
-        return new UpdateReturningExecutable<>(selections, tupleCreator);
+        return new UpdateSelectionExecutable<>(selections, tupleCreator, jdbcOptions);
     }
 
     private int executeImpl(Connection con) {
@@ -446,7 +465,8 @@ public class MutableUpdateImpl
     private <R> List<R> executeReturningImpl(
             Connection con,
             List<Selection<?>> selections,
-            TupleCreator<R> tupleCreator
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions
     ) {
 
         if (assignmentMap.isEmpty()) {
@@ -469,18 +489,49 @@ public class MutableUpdateImpl
         SqlBuilder builder = createFilteredBuilder();
 
         if (!triggerIgnored && getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY) {
-            return executeReturningWithTrigger(builder, con, selections, tupleCreator);
+            return executeReturningWithTrigger(builder, con, selections, tupleCreator, jdbcOptions);
         }
 
         renderReturningTo(builder, null, selections);
-        return executeReturningSql(builder, con, selections, tupleCreator);
+        return executeReturningSql(builder, con, selections, tupleCreator, jdbcOptions);
+    }
+
+    private <R> Stream<R> streamReturningImpl(
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions
+    ) {
+
+        if (assignmentMap.isEmpty()) {
+            return Stream.empty();
+        }
+
+        Dialect dialect = getSqlClient().getDialect();
+        if (!dialect.isUpdateReturningSupported()) {
+            throw new ExecutionException(
+                    "The update-returning statement is not supported by \"" +
+                            dialect.getClass().getName() +
+                            "\""
+            );
+        }
+
+        SqlBuilder builder = createFilteredBuilder();
+
+        if (!triggerIgnored && getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY) {
+            return streamReturningWithTrigger(builder, con, selections, tupleCreator, jdbcOptions);
+        }
+
+        renderReturningTo(builder, null, selections);
+        return streamReturningSql(builder, con, selections, tupleCreator, jdbcOptions, null);
     }
 
     private <R> List<R> executeReturningWithTrigger(
             SqlBuilder builder,
             Connection con,
             List<Selection<?>> selections,
-            TupleCreator<R> tupleCreator
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions
     ) {
         Map<Object, ImmutableSpi> oldRowMap = selectRowsForTrigger(builder, con);
         if (oldRowMap.isEmpty()) {
@@ -489,18 +540,56 @@ public class MutableUpdateImpl
 
         builder = new SqlBuilder(new AstContext(getSqlClient()));
         renderReturningTo(builder, oldRowMap.keySet(), selections);
-        List<R> rows = executeReturningSql(builder, con, selections, tupleCreator);
+        List<R> rows = executeReturningSql(builder, con, selections, tupleCreator, jdbcOptions);
         if (!rows.isEmpty()) {
             submitTrigger(con, oldRowMap);
         }
         return rows;
     }
 
+    private <R> Stream<R> streamReturningWithTrigger(
+            SqlBuilder builder,
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions
+    ) {
+        ConnectionManager.ConnectionScope scope = getSqlClient().getConnectionManager().open(con);
+        Connection actualCon = scope.connection();
+        try {
+            if (getSqlClient().isTargetTransferable()) {
+                Executor.validateMutationConnection(actualCon);
+            }
+            Map<Object, ImmutableSpi> oldRowMap = selectRowsForTrigger(builder, actualCon);
+            if (oldRowMap.isEmpty()) {
+                scope.close();
+                return Stream.empty();
+            }
+
+            builder = new SqlBuilder(new AstContext(getSqlClient()));
+            renderReturningTo(builder, oldRowMap.keySet(), selections);
+            return streamReturningSql(
+                    builder,
+                    actualCon,
+                    existingScopeConnectionManager(scope),
+                    selections,
+                    tupleCreator,
+                    jdbcOptions,
+                    () -> submitTrigger(actualCon, oldRowMap),
+                    null
+            );
+        } catch (RuntimeException | Error ex) {
+            scope.close();
+            throw ex;
+        }
+    }
+
     private <R> List<R> executeReturningSql(
             SqlBuilder builder,
             Connection con,
             List<Selection<?>> selections,
-            TupleCreator<R> tupleCreator
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions
     ) {
         Tuple3<String, List<Object>, List<Integer>> sqlResult = builder.build();
         return Selectors.select(
@@ -511,8 +600,75 @@ public class MutableUpdateImpl
                 sqlResult.get_3(),
                 selections,
                 tupleCreator,
-                getPurpose()
+                getPurpose(),
+                jdbcOptions
         );
+    }
+
+    private <R> Stream<R> streamReturningSql(
+            SqlBuilder builder,
+            Connection con,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions,
+            @Nullable Runnable beforeClose
+    ) {
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = builder.build();
+        return Selectors.stream(
+                getSqlClient(),
+                getSqlClient().getConnectionManager(),
+                con,
+                sqlResult.get_1(),
+                sqlResult.get_2(),
+                sqlResult.get_3(),
+                selections,
+                tupleCreator,
+                getPurpose(),
+                jdbcOptions,
+                beforeClose,
+                getSqlClient().isTargetTransferable() ? Executor::validateMutationConnection : null
+        );
+    }
+
+    private <R> Stream<R> streamReturningSql(
+            SqlBuilder builder,
+            Connection con,
+            ConnectionManager connectionManager,
+            List<Selection<?>> selections,
+            TupleCreator<R> tupleCreator,
+            JdbcOptions jdbcOptions,
+            @Nullable Runnable beforeClose,
+            @Nullable java.util.function.Consumer<Connection> connectionValidator
+    ) {
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = builder.build();
+        return Selectors.stream(
+                getSqlClient(),
+                connectionManager,
+                con,
+                sqlResult.get_1(),
+                sqlResult.get_2(),
+                sqlResult.get_3(),
+                selections,
+                tupleCreator,
+                getPurpose(),
+                jdbcOptions,
+                beforeClose,
+                connectionValidator
+        );
+    }
+
+    private ConnectionManager existingScopeConnectionManager(ConnectionManager.ConnectionScope scope) {
+        return new ConnectionManager() {
+            @Override
+            public <R> R execute(@Nullable Connection con, java.util.function.Function<Connection, R> block) {
+                return block.apply(scope.connection());
+            }
+
+            @Override
+            public ConnectionManager.ConnectionScope open(@Nullable Connection con) {
+                return scope;
+            }
+        };
     }
 
     private SqlBuilder createFilteredBuilder() {
@@ -1317,22 +1473,34 @@ public class MutableUpdateImpl
         }
     }
 
-    private class UpdateReturningExecutable<R> implements Executable<List<R>> {
+    private class UpdateSelectionExecutable<R> implements SelectionExecutable<R> {
 
         private final List<Selection<?>> selections;
 
         private final TupleCreator<R> tupleCreator;
 
-        private UpdateReturningExecutable(List<Selection<?>> selections, TupleCreator<R> tupleCreator) {
+        private final JdbcOptions jdbcOptions;
+
+        private UpdateSelectionExecutable(
+                List<Selection<?>> selections,
+                TupleCreator<R> tupleCreator,
+                JdbcOptions jdbcOptions
+        ) {
             this.selections = selections;
             this.tupleCreator = tupleCreator;
+            this.jdbcOptions = jdbcOptions;
         }
 
         @Override
         public List<R> execute(Connection con) {
             return getSqlClient()
                     .getConnectionManager()
-                    .execute(con, it -> executeReturningImpl(it, selections, tupleCreator));
+                    .execute(con, it -> executeReturningImpl(it, selections, tupleCreator, jdbcOptions));
+        }
+
+        @Override
+        public Stream<R> stream(Connection con) {
+            return streamReturningImpl(con, selections, tupleCreator, jdbcOptions);
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
@@ -16,6 +16,7 @@ import org.babyfish.jimmer.sql.fetcher.Field;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherSelection;
 import org.babyfish.jimmer.sql.meta.*;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.babyfish.jimmer.sql.runtime.JdbcOptions;
 import org.babyfish.jimmer.sql.runtime.SqlBuilder;
 import org.babyfish.jimmer.sql.runtime.TupleCreator;
 import org.jetbrains.annotations.NotNull;
@@ -56,6 +57,11 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
     @Override
     public TupleCreator<?> getTupleCreator() {
         return data.tupleCreator;
+    }
+
+    @Override
+    public JdbcOptions getJdbcOptions() {
+        return data.jdbcOptions;
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableRootQueryImpl.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
         extends AbstractConfigurableTypedQueryImpl
@@ -357,6 +358,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
                 Collections.singletonList(Expression.rowCount()),
                 null,
                 getMutableQuery().getPurpose(),
+                data.jdbcOptions,
                 data.forUpdate != null
         );
         return (Long)rows.get(0);
@@ -385,6 +387,7 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
                 Collections.singletonList(Expression.rowCount()),
                 null,
                 getMutableQuery().getPurpose(),
+                data.jdbcOptions,
                 getForUpdate() != null
         );
         return !rows.isEmpty();
@@ -406,6 +409,29 @@ public class ConfigurableRootQueryImpl<T extends TableLike<?>, R>
                 data.selections,
                 data.tupleCreator,
                 getMutableQuery().getPurpose(),
+                data.jdbcOptions,
+                data.forUpdate != null
+        );
+    }
+
+    @Override
+    public Stream<R> stream(Connection con) {
+        TypedQueryData data = getData();
+        if (data.limit == 0) {
+            return Stream.empty();
+        }
+        JSqlClientImplementor sqlClient = getMutableQuery().getSqlClient();
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(sqlClient);
+        return Selectors.stream(
+                sqlClient,
+                con,
+                sqlResult.get_1(),
+                sqlResult.get_2(),
+                sqlResult.get_3(),
+                data.selections,
+                data.tupleCreator,
+                getMutableQuery().getPurpose(),
+                data.jdbcOptions,
                 data.forUpdate != null
         );
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedTypedRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MergedTypedRootQueryImpl.java
@@ -16,9 +16,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>, TypedQueryImplementor {
 
@@ -28,6 +30,7 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
     private final List<Selection<?>> selections;
     private final TupleCreator<?> tupleCreator;
     private final ForUpdate forUpdate;
+    private final JdbcOptions jdbcOptions;
     protected final TypedRootQueryImplementor<?>[] queries;
 
     @SafeVarargs
@@ -41,7 +44,8 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
                 return new MergedTypedRootQueryImpl<>(
                         ((TypedQueryImplementor)queries[0]).getSqlClient(),
                         operator,
-                        queries
+                        queries,
+                        ((TypedQueryImplementor) queries[0]).getJdbcOptions()
                 );
         }
     }
@@ -49,7 +53,9 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
     private MergedTypedRootQueryImpl(
             JSqlClientImplementor sqlClient,
             String operator,
-            TypedRootQuery<R>[] queries) {
+            TypedRootQuery<R>[] queries,
+            JdbcOptions jdbcOptions
+    ) {
         this.sqlClient = sqlClient;
         this.operator = operator;
         if (queries.length < 2) {
@@ -71,6 +77,25 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
         selections = selectionArr;
         tupleCreator = queryArr[0].getTupleCreator();
         this.forUpdate = forUpdate;
+        this.jdbcOptions = jdbcOptions;
+    }
+
+    private MergedTypedRootQueryImpl(
+            JSqlClientImplementor sqlClient,
+            String operator,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            ForUpdate forUpdate,
+            TypedRootQueryImplementor<?>[] queries,
+            JdbcOptions jdbcOptions
+    ) {
+        this.sqlClient = sqlClient;
+        this.operator = operator;
+        this.selections = selections;
+        this.tupleCreator = tupleCreator;
+        this.forUpdate = forUpdate;
+        this.queries = Arrays.copyOf(queries, queries.length);
+        this.jdbcOptions = jdbcOptions;
     }
 
     private static List<Selection<?>> mergedSelections(
@@ -125,6 +150,24 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
                 selections,
                 tupleCreator,
                 ExecutionPurpose.QUERY,
+                jdbcOptions,
+                forUpdate != null
+        );
+    }
+
+    @Override
+    public Stream<R> stream(Connection con) {
+        Tuple3<String, List<Object>, List<Integer>> sqlResult = preExecute(new SqlBuilder(new AstContext(sqlClient)));
+        return Selectors.stream(
+                sqlClient,
+                con,
+                sqlResult.get_1(),
+                sqlResult.get_2(),
+                sqlResult.get_3(),
+                selections,
+                tupleCreator,
+                ExecutionPurpose.QUERY,
+                jdbcOptions,
                 forUpdate != null
         );
     }
@@ -222,6 +265,11 @@ public class MergedTypedRootQueryImpl<R> implements TypedRootQueryImplementor<R>
     @Override
     public JSqlClientImplementor getSqlClient() {
         return sqlClient;
+    }
+
+    @Override
+    public JdbcOptions getJdbcOptions() {
+        return jdbcOptions;
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableRootQueryImpl.java
@@ -9,6 +9,7 @@ import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
 import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
+import org.babyfish.jimmer.sql.ast.impl.util.JdbcOptionValidator;
 import org.babyfish.jimmer.sql.ast.query.ConfigurableRootQuery;
 import org.babyfish.jimmer.sql.ast.query.MutableRootQuery;
 import org.babyfish.jimmer.sql.ast.query.Order;
@@ -20,8 +21,11 @@ import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 import org.babyfish.jimmer.sql.ast.tuple.*;
 import org.babyfish.jimmer.sql.exception.ExecutionException;
 import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.JdbcOptions;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.babyfish.jimmer.sql.runtime.TupleCreator;
 import org.babyfish.jimmer.sql.runtime.TupleMapper;
+import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
 import java.util.Arrays;
@@ -36,6 +40,8 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     private final StatementContext ctx;
 
     private TypeMatchMode typeMatchMode = TypeMatchMode.POLYMORPHIC;
+
+    private JdbcOptions jdbcOptions = JdbcOptions.EMPTY;
 
     private boolean typeMatchPredicateApplied;
 
@@ -133,7 +139,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <R> ConfigurableRootQuery<T, R> select(Selection<R> selection) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(Collections.singletonList(selection), null),
+                typedData(Collections.singletonList(selection), null),
                 this
         );
     }
@@ -141,7 +147,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2> ConfigurableRootQuery<T, Tuple2<T1, T2>> select(Selection<T1> selection1, Selection<T2> selection2) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(Arrays.asList(selection1, selection2), null),
+                typedData(Arrays.asList(selection1, selection2), null),
                 this
         );
     }
@@ -149,7 +155,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3> ConfigurableRootQuery<T, Tuple3<T1, T2, T3>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -164,7 +170,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4> ConfigurableRootQuery<T, Tuple4<T1, T2, T3, T4>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -180,7 +186,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4, T5> ConfigurableRootQuery<T, Tuple5<T1, T2, T3, T4, T5>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4, Selection<T5> selection5) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -197,7 +203,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4, T5, T6> ConfigurableRootQuery<T, Tuple6<T1, T2, T3, T4, T5, T6>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4, Selection<T5> selection5, Selection<T6> selection6) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -215,7 +221,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4, T5, T6, T7> ConfigurableRootQuery<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4, Selection<T5> selection5, Selection<T6> selection6, Selection<T7> selection7) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -234,7 +240,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8> ConfigurableRootQuery<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4, Selection<T5> selection5, Selection<T6> selection6, Selection<T7> selection7, Selection<T8> selection8) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -254,7 +260,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9> ConfigurableRootQuery<T, Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> select(Selection<T1> selection1, Selection<T2> selection2, Selection<T3> selection3, Selection<T4> selection4, Selection<T5> selection5, Selection<T6> selection6, Selection<T7> selection7, Selection<T8> selection8, Selection<T9> selection9) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         Arrays.asList(
                                 selection1,
                                 selection2,
@@ -275,7 +281,7 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
     @Override
     public <R> ConfigurableRootQuery<T, R> select(TupleMapper<R> mapper) {
         return new ConfigurableRootQueryImpl<>(
-                new TypedQueryData(
+                typedData(
                         mapper.getSelections(),
                         mapper
                 ),
@@ -283,10 +289,30 @@ public class MutableRootQueryImpl<T extends TableLike<?>>
         );
     }
 
+    private TypedQueryData typedData(List<Selection<?>> selections, TupleCreator<?> tupleCreator) {
+        return new TypedQueryData(selections, tupleCreator, jdbcOptions);
+    }
+
     @Override
     public MutableRootQuery<T> typeMatchMode(TypeMatchMode mode) {
         validateMutable();
         typeMatchMode = mode != null ? mode : TypeMatchMode.POLYMORPHIC;
+        return this;
+    }
+
+    @Override
+    public MutableRootQuery<T> jdbcFetchSize(@Nullable Integer fetchSize) {
+        validateMutable();
+        JdbcOptionValidator.validateLocalFetchSize(fetchSize);
+        jdbcOptions = jdbcOptions.fetchSize(fetchSize);
+        return this;
+    }
+
+    @Override
+    public MutableRootQuery<T> jdbcQueryTimeout(@Nullable Integer queryTimeout) {
+        validateMutable();
+        JdbcOptionValidator.validateLocalQueryTimeout(queryTimeout);
+        jdbcOptions = jdbcOptions.queryTimeout(queryTimeout);
         return this;
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedQueryData.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedQueryData.java
@@ -12,6 +12,7 @@ import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherImplementor;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherSelection;
+import org.babyfish.jimmer.sql.runtime.JdbcOptions;
 import org.babyfish.jimmer.sql.runtime.TupleCreator;
 
 import java.util.Collections;
@@ -45,6 +46,8 @@ class TypedQueryData {
 
     final String hint;
 
+    final JdbcOptions jdbcOptions;
+
     private PropExpressionImplementor<?> idOnlyExpression;
 
     private boolean idOnlyExpressionResolved;
@@ -62,6 +65,27 @@ class TypedQueryData {
         reverseSortOptimizationEnabled = null;
         forUpdate = null;
         hint = null;
+        jdbcOptions = JdbcOptions.EMPTY;
+    }
+
+    public TypedQueryData(
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            JdbcOptions jdbcOptions
+    ) {
+        this.selections = processSelections(selections);
+        this.tupleCreator = tupleCreator;
+        oldSelections = null;
+        oldTupleCreator = null;
+        distinct = false;
+        limit = Integer.MAX_VALUE;
+        offset = 0;
+        withoutSortingAndPaging = false;
+        reverseSorting = false;
+        reverseSortOptimizationEnabled = null;
+        forUpdate = null;
+        hint = null;
+        this.jdbcOptions = jdbcOptions;
     }
 
     private TypedQueryData(
@@ -76,7 +100,8 @@ class TypedQueryData {
             boolean reverseSorting,
             Boolean reverseSortOptimizationEnabled,
             ForUpdate forUpdate,
-            String hint
+            String hint,
+            JdbcOptions jdbcOptions
     ) {
         this.selections = selections;
         this.tupleCreator = tupleCreator;
@@ -90,6 +115,7 @@ class TypedQueryData {
         this.reverseSortOptimizationEnabled = reverseSortOptimizationEnabled;
         this.forUpdate = forUpdate;
         this.hint = hint;
+        this.jdbcOptions = jdbcOptions;
     }
 
     public TypedQueryData reselect(List<Selection<?>> selections, TupleCreator<?> tupleCreator) {
@@ -105,7 +131,8 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -122,7 +149,8 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -139,7 +167,8 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -156,7 +185,8 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -173,7 +203,8 @@ class TypedQueryData {
                 true,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -190,7 +221,8 @@ class TypedQueryData {
                 reverseSorting,
                 enabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -207,7 +239,8 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
         );
     }
 
@@ -237,7 +270,26 @@ class TypedQueryData {
                 reverseSorting,
                 reverseSortOptimizationEnabled,
                 forUpdate,
-                hint
+                hint,
+                jdbcOptions
+        );
+    }
+
+    public TypedQueryData jdbcOptions(JdbcOptions jdbcOptions) {
+        return new TypedQueryData(
+                selections,
+                tupleCreator,
+                oldSelections,
+                oldTupleCreator,
+                distinct,
+                limit,
+                offset,
+                withoutSortingAndPaging,
+                reverseSorting,
+                reverseSortOptimizationEnabled,
+                forUpdate,
+                hint,
+                jdbcOptions
         );
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedQueryImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TypedQueryImplementor.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.ast.impl.Ast;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.table.Table;
+import org.babyfish.jimmer.sql.runtime.JdbcOptions;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.babyfish.jimmer.sql.runtime.TupleCreator;
 import org.jetbrains.annotations.NotNull;
@@ -16,6 +17,10 @@ public interface TypedQueryImplementor extends Ast {
 
     default TupleCreator<?> getTupleCreator() {
         return null;
+    }
+
+    default JdbcOptions getJdbcOptions() {
+        return JdbcOptions.EMPTY;
     }
 
     JSqlClientImplementor getSqlClient();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/util/JdbcOptionValidator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/util/JdbcOptionValidator.java
@@ -1,0 +1,33 @@
+package org.babyfish.jimmer.sql.ast.impl.util;
+
+import org.jetbrains.annotations.Nullable;
+
+public final class JdbcOptionValidator {
+
+    private JdbcOptionValidator() {
+    }
+
+    public static void validateLocalFetchSize(@Nullable Integer fetchSize) {
+        if (fetchSize != null && fetchSize < 0) {
+            throw new IllegalArgumentException("`jdbcFetchSize` cannot be negative");
+        }
+    }
+
+    public static void validateDefaultFetchSize(@Nullable Integer fetchSize) {
+        if (fetchSize != null && fetchSize <= 0) {
+            throw new IllegalArgumentException("`defaultJdbcFetchSize` must be greater than 0");
+        }
+    }
+
+    public static void validateLocalQueryTimeout(@Nullable Integer queryTimeout) {
+        if (queryTimeout != null && queryTimeout < 0) {
+            throw new IllegalArgumentException("`jdbcQueryTimeout` cannot be negative");
+        }
+    }
+
+    public static void validateDefaultQueryTimeout(@Nullable Integer queryTimeout) {
+        if (queryTimeout != null && queryTimeout <= 0) {
+            throw new IllegalArgumentException("`defaultJdbcQueryTimeout` must be greater than 0");
+        }
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpdate.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpdate.java
@@ -7,7 +7,8 @@ import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable;
 
 import java.util.function.Supplier;
 
-public interface MutableUpdate extends Filterable, Executable<Integer>, ReturningSelectable {
+public interface MutableUpdate
+        extends Filterable, Executable<Integer>, ReturningSelectable, JdbcConfigurable<MutableUpdate> {
 
     @OldChain
     MutableUpdate setTypeMatchMode(TypeMatchMode mode);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpdate.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpdate.java
@@ -1,17 +1,13 @@
 package org.babyfish.jimmer.sql.ast.mutation;
 
-import org.babyfish.jimmer.sql.ast.TypeMatchMode;
-
 import org.babyfish.jimmer.lang.OldChain;
-import org.babyfish.jimmer.sql.ast.Executable;
-import org.babyfish.jimmer.sql.ast.Expression;
-import org.babyfish.jimmer.sql.ast.Predicate;
-import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.query.Filterable;
+import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable;
 
 import java.util.function.Supplier;
 
-public interface MutableUpdate extends Filterable, Executable<Integer> {
+public interface MutableUpdate extends Filterable, Executable<Integer>, ReturningSelectable {
 
     @OldChain
     MutableUpdate setTypeMatchMode(TypeMatchMode mode);
@@ -24,7 +20,7 @@ public interface MutableUpdate extends Filterable, Executable<Integer> {
 
     @OldChain
     @Override
-    MutableUpdate where(Predicate ... predicates);
+    MutableUpdate where(Predicate... predicates);
 
     /**
      * This method is deprecated, using {@code Dynamic Predicates}
@@ -66,7 +62,7 @@ public interface MutableUpdate extends Filterable, Executable<Integer> {
      *         eq?, ne?, lt?, le?, gt?, ge?, like?, ilike?, betweenIf?
      *     </li>
      * </ul>
-     *
+     * <p>
      * Taking Java's {@code geIf} as an example, this functionality
      * is ultimately implemented like this.
      * <pre>{@code
@@ -123,7 +119,7 @@ public interface MutableUpdate extends Filterable, Executable<Integer> {
      *         eq?, ne?, lt?, le?, gt?, ge?, like?, ilike?, betweenIf?
      *     </li>
      * </ul>
-     *
+     * <p>
      * Taking Java's {@code geIf} as an example, this functionality
      * is ultimately implemented like this.
      * <pre>{@code
@@ -131,7 +127,7 @@ public interface MutableUpdate extends Filterable, Executable<Integer> {
      * }</pre>
      *
      * @param condition The condition
-     * @param block A lambda to create predicate when condition is true
+     * @param block     A lambda to create predicate when condition is true
      * @return Return the current object to support chain programming style
      */
     @OldChain

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/MutableRootQuery.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/MutableRootQuery.java
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.ast.query;
 import org.babyfish.jimmer.Specification;
 import org.babyfish.jimmer.lang.OldChain;
 import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.JdbcConfigurable;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.TypeMatchMode;
 import org.babyfish.jimmer.sql.ast.query.selectable.RootSelectable;
@@ -13,7 +14,8 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.function.Supplier;
 
-public interface MutableRootQuery<T extends TableLike<?>> extends MutableQuery, RootSelectable<T> {
+public interface MutableRootQuery<T extends TableLike<?>>
+        extends MutableQuery, RootSelectable<T>, JdbcConfigurable<MutableRootQuery<T>> {
 
     @OldChain
     MutableRootQuery<T> typeMatchMode(TypeMatchMode mode);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/TypedRootQuery.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/TypedRootQuery.java
@@ -1,8 +1,7 @@
 package org.babyfish.jimmer.sql.ast.query;
 
-import org.babyfish.jimmer.sql.ast.Executable;
+import org.babyfish.jimmer.sql.ast.SelectionExecutable;
 import org.babyfish.jimmer.sql.ast.impl.query.MergedTypedRootQueryImpl;
-import org.babyfish.jimmer.sql.ast.impl.query.TypedQueryImplementor;
 import org.babyfish.jimmer.sql.ast.impl.query.TypedRootQueryImplementor;
 import org.babyfish.jimmer.sql.exception.EmptyResultException;
 import org.babyfish.jimmer.sql.exception.TooManyResultsException;
@@ -15,7 +14,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public interface TypedRootQuery<R> extends Executable<List<R>> {
+public interface TypedRootQuery<R> extends SelectionExecutable<R> {
 
     @SafeVarargs
     static <R> TypedRootQuery<R> union(TypedRootQuery<R> ... queries) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/ReturningSelectable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/ReturningSelectable.java
@@ -1,35 +1,33 @@
 package org.babyfish.jimmer.sql.ast.query.selectable;
 
-import org.babyfish.jimmer.sql.ast.Executable;
 import org.babyfish.jimmer.sql.ast.Selection;
+import org.babyfish.jimmer.sql.ast.SelectionExecutable;
 import org.babyfish.jimmer.sql.ast.tuple.*;
 import org.babyfish.jimmer.sql.runtime.TupleMapper;
 
-import java.util.List;
-
 public interface ReturningSelectable {
 
-    <R> Executable<List<R>> returning(Selection<R> selection);
+    <R> SelectionExecutable<R> returning(Selection<R> selection);
 
-    <T1, T2> Executable<List<Tuple2<T1, T2>>> returning(
+    <T1, T2> SelectionExecutable<Tuple2<T1, T2>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2
     );
 
-    <T1, T2, T3> Executable<List<Tuple3<T1, T2, T3>>> returning(
+    <T1, T2, T3> SelectionExecutable<Tuple3<T1, T2, T3>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3
     );
 
-    <T1, T2, T3, T4> Executable<List<Tuple4<T1, T2, T3, T4>>> returning(
+    <T1, T2, T3, T4> SelectionExecutable<Tuple4<T1, T2, T3, T4>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
             Selection<T4> selection4
     );
 
-    <T1, T2, T3, T4, T5> Executable<List<Tuple5<T1, T2, T3, T4, T5>>> returning(
+    <T1, T2, T3, T4, T5> SelectionExecutable<Tuple5<T1, T2, T3, T4, T5>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -37,7 +35,7 @@ public interface ReturningSelectable {
             Selection<T5> selection5
     );
 
-    <T1, T2, T3, T4, T5, T6> Executable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> returning(
+    <T1, T2, T3, T4, T5, T6> SelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -46,7 +44,7 @@ public interface ReturningSelectable {
             Selection<T6> selection6
     );
 
-    <T1, T2, T3, T4, T5, T6, T7> Executable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> returning(
+    <T1, T2, T3, T4, T5, T6, T7> SelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -56,7 +54,7 @@ public interface ReturningSelectable {
             Selection<T7> selection7
     );
 
-    <T1, T2, T3, T4, T5, T6, T7, T8> Executable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> returning(
+    <T1, T2, T3, T4, T5, T6, T7, T8> SelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -67,7 +65,7 @@ public interface ReturningSelectable {
             Selection<T8> selection8
     );
 
-    <T1, T2, T3, T4, T5, T6, T7, T8, T9> Executable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> returning(
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9> SelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> returning(
             Selection<T1> selection1,
             Selection<T2> selection2,
             Selection<T3> selection3,
@@ -79,5 +77,5 @@ public interface ReturningSelectable {
             Selection<T9> selection9
     );
 
-    <R> Executable<List<R>> returning(TupleMapper<R> mapper);
+    <R> SelectionExecutable<R> returning(TupleMapper<R> mapper);
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/ReturningSelectable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/query/selectable/ReturningSelectable.java
@@ -1,0 +1,83 @@
+package org.babyfish.jimmer.sql.ast.query.selectable;
+
+import org.babyfish.jimmer.sql.ast.Executable;
+import org.babyfish.jimmer.sql.ast.Selection;
+import org.babyfish.jimmer.sql.ast.tuple.*;
+import org.babyfish.jimmer.sql.runtime.TupleMapper;
+
+import java.util.List;
+
+public interface ReturningSelectable {
+
+    <R> Executable<List<R>> returning(Selection<R> selection);
+
+    <T1, T2> Executable<List<Tuple2<T1, T2>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2
+    );
+
+    <T1, T2, T3> Executable<List<Tuple3<T1, T2, T3>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3
+    );
+
+    <T1, T2, T3, T4> Executable<List<Tuple4<T1, T2, T3, T4>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4
+    );
+
+    <T1, T2, T3, T4, T5> Executable<List<Tuple5<T1, T2, T3, T4, T5>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5
+    );
+
+    <T1, T2, T3, T4, T5, T6> Executable<List<Tuple6<T1, T2, T3, T4, T5, T6>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6
+    );
+
+    <T1, T2, T3, T4, T5, T6, T7> Executable<List<Tuple7<T1, T2, T3, T4, T5, T6, T7>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7
+    );
+
+    <T1, T2, T3, T4, T5, T6, T7, T8> Executable<List<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7,
+            Selection<T8> selection8
+    );
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9> Executable<List<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>>> returning(
+            Selection<T1> selection1,
+            Selection<T2> selection2,
+            Selection<T3> selection3,
+            Selection<T4> selection4,
+            Selection<T5> selection5,
+            Selection<T6> selection6,
+            Selection<T7> selection7,
+            Selection<T8> selection8,
+            Selection<T9> selection9
+    );
+
+    <R> Executable<List<R>> returning(TupleMapper<R> mapper);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
@@ -365,6 +365,16 @@ public abstract class AbstractJSqlClientDelegate implements JSqlClientImplemento
     }
 
     @Override
+    public Integer getDefaultJdbcFetchSize() {
+        return sqlClient().getDefaultJdbcFetchSize();
+    }
+
+    @Override
+    public Integer getDefaultJdbcQueryTimeout() {
+        return sqlClient().getDefaultJdbcQueryTimeout();
+    }
+
+    @Override
     public int getMaxJoinFetchDepth() {
         return sqlClient().getMaxJoinFetchDepth();
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -189,6 +189,10 @@ public interface Dialect extends SqlTypeStrategy {
         return false;
     }
 
+    default boolean isUpdateReturningSupported() {
+        return false;
+    }
+
     default boolean isInsertReturningSupported() {
         return false;
     }
@@ -218,6 +222,14 @@ public interface Dialect extends SqlTypeStrategy {
     default void updateByValues(UpdateByValuesContext ctx) {
         throw new UnsupportedOperationException(
                 "The update-by-values statement is not supported by \"" +
+                        getClass().getName() +
+                        "\""
+        );
+    }
+
+    default void updateReturning(UpdateReturningContext ctx) {
+        throw new UnsupportedOperationException(
+                "The update-returning statement is not supported by \"" +
                         getClass().getName() +
                         "\""
         );
@@ -284,6 +296,17 @@ public interface Dialect extends SqlTypeStrategy {
         UpdateByValuesContext appendPredicates(String targetPrefix, String sourcePrefix);
 
         UpdateByValuesContext appendReturning(String targetPrefix);
+    }
+
+    interface UpdateReturningContext {
+
+        UpdateReturningContext sql(String sql);
+
+        UpdateReturningContext appendUpdateStatement();
+
+        UpdateReturningContext appendUpdateStatementWithReturning();
+
+        UpdateReturningContext appendReturningColumns();
     }
 
     interface UpsertContext {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -147,6 +147,11 @@ public class H2Dialect extends DefaultDialect {
     }
 
     @Override
+    public boolean isUpdateReturningSupported() {
+        return true;
+    }
+
+    @Override
     public boolean isInsertReturningSupported() {
         return true;
     }
@@ -192,6 +197,16 @@ public class H2Dialect extends DefaultDialect {
                 .enter(AbstractSqlBuilder.ScopeType.SET)
                 .appendAssignments("tb_1_.", "tb_2_.")
                 .leave()
+                .sql(")");
+    }
+
+    @Override
+    public void updateReturning(UpdateReturningContext ctx) {
+        ctx
+                .sql("select ")
+                .appendReturningColumns()
+                .sql(" from final table (")
+                .appendUpdateStatement()
                 .sql(")");
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
@@ -205,6 +205,11 @@ public class PostgresDialect extends DefaultDialect {
     }
 
     @Override
+    public boolean isUpdateReturningSupported() {
+        return true;
+    }
+
+    @Override
     public boolean isInsertReturningSupported() {
         return true;
     }
@@ -276,6 +281,11 @@ public class PostgresDialect extends DefaultDialect {
                 .appendPredicates("tb_1_.", "tb_2_.")
                 .sql(" returning ")
                 .appendReturning("tb_1_.");
+    }
+
+    @Override
+    public void updateReturning(UpdateReturningContext ctx) {
+        ctx.appendUpdateStatementWithReturning();
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.fetcher.impl;
 
+import org.babyfish.jimmer.meta.EmbeddedLevel;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.runtime.DraftSpi;
@@ -49,6 +50,44 @@ public class FetcherUtil {
             return true;
         });
         return hasRef[0];
+    }
+
+    public static boolean hasPostFetchColumns(JSqlClientImplementor sqlClient, List<Selection<?>> selections) {
+        for (Selection<?> selection : selections) {
+            if (selection instanceof FetcherSelection<?>) {
+                Fetcher<?> fetcher = ((FetcherSelection<?>) selection).getFetcher();
+                if (requiresPostFetch(sqlClient, fetcher)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Object convert(
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            Object row
+    ) {
+        Map<Integer, Object> indexValueMap = null;
+        for (int i = 0; i < selections.size(); i++) {
+            Selection<?> selection = selections.get(i);
+            if (selection instanceof FetcherSelection<?>) {
+                Function<Object, Object> converter =
+                        (Function<Object, Object>) ((FetcherSelection<?>) selection).getConverter();
+                if (converter != null) {
+                    if (indexValueMap == null) {
+                        indexValueMap = new HashMap<>();
+                    }
+                    Object value = ColumnAccessors.get(row, i, tupleCreator);
+                    indexValueMap.put(i, value != null ? converter.apply(value) : null);
+                }
+            }
+        }
+        return indexValueMap != null ?
+                ColumnAccessors.set(row, indexValueMap, tupleCreator) :
+                row;
     }
 
     @SuppressWarnings("unchecked")
@@ -172,18 +211,34 @@ public class FetcherUtil {
         return Arrays.asList(arr);
     }
 
-    private static boolean requiresPostFetch(JSqlClientImplementor sqlClient, Fetcher<?> fetcher) {
+    public static boolean requiresPostFetch(JSqlClientImplementor sqlClient, Fetcher<?> fetcher) {
+        return requiresPostFetch(sqlClient, fetcher, 0);
+    }
+
+    private static boolean requiresPostFetch(
+            JSqlClientImplementor sqlClient,
+            Fetcher<?> fetcher,
+            int joinFetchDepth
+    ) {
         if (hasReferenceFilter(fetcher.getImmutableType(), sqlClient)) {
             return true;
         }
         for (Field field : fetcher.getFieldMap().values()) {
-            if (!field.isSimpleField()) {
+            if (field.isSimpleField()) {
+                continue;
+            }
+            if (joinFetchDepth < sqlClient.getMaxJoinFetchDepth() &&
+                    JoinFetchFieldVisitor.isJoinField(field, sqlClient) &&
+                    !requiresPostFetch(sqlClient, field.getChildFetcher(), joinFetchDepth + 1)) {
+                continue;
+            }
+            if (!field.getProp().isEmbedded(EmbeddedLevel.SCALAR)) {
                 return true;
             }
         }
         if (fetcher instanceof FetcherImplementor<?>) {
             for (Fetcher<?> typeBranchFetcher : ((FetcherImplementor<?>) fetcher).__getTypeBranchFetcherMap().values()) {
-                if (requiresPostFetch(sqlClient, typeBranchFetcher)) {
+                if (requiresPostFetch(sqlClient, typeBranchFetcher, joinFetchDepth)) {
                     return true;
                 }
             }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/AbstractExecutorProxy.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/AbstractExecutorProxy.java
@@ -43,6 +43,24 @@ public abstract class AbstractExecutorProxy implements Executor {
         );
     }
 
+    @Override
+    public void openCursor(
+            long cursorId,
+            String sql,
+            List<Object> variables,
+            List<Integer> variablePositions,
+            ExecutionPurpose purpose,
+            @Nullable ExecutorContext ctx,
+            JSqlClientImplementor sqlClient
+    ) {
+        raw.openCursor(cursorId, sql, variables, variablePositions, purpose, ctx, sqlClient);
+    }
+
+    @Override
+    public void closeCursor(long cursorId) {
+        raw.closeCursor(cursorId);
+    }
+
     protected abstract AbstractExecutorProxy recreate(Executor raw);
 
     protected abstract Batch createBatch(BatchContext raw);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ConnectionManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ConnectionManager.java
@@ -18,6 +18,15 @@ public interface ConnectionManager {
         return execute(null, block);
     }
 
+    default ConnectionScope open(@Nullable Connection con) {
+        if (con != null) {
+            return ConnectionScope.userConnection(con);
+        }
+        throw new UnsupportedOperationException(
+                "The current connection manager does not support streaming without explicit JDBC connection"
+        );
+    }
+
     ConnectionManager EXTERNAL_ONLY = new ConnectionManager() {
         @Override
         public <R> R execute(@Nullable Connection con, Function<Connection, R> block) {
@@ -56,5 +65,26 @@ public interface ConnectionManager {
                 return dataSource.getConnection();
             }
         };
+    }
+
+    interface ConnectionScope extends AutoCloseable {
+
+        Connection connection();
+
+        @Override
+        void close();
+
+        static ConnectionScope userConnection(Connection con) {
+            return new ConnectionScope() {
+                @Override
+                public Connection connection() {
+                    return con;
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+        }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DefaultExecutor.java
@@ -20,7 +20,7 @@ public class DefaultExecutor implements Executor {
     DefaultExecutor() {
     }
 
-    private static void setParameters(
+    static void setParameters(
             PreparedStatement stmt,
             List<Object> variables,
             JSqlClientImplementor sqlClient
@@ -46,7 +46,6 @@ public class DefaultExecutor implements Executor {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <R> R execute(@NotNull Args<R> args) {
         String sql = args.sql;
@@ -59,25 +58,30 @@ public class DefaultExecutor implements Executor {
             setParameters(stmt, variables, sqlClient);
             return args.block.apply(stmt, args);
         } catch (Exception ex) {
-            ExceptionTranslator<Exception> exceptionTranslator =
-                    (ExceptionTranslator<Exception>) args.getExceptionTranslator();
-            Exception translatedException;
-            if (exceptionTranslator == null) {
-                translatedException = ex;
-            } else {
-                translatedException = exceptionTranslator.translate(ex, args);
-            }
-            if (translatedException instanceof RuntimeException) {
-                throw (RuntimeException) translatedException;
-            }
-            throw new ExecutionException(
-                    "Cannot execute SQL statement: " +
-                    sql +
-                    ", variables: " +
-                    variables,
-                    translatedException
-            );
+            throw translate(args, ex);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    static RuntimeException translate(Args<?> args, Exception ex) {
+        ExceptionTranslator<Exception> exceptionTranslator =
+                (ExceptionTranslator<Exception>) args.getExceptionTranslator();
+        Exception translatedException;
+        if (exceptionTranslator == null) {
+            translatedException = ex;
+        } else {
+            translatedException = exceptionTranslator.translate(ex, args);
+        }
+        if (translatedException instanceof RuntimeException) {
+            return (RuntimeException) translatedException;
+        }
+        return new ExecutionException(
+                "Cannot execute SQL statement: " +
+                        args.sql +
+                        ", variables: " +
+                        args.variables,
+                translatedException
+        );
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Executor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Executor.java
@@ -44,10 +44,11 @@ public interface Executor {
     );
 
     /**
-     * This method will never be invoked unless the current operation is `Query.forEach`
+     * This method will never be invoked unless the current operation is cursor-style
+     * execution such as `Query.forEach` or selection streaming.
      *
-     * <p>For `Query.forEach`, SQL execution result log have to be printed after children fetching,
-     * this method can give SQL logger a chance to print SQL before children fetching</p>
+     * <p>For cursor-style execution, this method gives SQL loggers a chance to print SQL
+     * before row consumption or children fetching.</p>
      */
     default void openCursor(
             long cursorId,
@@ -58,6 +59,9 @@ public interface Executor {
             @Nullable ExecutorContext ctx,
             JSqlClientImplementor sqlClient
     ) {
+    }
+
+    default void closeCursor(long cursorId) {
     }
 
     static Executor log() {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ExecutorForLog.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/ExecutorForLog.java
@@ -83,6 +83,7 @@ public class ExecutorForLog extends AbstractExecutorProxy {
             @Nullable ExecutorContext ctx,
             JSqlClientImplementor sqlClient
     ) {
+        super.openCursor(cursorId, sql, variables, variablePositions, purpose, ctx, sqlClient);
         if (!logger.isEnabledForLevel(level)) {
             return;
         }
@@ -98,6 +99,15 @@ public class ExecutorForLog extends AbstractExecutorProxy {
                 sqlClient
         );
         log(builder.toString());
+    }
+
+    @Override
+    public void closeCursor(long cursorId) {
+        super.closeCursor(cursorId);
+        if (!logger.isEnabledForLevel(level)) {
+            return;
+        }
+        log(RESPONSE + "Close cursor(" + cursorId + ")");
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JSqlClientImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JSqlClientImplementor.java
@@ -65,6 +65,12 @@ public interface JSqlClientImplementor extends JSqlClient, SqlContext {
 
     int getDefaultListBatchSize();
 
+    @Nullable
+    Integer getDefaultJdbcFetchSize();
+
+    @Nullable
+    Integer getDefaultJdbcQueryTimeout();
+
     boolean isInListPaddingEnabled();
 
     boolean isExpandedInListPaddingEnabled();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JdbcOptions.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/JdbcOptions.java
@@ -1,0 +1,64 @@
+package org.babyfish.jimmer.sql.runtime;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public final class JdbcOptions {
+
+    public static final JdbcOptions EMPTY = new JdbcOptions(null, null);
+
+    @Nullable
+    private final Integer fetchSize;
+
+    @Nullable
+    private final Integer queryTimeout;
+
+    private JdbcOptions(@Nullable Integer fetchSize, @Nullable Integer queryTimeout) {
+        this.fetchSize = fetchSize;
+        this.queryTimeout = queryTimeout;
+    }
+
+    public static JdbcOptions of(@Nullable Integer fetchSize, @Nullable Integer queryTimeout) {
+        if (fetchSize == null && queryTimeout == null) {
+            return EMPTY;
+        }
+        return new JdbcOptions(fetchSize, queryTimeout);
+    }
+
+    @Nullable
+    public Integer getFetchSize() {
+        return fetchSize;
+    }
+
+    @Nullable
+    public Integer getQueryTimeout() {
+        return queryTimeout;
+    }
+
+    public JdbcOptions fetchSize(@Nullable Integer fetchSize) {
+        return of(fetchSize, queryTimeout);
+    }
+
+    public JdbcOptions queryTimeout(@Nullable Integer queryTimeout) {
+        return of(fetchSize, queryTimeout);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof JdbcOptions)) {
+            return false;
+        }
+        JdbcOptions that = (JdbcOptions) o;
+        return Objects.equals(fetchSize, that.fetchSize) &&
+                Objects.equals(queryTimeout, that.queryTimeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fetchSize, queryTimeout);
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Selectors.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/Selectors.java
@@ -1,16 +1,20 @@
 package org.babyfish.jimmer.sql.runtime;
 
+import org.babyfish.jimmer.runtime.DraftContext;
 import org.babyfish.jimmer.runtime.Internal;
 import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherUtil;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.List;
+import java.sql.SQLException;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class Selectors {
 
@@ -19,7 +23,6 @@ public class Selectors {
     private Selectors() {
     }
 
-    @SuppressWarnings("unchecked")
     public static <R> List<R> select(
             JSqlClientImplementor sqlClient,
             Connection con,
@@ -30,6 +33,31 @@ public class Selectors {
             TupleCreator<?> tupleCreator,
             ExecutionPurpose purpose
     ) {
+        return select(
+                sqlClient,
+                con,
+                sql,
+                variables,
+                variablePositions,
+                selections,
+                tupleCreator,
+                purpose,
+                JdbcOptions.EMPTY
+        );
+    }
+
+    public static <R> List<R> select(
+            JSqlClientImplementor sqlClient,
+            Connection con,
+            String sql,
+            List<Object> variables,
+            @Nullable List<Integer> variablePositions,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            ExecutionPurpose purpose,
+            JdbcOptions jdbcOptions
+    ) {
+        JdbcOptions effectiveJdbcOptions = effectiveJdbcOptions(sqlClient, jdbcOptions);
         List<R> rows = sqlClient.getExecutor().execute(
                 new Executor.Args<>(
                         sqlClient,
@@ -41,23 +69,134 @@ public class Selectors {
                         null,
                         null,
                         (stmt, args) -> {
+                            applyJdbcOptions(stmt, effectiveJdbcOptions);
                             Reader<?> reader = Readers.createReader(sqlClient, selections, tupleCreator);
                             return Internal.usingSqlDraftContext(draftCtx -> {
                                 Reader.Context ctx = new Reader.Context(draftCtx, sqlClient);
-                                List<R> results = new ArrayList<>();
                                 try (ResultSet resultSet = stmt.executeQuery()) {
-                                    while (resultSet.next()) {
-                                        results.add((R) reader.read(resultSet, ctx));
-                                        ctx.resetCol();
-                                    }
+                                    return readAll(resultSet, reader, ctx);
                                 }
-                                return results;
                             });
                         }
                 )
         );
         FetcherUtil.fetch(sqlClient, con, selections, tupleCreator, rows);
         return rows;
+    }
+
+    public static <R> Stream<R> stream(
+            JSqlClientImplementor sqlClient,
+            Connection con,
+            String sql,
+            List<Object> variables,
+            @Nullable List<Integer> variablePositions,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            ExecutionPurpose purpose,
+            JdbcOptions jdbcOptions,
+            boolean forUpdate
+    ) {
+        validateStreamSelections(sqlClient, selections);
+        ConnectionManager connectionManager = sqlClient.getSlaveConnectionManager(forUpdate);
+        return stream(
+                sqlClient,
+                connectionManager,
+                con,
+                sql,
+                variables,
+                variablePositions,
+                selections,
+                tupleCreator,
+                purpose,
+                jdbcOptions,
+                null,
+                null
+        );
+    }
+
+    public static <R> Stream<R> stream(
+            JSqlClientImplementor sqlClient,
+            ConnectionManager connectionManager,
+            Connection con,
+            String sql,
+            List<Object> variables,
+            @Nullable List<Integer> variablePositions,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            ExecutionPurpose purpose,
+            JdbcOptions jdbcOptions,
+            @Nullable Runnable beforeClose,
+            @Nullable Consumer<Connection> connectionValidator
+    ) {
+        validateStreamSelections(sqlClient, selections);
+        JdbcOptions effectiveJdbcOptions = effectiveJdbcOptions(sqlClient, jdbcOptions);
+        Executor.Args<Void> args = new Executor.Args<>(
+                sqlClient,
+                null,
+                sql,
+                variables,
+                variablePositions,
+                purpose,
+                null,
+                null,
+                (stmt, it) -> null
+        );
+        ConnectionManager.ConnectionScope scope = null;
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        long cursorId = CURSOR_ID_SEQUENCE.incrementAndGet();
+        try {
+            scope = connectionManager.open(con);
+            if (connectionValidator != null) {
+                connectionValidator.accept(scope.connection());
+            }
+            args = new Executor.Args<>(
+                    sqlClient,
+                    scope.connection(),
+                    sql,
+                    variables,
+                    variablePositions,
+                    purpose,
+                    null,
+                    null,
+                    (statement, it) -> null
+            );
+            stmt = scope.connection().prepareStatement(sql);
+            DefaultExecutor.setParameters(stmt, variables, sqlClient);
+            applyJdbcOptions(stmt, effectiveJdbcOptions);
+            sqlClient.getExecutor().openCursor(
+                    cursorId,
+                    sql,
+                    variables,
+                    variablePositions,
+                    purpose,
+                    args.ctx,
+                    sqlClient
+            );
+            rs = stmt.executeQuery();
+            Reader<?> reader = Readers.createReader(sqlClient, selections, tupleCreator);
+            DraftContext draftContext = new DraftContext(null);
+            Reader.Context readerContext = new Reader.Context(draftContext, sqlClient);
+            return createStream(
+                    sqlClient,
+                    args,
+                    cursorId,
+                    rs,
+                    stmt,
+                    scope,
+                    reader,
+                    readerContext,
+                    draftContext,
+                    selections,
+                    tupleCreator,
+                    beforeClose
+            );
+        } catch (Exception ex) {
+            closeQuietly(rs);
+            closeQuietly(stmt);
+            closeQuietly(scope);
+            throw DefaultExecutor.translate(args, ex);
+        }
     }
 
     public static <R> List<R> select(
@@ -70,8 +209,33 @@ public class Selectors {
             TupleCreator<?> tupleCreator,
             ExecutionPurpose purpose,
             boolean forUpdate) {
+        return select(
+                sqlClient,
+                con,
+                sql,
+                variables,
+                variablePositions,
+                selections,
+                tupleCreator,
+                purpose,
+                JdbcOptions.EMPTY,
+                forUpdate
+        );
+    }
+
+    public static <R> List<R> select(
+            JSqlClientImplementor sqlClient,
+            Connection con,
+            String sql,
+            List<Object> variables,
+            @Nullable List<Integer> variablePositions,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            ExecutionPurpose purpose,
+            JdbcOptions jdbcOptions,
+            boolean forUpdate) {
         return sqlClient.getSlaveConnectionManager(forUpdate).execute(con, conn ->
-                select(sqlClient, conn, sql, variables, variablePositions, selections, tupleCreator, purpose)
+                select(sqlClient, conn, sql, variables, variablePositions, selections, tupleCreator, purpose, jdbcOptions)
         );
     }
 
@@ -131,6 +295,227 @@ public class Selectors {
             executor.execute(args);
         } finally {
             Cursors.setCurrentCursorId(oldCursorId);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <R> List<R> readAll(ResultSet resultSet, Reader<?> reader, Reader.Context ctx) throws SQLException {
+        List<R> results = new ArrayList<>();
+        while (resultSet.next()) {
+            results.add((R) reader.read(resultSet, ctx));
+            ctx.resetCol();
+        }
+        return results;
+    }
+
+    private static void validateStreamSelections(
+            JSqlClientImplementor sqlClient,
+            List<Selection<?>> selections
+    ) {
+        if (FetcherUtil.hasPostFetchColumns(sqlClient, selections)) {
+            throw new UnsupportedOperationException(
+                    "Streaming does not support fetcher selections that require post-fetch; " +
+                            "use selections that can be read from the root JDBC result set"
+            );
+        }
+    }
+
+    private static JdbcOptions effectiveJdbcOptions(
+            JSqlClientImplementor sqlClient,
+            JdbcOptions jdbcOptions
+    ) {
+        Integer fetchSize = jdbcOptions.getFetchSize() != null ?
+                jdbcOptions.getFetchSize() :
+                sqlClient.getDefaultJdbcFetchSize();
+        Integer queryTimeout = jdbcOptions.getQueryTimeout() != null ?
+                jdbcOptions.getQueryTimeout() :
+                sqlClient.getDefaultJdbcQueryTimeout();
+        return JdbcOptions.of(fetchSize, queryTimeout);
+    }
+
+    private static void applyJdbcOptions(PreparedStatement stmt, JdbcOptions jdbcOptions) throws SQLException {
+        if (jdbcOptions.getFetchSize() != null) {
+            stmt.setFetchSize(jdbcOptions.getFetchSize());
+        }
+        if (jdbcOptions.getQueryTimeout() != null) {
+            stmt.setQueryTimeout(jdbcOptions.getQueryTimeout());
+        }
+    }
+
+    private static <R> Stream<R> createStream(
+            JSqlClientImplementor sqlClient,
+            Executor.Args<?> args,
+            long cursorId,
+            ResultSet resultSet,
+            PreparedStatement stmt,
+            ConnectionManager.ConnectionScope scope,
+            Reader<?> reader,
+            Reader.Context readerContext,
+            DraftContext draftContext,
+            List<Selection<?>> selections,
+            TupleCreator<?> tupleCreator,
+            @Nullable Runnable beforeClose
+    ) {
+        JdbcResourceCloser closer = new JdbcResourceCloser(
+                sqlClient,
+                cursorId,
+                resultSet,
+                stmt,
+                scope,
+                draftContext,
+                beforeClose
+        );
+        Iterator<R> iterator = new Iterator<R>() {
+
+            private boolean loaded;
+
+            private boolean hasNext;
+
+            @Override
+            public boolean hasNext() {
+                if (!loaded) {
+                    try {
+                        hasNext = resultSet.next();
+                        loaded = true;
+                        if (!hasNext) {
+                            closer.close();
+                        }
+                    } catch (SQLException ex) {
+                        closer.closeSilently(false);
+                        throw DefaultExecutor.translate(args, ex);
+                    }
+                }
+                return hasNext;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public R next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                loaded = false;
+                try {
+                    Object row = reader.read(resultSet, readerContext);
+                    readerContext.resetCol();
+                    return (R) FetcherUtil.convert(selections, tupleCreator, row);
+                } catch (SQLException ex) {
+                    closer.closeSilently(false);
+                    throw DefaultExecutor.translate(args, ex);
+                } catch (RuntimeException ex) {
+                    closer.closeSilently(false);
+                    throw ex;
+                }
+            }
+        };
+        Spliterator<R> spliterator = Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED);
+        return StreamSupport.stream(spliterator, false).onClose(closer::close);
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static class JdbcResourceCloser {
+
+        private final JSqlClientImplementor sqlClient;
+
+        private final long cursorId;
+
+        private final ResultSet resultSet;
+
+        private final PreparedStatement stmt;
+
+        private final ConnectionManager.ConnectionScope scope;
+
+        private final DraftContext draftContext;
+
+        @Nullable
+        private final Runnable beforeClose;
+
+        private boolean closed;
+
+        private JdbcResourceCloser(
+                JSqlClientImplementor sqlClient,
+                long cursorId,
+                ResultSet resultSet,
+                PreparedStatement stmt,
+                ConnectionManager.ConnectionScope scope,
+                DraftContext draftContext,
+                @Nullable Runnable beforeClose
+        ) {
+            this.sqlClient = sqlClient;
+            this.cursorId = cursorId;
+            this.resultSet = resultSet;
+            this.stmt = stmt;
+            this.scope = scope;
+            this.draftContext = draftContext;
+            this.beforeClose = beforeClose;
+        }
+
+        void close() {
+            close(true);
+        }
+
+        void close(boolean runBeforeClose) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            RuntimeException runtimeException = null;
+            try {
+                resultSet.close();
+            } catch (SQLException ex) {
+                runtimeException = new RuntimeException(ex);
+            }
+            try {
+                stmt.close();
+            } catch (SQLException ex) {
+                if (runtimeException == null) {
+                    runtimeException = new RuntimeException(ex);
+                } else {
+                    runtimeException.addSuppressed(ex);
+                }
+            }
+            if (runBeforeClose && beforeClose != null) {
+                try {
+                    beforeClose.run();
+                } catch (RuntimeException ex) {
+                    if (runtimeException == null) {
+                        runtimeException = ex;
+                    } else {
+                        runtimeException.addSuppressed(ex);
+                    }
+                }
+            }
+            try {
+                scope.close();
+            } catch (RuntimeException ex) {
+                if (runtimeException == null) {
+                    runtimeException = ex;
+                } else {
+                    runtimeException.addSuppressed(ex);
+                }
+            } finally {
+                draftContext.dispose();
+                sqlClient.getExecutor().closeCursor(cursorId);
+            }
+            if (runtimeException != null) {
+                throw runtimeException;
+            }
+        }
+
+        void closeSilently(boolean runBeforeClose) {
+            try {
+                close(runBeforeClose);
+            } catch (RuntimeException ignored) {
+            }
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/transaction/AbstractTxConnectionManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/transaction/AbstractTxConnectionManager.java
@@ -33,6 +33,48 @@ public abstract class AbstractTxConnectionManager implements TxConnectionManager
     }
 
     @Override
+    public final ConnectionScope open(@Nullable Connection con) {
+        if (con != null) {
+            return ConnectionScope.userConnection(con);
+        }
+        try {
+            Scope parent = scopeLocal.get();
+            Scope scope = createScope(parent, Propagation.SUPPORTS);
+            scopeLocal.set(scope);
+            return new ConnectionScope() {
+
+                private boolean closed;
+
+                @Override
+                public Connection connection() {
+                    return scope.con;
+                }
+
+                @Override
+                public void close() {
+                    if (closed) {
+                        return;
+                    }
+                    closed = true;
+                    try {
+                        scope.terminate(false);
+                    } catch (SQLException ex) {
+                        throw new ExecutionException("JDBC error raised: " + ex.getMessage(), ex);
+                    } finally {
+                        if (parent != null) {
+                            scopeLocal.set(parent);
+                        } else {
+                            scopeLocal.remove();
+                        }
+                    }
+                }
+            };
+        } catch (SQLException ex) {
+            throw new ExecutionException("JDBC error raised: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
     public final <R> R executeTransaction(Function<Connection, R> block) {
         return executeTransaction(Propagation.REQUIRED, block);
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -9,10 +9,13 @@ import org.babyfish.jimmer.sql.model.*;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2Fetcher;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 
 import static org.babyfish.jimmer.sql.common.Constants.*;
@@ -228,18 +231,10 @@ public class ObjectCacheTest extends AbstractQueryTest {
                     );
                 }
         );
-        jdbc(con -> {
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "update tree_node set name = ? where node_id = ?"
-            )) {
-                stmt.setString(1, "clothing");
-                stmt.setLong(2, 9L);
-                stmt.executeUpdate();
-            }
-        });
-        sqlClient.getCaches().getObjectCache(TreeNode2.class).delete(9L);
         connectAndExpect(
                 con -> {
+                    updateTreeNodeName(con, "clothing");
+                    sqlClient.getCaches().getObjectCache(TreeNode2.class).delete(9L);
                     return sqlClient
                             .getEntities()
                             .forConnection(con)
@@ -269,5 +264,17 @@ public class ObjectCacheTest extends AbstractQueryTest {
                     );
                 }
         );
+    }
+
+    private static void updateTreeNodeName(Connection con, String name) {
+        try (PreparedStatement stmt = con.prepareStatement(
+                "update tree_node set name = ? where node_id = ?"
+        )) {
+            stmt.setString(1, name);
+            stmt.setLong(2, 9L);
+            stmt.executeUpdate();
+        } catch (SQLException ex) {
+            Assertions.fail("SQL error", ex);
+        }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractMutationTest.java
@@ -491,5 +491,9 @@ public abstract class AbstractMutationTest extends AbstractTest {
                     "modifiedEntities[" + index + "]"
             );
         }
+
+        public void modified(Consumer<Object> block) {
+            block.accept(item.getModifiedEntity());
+        }
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/AbstractTest.java
@@ -45,7 +45,8 @@ public class AbstractTest extends Tests {
 
     protected static final ZoneOffset ZONE_ID = ZoneOffset.ofHours(8);
 
-    protected static final String JDBC_URL = "jdbc:h2:./build/h2/jimmer_test_db;database_to_upper=true;time zone=GMT+8";
+    protected static final String JDBC_URL =
+            "jdbc:h2:mem:jimmer_test_db;database_to_upper=true;time zone=GMT+8;DB_CLOSE_DELAY=-1";
 
     protected static final Object UNKNOWN_VARIABLE = new Object() {
         @Override
@@ -58,7 +59,7 @@ public class AbstractTest extends Tests {
 
     @BeforeAll
     public static void beforeAll() {
-        jdbc(AbstractTest::initDatabase);
+        initializeDatabaseIfNecessary();
     }
 
     @BeforeEach
@@ -204,13 +205,14 @@ public class AbstractTest extends Tests {
     }
 
     public static void jdbc(SqlConsumer<Connection> block) {
-        jdbc(null, false, block);
+        jdbc(null, true, block);
     }
 
     public static void jdbc(DataSource dataSource, boolean rollback, SqlConsumer<Connection> block) {
-        try (Connection con = dataSource != null ?
-                dataSource.getConnection() :
-                new Driver().connect(JDBC_URL, null)) {
+        if (dataSource == null) {
+            initializeDatabaseIfNecessary();
+        }
+        try (Connection con = dataSource != null ? dataSource.getConnection() : h2Connection()) {
             if (rollback) {
                 con.setAutoCommit(false);
                 try {
@@ -224,6 +226,28 @@ public class AbstractTest extends Tests {
         } catch (SQLException ex) {
             Assertions.fail("SQL error", ex);
         }
+    }
+
+    private static void initializeDatabaseIfNecessary() {
+        DatabaseInitializer.initialize();
+    }
+
+    private static class DatabaseInitializer {
+
+        static {
+            try (Connection con = h2Connection()) {
+                initDatabase(con);
+            } catch (SQLException ex) {
+                Assertions.fail("SQL error", ex);
+            }
+        }
+
+        static void initialize() {
+        }
+    }
+
+    private static Connection h2Connection() throws SQLException {
+        return new Driver().connect(JDBC_URL, null);
     }
 
     public interface SqlConsumer<T> {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/ProxyRecorder.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/common/ProxyRecorder.java
@@ -1,0 +1,122 @@
+package org.babyfish.jimmer.sql.common;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+public final class ProxyRecorder<T> implements InvocationHandler {
+
+    private final Class<T> type;
+
+    private final Map<String, Object> returns = new HashMap<>();
+
+    private final Map<String, List<Object[]>> calls = new HashMap<>();
+
+    private T proxy;
+
+    private ProxyRecorder(Class<T> type) {
+        this.type = type;
+    }
+
+    public static <T> ProxyRecorder<T> of(Class<T> type) {
+        return new ProxyRecorder<>(type);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T proxy() {
+        if (proxy == null) {
+            proxy = (T) Proxy.newProxyInstance(
+                    type.getClassLoader(),
+                    new Class<?>[] {type},
+                    this
+            );
+        }
+        return proxy;
+    }
+
+    public ProxyRecorder<T> returns(String methodName, Object value) {
+        returns.put(methodName, value);
+        return this;
+    }
+
+    public void assertCalledOnce(String methodName) {
+        Assertions.assertEquals(
+                1,
+                calls.getOrDefault(methodName, Collections.emptyList()).size(),
+                "Expected method \"" + methodName + "\" to be called once"
+        );
+    }
+
+    public void assertCalledOnceWith(String methodName, Object... args) {
+        assertCalledOnce(methodName);
+        Assertions.assertArrayEquals(args, calls.get(methodName).get(0));
+    }
+
+    public void assertNeverCalled(String methodName) {
+        Assertions.assertEquals(
+                0,
+                calls.getOrDefault(methodName, Collections.emptyList()).size(),
+                "Expected method \"" + methodName + "\" not to be called"
+        );
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+        String methodName = method.getName();
+        if (method.getDeclaringClass() == Object.class) {
+            switch (methodName) {
+                case "toString":
+                    return "ProxyRecorder(" + type.getName() + ")";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return args != null && args.length == 1 && proxy == args[0];
+                default:
+                    throw new AssertionError("Unexpected Object method: " + methodName);
+            }
+        }
+        calls.computeIfAbsent(methodName, it -> new ArrayList<>()).add(copy(args));
+        if (returns.containsKey(methodName)) {
+            return returns.get(methodName);
+        }
+        return defaultValue(method.getReturnType());
+    }
+
+    private static Object[] copy(Object[] args) {
+        return args != null ? Arrays.copyOf(args, args.length) : new Object[0];
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        return null;
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/SaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/embedded/SaveTest.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.embedded.Machine;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SaveTest extends AbstractMutationTest {
@@ -88,15 +89,15 @@ public class SaveTest extends AbstractMutationTest {
                                         "\"diskSize\":512" +
                                         "}"
                         );
-                        it.modified(
-                                "{" +
-                                        "\"id\":100," +
-                                        "\"location\":{\"host\":\"server\",\"port\":80}," +
-                                        "\"cpuFrequency\":3," +
-                                        "\"memorySize\":16," +
-                                        "\"diskSize\":512" +
-                                        "}"
-                        );
+                        it.modified(entity -> {
+                            Machine modified = (Machine) entity;
+                            Assertions.assertTrue(modified.id() > 0L);
+                            Assertions.assertEquals("server", modified.location().host());
+                            Assertions.assertEquals(80, modified.location().port());
+                            Assertions.assertEquals(3, modified.cpuFrequency());
+                            Assertions.assertEquals(16, modified.memorySize());
+                            Assertions.assertEquals(512, modified.diskSize());
+                        });
                     });
                     ctx.rowCount(AffectedTable.of(Machine.class), 1);
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
@@ -21,6 +21,7 @@ import org.babyfish.jimmer.sql.model.inheritance.*;
 import org.babyfish.jimmer.sql.model.wild.*;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -1556,27 +1557,23 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         it.batchVariables(4, "Task-5", 2L);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "--->\"id\":1," +
-                                "--->\"tasks\":[" +
-                                "--->--->{\"id\":100,\"taskName\":\"Task-1\",\"owner\":{\"id\":1}}," +
-                                "--->--->{\"id\":101,\"taskName\":\"Task-2\",\"owner\":{\"id\":1}}," +
-                                "--->--->{\"id\":102,\"taskName\":\"Task-3\",\"owner\":{\"id\":1}}" +
-                                "--->]" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Worker worker = (Worker) entity;
+                            Assertions.assertEquals(1L, worker.id());
+                            Assertions.assertEquals(3, worker.tasks().size());
+                            assertTask(worker.tasks().get(0), "Task-1", 1L);
+                            assertTask(worker.tasks().get(1), "Task-2", 1L);
+                            assertTask(worker.tasks().get(2), "Task-3", 1L);
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "--->\"id\":2," +
-                                "--->\"tasks\":[" +
-                                "--->--->{\"id\":103,\"taskName\":\"Task-4\",\"owner\":{\"id\":2}}," +
-                                "--->--->{\"id\":104,\"taskName\":\"Task-5\",\"owner\":{\"id\":2}}" +
-                                "--->]" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Worker worker = (Worker) entity;
+                            Assertions.assertEquals(2L, worker.id());
+                            Assertions.assertEquals(2, worker.tasks().size());
+                            assertTask(worker.tasks().get(0), "Task-4", 2L);
+                            assertTask(worker.tasks().get(1), "Task-5", 2L);
+                        });
                     });
                 }
         );
@@ -1668,7 +1665,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                                 UNKNOWN_VARIABLE,
                                 "daisy@gmail.com",
                                 "https://www.facebook.com/17346127y497123",
-                                100L,
+                                UNKNOWN_VARIABLE,
                                 false
                         );
                     });
@@ -1785,18 +1782,27 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TASK(NAME, OWNER_ID) values(?, ?)");
-                        it.variables("Install K8S", 100L);
+                        it.variables("Install K8S", UNKNOWN_VARIABLE);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                "\"id\":108,\"taskName\":\"Install K8S\"," +
-                                "\"owner\":{\"id\":100,\"name\":\"Tim\"}" +
-                                "}"
-                        );
+                        it.modified(entity -> {
+                            Task modified = (Task) entity;
+                            Assertions.assertTrue(modified.id() > 0L);
+                            Assertions.assertEquals("Install K8S", modified.taskName());
+                            Assertions.assertNotNull(modified.owner());
+                            Assertions.assertTrue(modified.owner().id() > 0L);
+                            Assertions.assertEquals("Tim", modified.owner().name());
+                        });
                     });
                 }
         );
+    }
+
+    private static void assertTask(Task task, String name, long ownerId) {
+        Assertions.assertTrue(task.id() > 0L);
+        Assertions.assertEquals(name, task.taskName());
+        Assertions.assertNotNull(task.owner());
+        Assertions.assertEquals(ownerId, task.owner().id());
     }
 
     @Test

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdInsertTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdInsertTest.java
@@ -10,6 +10,7 @@ import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.TreeNode;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabaseAutoIdInsertTest extends AbstractMutationTest {
@@ -31,10 +32,15 @@ public class DatabaseAutoIdInsertTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TREE_NODE(NODE_ID, NAME, PARENT_ID) values(?, ?, ?)");
-                        it.variables(100L, "Computer", new DbLiteral.DbNull(long.class));
+                        it.variables(UNKNOWN_VARIABLE, "Computer", new DbLiteral.DbNull(long.class));
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"name\":\"Computer\",\"parent\":null}");
+                        it.modified(entity -> {
+                            TreeNode node = (TreeNode) entity;
+                            Assertions.assertTrue(node.id() > 0L);
+                            Assertions.assertEquals("Computer", node.name());
+                            Assertions.assertNull(node.parent());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdUpsertTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DatabaseAutoIdUpsertTest.java
@@ -10,6 +10,7 @@ import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.TreeNode;
 import org.babyfish.jimmer.sql.model.TreeNodeDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabaseAutoIdUpsertTest extends AbstractMutationTest {
@@ -40,10 +41,15 @@ public class DatabaseAutoIdUpsertTest extends AbstractMutationTest {
                     });
                     ctx.statement(it -> {
                         it.sql("insert into TREE_NODE(NODE_ID, NAME, PARENT_ID) values(?, ?, ?)");
-                        it.variables(100L, "Computer", new DbLiteral.DbNull(long.class));
+                        it.variables(UNKNOWN_VARIABLE, "Computer", new DbLiteral.DbNull(long.class));
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"name\":\"Computer\",\"parent\":null}");
+                        it.modified(entity -> {
+                            TreeNode node = (TreeNode) entity;
+                            Assertions.assertTrue(node.id() > 0L);
+                            Assertions.assertEquals("Computer", node.name());
+                            Assertions.assertNull(node.parent());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DuplicatedKeyTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/DuplicatedKeyTest.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.Immutables;
 import org.babyfish.jimmer.sql.model.hr.Department;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -17,6 +18,7 @@ public class DuplicatedKeyTest extends AbstractMutationTest {
                 Immutables.createDepartment(draft -> draft.setName("Develop")),
                 Immutables.createDepartment(draft -> draft.setName("Develop"))
         );
+        long[] idBox = new long[1];
         executeAndExpectResult(
                 getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE))
                         .saveEntitiesCommand(departments),
@@ -34,10 +36,19 @@ public class DuplicatedKeyTest extends AbstractMutationTest {
                         it.variables("Develop", 0L);
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":\"100\",\"name\":\"Develop\"}");
+                        it.modified(entity -> {
+                            Department department = (Department) entity;
+                            Assertions.assertTrue(department.id() > 0L);
+                            Assertions.assertEquals("Develop", department.name());
+                            idBox[0] = department.id();
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":\"100\",\"name\":\"Develop\"}");
+                        it.modified(entity -> {
+                            Department department = (Department) entity;
+                            Assertions.assertEquals(idBox[0], department.id());
+                            Assertions.assertEquals("Develop", department.name());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/FluentDMLTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/FluentDMLTest.java
@@ -3,22 +3,29 @@ package org.babyfish.jimmer.sql.mutation;
 import org.babyfish.jimmer.sql.JoinType;
 import org.babyfish.jimmer.sql.ast.Expression;
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode;
+import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.common.NativeDatabases;
 import org.babyfish.jimmer.sql.dialect.MySqlDialect;
 import org.babyfish.jimmer.sql.dialect.PostgresDialect;
-import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.exception.ExecutionException;
+import org.babyfish.jimmer.sql.model.AuthorTable;
+import org.babyfish.jimmer.sql.model.AuthorTableEx;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+import org.babyfish.jimmer.sql.model.BookTable;
 import org.babyfish.jimmer.sql.model.hr.EmployeeTable;
 import org.babyfish.jimmer.sql.model.inheritance.AdministratorTable;
-import org.babyfish.jimmer.sql.exception.ExecutionException;
+import org.babyfish.jimmer.sql.tuple.BookUpdateReturningTuple;
+import org.babyfish.jimmer.sql.tuple.BookUpdateReturningTupleMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 import static org.babyfish.jimmer.sql.common.Constants.*;
-import static org.babyfish.jimmer.sql.common.Constants.graphQLInActionId3;
 
 public class FluentDMLTest extends AbstractMutationTest {
 
@@ -71,6 +78,72 @@ public class FluentDMLTest extends AbstractMutationTest {
                         it.sql("update BOOK_STORE tb_1_ set WEBSITE = null");
                     });
                     ctx.rowCount(2);
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateReturning() {
+        BookTable book = BookTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpdate(book)
+                        .set(book.name(), "Learning GraphQL+")
+                        .where(book.id().eq(learningGraphQLId1))
+                        .returning(book.id(), book.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, NAME " +
+                                        "from final table (" +
+                                        "update BOOK tb_1_ " +
+                                        "set NAME = ? " +
+                                        "where tb_1_.ID = ?" +
+                                        ")"
+                        );
+                        it.variables("Learning GraphQL+", learningGraphQLId1);
+                    });
+                    ctx.value((List<Tuple2<UUID, String>> rows) -> {
+                        Assertions.assertEquals(1, rows.size());
+                        Assertions.assertEquals(learningGraphQLId1, rows.get(0).get_1());
+                        Assertions.assertEquals("Learning GraphQL+", rows.get(0).get_2());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateReturningTypedTuple() {
+        BookTable book = BookTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpdate(book)
+                        .set(book.name(), "Effective TypeScript+")
+                        .where(book.id().eq(effectiveTypeScriptId1))
+                        .returning(
+                                BookUpdateReturningTupleMapper
+                                        .id(book.id())
+                                        .name(book.name())
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, NAME " +
+                                        "from final table (" +
+                                        "update BOOK tb_1_ " +
+                                        "set NAME = ? " +
+                                        "where tb_1_.ID = ?" +
+                                        ")"
+                        );
+                        it.variables("Effective TypeScript+", effectiveTypeScriptId1);
+                    });
+                    ctx.value((List<BookUpdateReturningTuple> rows) -> {
+                        Assertions.assertEquals(1, rows.size());
+                        Assertions.assertEquals(effectiveTypeScriptId1, rows.get(0).getId());
+                        Assertions.assertEquals("Effective TypeScript+", rows.get(0).getName());
+                    });
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/FluentDMLTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/FluentDMLTest.java
@@ -24,6 +24,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.babyfish.jimmer.sql.common.Constants.*;
 
@@ -104,6 +106,31 @@ public class FluentDMLTest extends AbstractMutationTest {
                         );
                         it.variables("Learning GraphQL+", learningGraphQLId1);
                     });
+                    ctx.value((List<Tuple2<UUID, String>> rows) -> {
+                        Assertions.assertEquals(1, rows.size());
+                        Assertions.assertEquals(learningGraphQLId1, rows.get(0).get_1());
+                        Assertions.assertEquals("Learning GraphQL+", rows.get(0).get_2());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateReturningStream() {
+        BookTable book = BookTable.$;
+        connectAndExpect(
+                con -> {
+                    try (Stream<Tuple2<UUID, String>> stream = getSqlClient()
+                            .createUpdate(book)
+                            .set(book.name(), "Learning GraphQL+")
+                            .where(book.id().eq(learningGraphQLId1))
+                            .returning(book.id(), book.name())
+                            .stream(con)
+                    ) {
+                        return stream.collect(Collectors.toList());
+                    }
+                },
+                ctx -> {
                     ctx.value((List<Tuple2<UUID, String>> rows) -> {
                         Assertions.assertEquals(1, rows.size());
                         Assertions.assertEquals(learningGraphQLId1, rows.get(0).get_1());

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/IdentityTest.java
@@ -21,6 +21,7 @@ import org.babyfish.jimmer.sql.model.inheritance.Administrator;
 import org.babyfish.jimmer.sql.model.inheritance.AdministratorDraft;
 import org.babyfish.jimmer.sql.runtime.DbLiteral;
 import org.babyfish.jimmer.sql.runtime.ScalarProvider;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
@@ -1114,14 +1115,13 @@ public class IdentityTest extends AbstractMutationTest {
                         it.variables("a_5", Timestamp.valueOf(time), Timestamp.valueOf(time), false);
                     });
                     ctx.entity(it -> {
-                        it.modified(
-                                "{" +
-                                        "--->\"name\":\"a_5\"," +
-                                        "--->\"createdTime\":\"2024-06-06 22:13:00\"," +
-                                        "--->\"modifiedTime\":\"2024-06-06 22:13:00\"," +
-                                        "--->\"id\":100" +
-                                        "}"
-                        );
+                        it.modified(entity -> {
+                            Administrator modified = (Administrator) entity;
+                            Assertions.assertTrue(modified.getId() > 0L);
+                            Assertions.assertEquals("a_5", modified.getName());
+                            Assertions.assertEquals(time, modified.getCreatedTime());
+                            Assertions.assertEquals(time, modified.getModifiedTime());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveTest.java
@@ -1402,10 +1402,20 @@ public class SaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {});
                     ctx.entity(it -> {});
                     ctx.entity(it -> {
-                        it.modified("{\"id\":100,\"taskName\":\"Setup kafka\",\"owner\":{\"id\":1}}");
+                        it.modified(entity -> {
+                            Task task = (Task) entity;
+                            Assertions.assertTrue(task.id() > 0L);
+                            Assertions.assertEquals("Setup kafka", task.taskName());
+                            Assertions.assertEquals(1L, task.owner().id());
+                        });
                     });
                     ctx.entity(it -> {
-                        it.modified("{\"id\":101,\"taskName\":\"Setup K8S\",\"owner\":{\"id\":1}}");
+                        it.modified(entity -> {
+                            Task task = (Task) entity;
+                            Assertions.assertTrue(task.id() > 0L);
+                            Assertions.assertEquals("Setup K8S", task.taskName());
+                            Assertions.assertEquals(1L, task.owner().id());
+                        });
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceDMLTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceDMLTest.java
@@ -47,13 +47,36 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
     }
 
     @Test
+    public void testUpdateReturningCannotReturnPropFromDifferentPhysicalTable() {
+        OrganizationTable organization = OrganizationTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpdate(organization)
+                        .set(organization.taxCode(), "GLOBEX-002")
+                        .where(organization.id().eq(200L))
+                        .returning(organization.name())
+                        .execute(con),
+                ctx -> ctx.throwable(it -> {
+                    it.type(IllegalArgumentException.class);
+                    it.message(
+                            "The update-returning property \"" +
+                                    "org.babyfish.jimmer.sql.model.inheritance.joinedtable.Client.name\" " +
+                                    "must belong to the same physical table as the update target. " +
+                                    "The property belongs to table \"JOINED_CLIENT\" " +
+                                    "but the update target table is \"JOINED_ORGANIZATION\""
+                    );
+                })
+        );
+    }
+
+    @Test
     public void testUpdateDerivedTypeCanSetRootProp() {
         executeAndExpectRowCount(
                 sqlOnlyUpdateJoinClient(1)
                         .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.name(), "Globex+");
-                    u.where(organization.taxCode().eq("GLOBEX-001"));
-                }),
+                            u.set(organization.name(), "Globex+");
+                            u.where(organization.taxCode().eq("GLOBEX-001"));
+                        }),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(
@@ -163,10 +186,10 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
         executeAndExpectRowCount(
                 mysqlStyleUpdateJoinClient(1)
                         .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.name(), "Globex+");
-                    u.set(organization.taxCode(), "GLOBEX-002");
-                    u.where(organization.taxCode().eq("GLOBEX-001"));
-                }),
+                            u.set(organization.name(), "Globex+");
+                            u.set(organization.taxCode(), "GLOBEX-002");
+                            u.where(organization.taxCode().eq("GLOBEX-001"));
+                        }),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(
@@ -290,12 +313,12 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
         executeAndExpectRowCount(
                 sqlOnlyUpdateJoinClient(1)
                         .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.taxCode(), "GLOBEX-002");
-                    u.where(
-                            organization.name().eq("Globex"),
-                            organization.taxCode().eq("GLOBEX-001")
-                    );
-                }),
+                            u.set(organization.taxCode(), "GLOBEX-002");
+                            u.where(
+                                    organization.name().eq("Globex"),
+                                    organization.taxCode().eq("GLOBEX-001")
+                            );
+                        }),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(
@@ -318,9 +341,9 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
         executeAndExpectRowCount(
                 sqlOnlyUpdateJoinClient(1)
                         .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.taxCode(), "GLOBEX-002");
-                    u.where(organization.name().isNotNull());
-                }),
+                            u.set(organization.taxCode(), "GLOBEX-002");
+                            u.where(organization.name().isNotNull());
+                        }),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(
@@ -363,9 +386,9 @@ public class JoinedInheritanceDMLTest extends AbstractMutationTest {
         executeAndExpectRowCount(
                 sqlOnlyUpdateJoinClient(2)
                         .createUpdate(OrganizationTable.class, (u, organization) -> {
-                    u.set(organization.taxCode(), "ORG-UPDATED");
-                    u.where(organization.type().eq("ORG"));
-                }),
+                            u.set(organization.taxCode(), "ORG-UPDATED");
+                            u.where(organization.type().eq("ORG"));
+                        }),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/FluentJoinTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/FluentJoinTest.java
@@ -4,12 +4,15 @@ import org.babyfish.jimmer.sql.JoinType;
 import org.babyfish.jimmer.sql.ast.Expression;
 import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.table.WeakJoin;
+import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.babyfish.jimmer.sql.common.Constants.*;
 
@@ -29,6 +32,33 @@ public class FluentJoinTest extends AbstractQueryTest {
                             "select " +
                                     "tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID " +
                                     "from BOOK tb_1_"
+                    );
+                }
+        );
+    }
+
+    @Test
+    public void testStream() {
+        BookTable book = BookTable.$;
+        connectAndExpect(
+                con -> {
+                    try (Stream<Tuple2<Integer, String>> stream = getSqlClient()
+                            .createQuery(book)
+                            .where(book.name().eq("Learning GraphQL"))
+                            .orderBy(book.edition())
+                            .select(book.edition(), book.name())
+                            .stream(con)
+                    ) {
+                        return stream.collect(Collectors.toList());
+                    }
+                },
+                ctx -> {
+                    ctx.rows(
+                            "[" +
+                                    "{\"_1\":1,\"_2\":\"Learning GraphQL\"}," +
+                                    "{\"_1\":2,\"_2\":\"Learning GraphQL\"}," +
+                                    "{\"_1\":3,\"_2\":\"Learning GraphQL\"}" +
+                                    "]"
                     );
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
@@ -1,6 +1,6 @@
 package org.babyfish.jimmer.sql.runtime;
 
-import org.babyfish.jimmer.sql.common.ProxyRecorder;
+import org.babyfish.jimmer.support.ProxyRecorder;
 import org.babyfish.jimmer.sql.dialect.PostgresDialect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SavepointManagerTest.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.runtime;
 
+import org.babyfish.jimmer.sql.common.ProxyRecorder;
 import org.babyfish.jimmer.sql.dialect.PostgresDialect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,24 +10,17 @@ import java.sql.PreparedStatement;
 import java.sql.Savepoint;
 import java.util.Collections;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 public class SavepointManagerTest {
 
     @Test
-    public void testBatchWithoutSavepoint() throws Exception {
-        Connection con = mock(Connection.class);
-        PreparedStatement stmt = mock(PreparedStatement.class);
-        when(con.prepareStatement(anyString())).thenReturn(stmt);
-        when(stmt.executeBatch()).thenReturn(new int[] {1});
+    public void testBatchWithoutSavepoint() {
+        ProxyRecorder<Connection> con = ProxyRecorder.of(Connection.class);
+        ProxyRecorder<PreparedStatement> stmt = ProxyRecorder.of(PreparedStatement.class);
+        con.returns("prepareStatement", stmt.proxy());
+        stmt.returns("executeBatch", new int[] {1});
 
         try (Executor.BatchContext ctx = DefaultExecutor.INSTANCE.executeBatch(
-                con,
+                con.proxy(),
                 "insert into test_table(id) values(?)",
                 null,
                 ExecutionPurpose.MUTATE,
@@ -36,28 +30,28 @@ public class SavepointManagerTest {
             ctx.add(Collections.emptyList());
             Assertions.assertArrayEquals(new int[] {1}, ctx.execute(null));
         }
-        verify(con).prepareStatement(anyString());
-        verify(con, never()).getAutoCommit();
-        verify(con, never()).setSavepoint();
-        verify(con, never()).releaseSavepoint(any(Savepoint.class));
-        verify(stmt).addBatch();
-        verify(stmt).executeBatch();
-        verify(stmt).close();
+        con.assertCalledOnce("prepareStatement");
+        con.assertNeverCalled("getAutoCommit");
+        con.assertNeverCalled("setSavepoint");
+        con.assertNeverCalled("releaseSavepoint");
+        stmt.assertCalledOnce("addBatch");
+        stmt.assertCalledOnce("executeBatch");
+        stmt.assertCalledOnce("close");
     }
 
     @Test
-    public void testBatchWithSavepoint() throws Exception {
-        Connection con = mock(Connection.class);
-        PreparedStatement stmt = mock(PreparedStatement.class);
-        Savepoint savepoint = mock(Savepoint.class);
-        when(con.getAutoCommit()).thenReturn(false);
-        when(con.setSavepoint()).thenReturn(savepoint);
-        when(con.prepareStatement(anyString())).thenReturn(stmt);
-        when(stmt.getConnection()).thenReturn(con);
-        when(stmt.executeBatch()).thenReturn(new int[] {1});
+    public void testBatchWithSavepoint() {
+        ProxyRecorder<Connection> con = ProxyRecorder.of(Connection.class);
+        ProxyRecorder<PreparedStatement> stmt = ProxyRecorder.of(PreparedStatement.class);
+        Savepoint savepoint = ProxyRecorder.of(Savepoint.class).proxy();
+        con.returns("getAutoCommit", false);
+        con.returns("setSavepoint", savepoint);
+        con.returns("prepareStatement", stmt.proxy());
+        stmt.returns("getConnection", con.proxy());
+        stmt.returns("executeBatch", new int[] {1});
 
         try (Executor.BatchContext ctx = DefaultExecutor.INSTANCE.executeBatch(
-                con,
+                con.proxy(),
                 "insert into test_table(id) values(?)",
                 null,
                 ExecutionPurpose.MUTATE,
@@ -67,19 +61,18 @@ public class SavepointManagerTest {
             ctx.add(Collections.emptyList());
             Assertions.assertArrayEquals(new int[] {1}, ctx.execute(null));
         }
-        verify(con).getAutoCommit();
-        verify(con).setSavepoint();
-        verify(con).releaseSavepoint(savepoint);
-        verify(stmt).addBatch();
-        verify(stmt).executeBatch();
-        verify(stmt).close();
+        con.assertCalledOnce("getAutoCommit");
+        con.assertCalledOnce("setSavepoint");
+        con.assertCalledOnceWith("releaseSavepoint", savepoint);
+        stmt.assertCalledOnce("addBatch");
+        stmt.assertCalledOnce("executeBatch");
+        stmt.assertCalledOnce("close");
     }
 
     private static JSqlClientImplementor sqlClient() {
-        JSqlClientImplementor sqlClient = mock(JSqlClientImplementor.class);
-        when(sqlClient.getDialect()).thenReturn(new PostgresDialect());
-        when(sqlClient.getExecutorContextPrefixes()).thenReturn(null);
-        when(sqlClient.isConstraintViolationTranslatable()).thenReturn(true);
-        return sqlClient;
+        ProxyRecorder<JSqlClientImplementor> sqlClient = ProxyRecorder.of(JSqlClientImplementor.class);
+        sqlClient.returns("getDialect", new PostgresDialect());
+        sqlClient.returns("isConstraintViolationTranslatable", true);
+        return sqlClient.proxy();
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SelectionExecutableTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/runtime/SelectionExecutableTest.java
@@ -1,0 +1,245 @@
+package org.babyfish.jimmer.sql.runtime;
+
+import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.fetcher.ReferenceFetchType;
+import org.babyfish.jimmer.sql.model.Book;
+import org.babyfish.jimmer.sql.model.BookFetcher;
+import org.babyfish.jimmer.sql.model.BookStoreFetcher;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.model.embedded.*;
+import org.babyfish.jimmer.support.JdbcRecorder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.babyfish.jimmer.sql.common.Constants.learningGraphQLId1;
+
+public class SelectionExecutableTest extends AbstractQueryTest {
+
+    @Test
+    public void testQueryExecuteUsesLocalJdbcOptions() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            JdbcRecorder recorder = new JdbcRecorder(con);
+            getSqlClient()
+                    .createQuery(book)
+                    .jdbcFetchSize(128)
+                    .jdbcQueryTimeout(16)
+                    .where(book.id().eq(learningGraphQLId1))
+                    .select(book.id(), book.name())
+                    .execute(recorder.connection());
+            Assertions.assertEquals("[128]", recorder.fetchSizes().toString());
+            Assertions.assertEquals("[16]", recorder.queryTimeouts().toString());
+        });
+    }
+
+    @Test
+    public void testQueryStreamUsesLocalJdbcOptionsAndClosesResources() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            JdbcRecorder recorder = new JdbcRecorder(con);
+            try (Stream<Tuple2<UUID, String>> ignored = getSqlClient()
+                    .createQuery(book)
+                    .jdbcFetchSize(128)
+                    .jdbcQueryTimeout(16)
+                    .where(book.id().eq(learningGraphQLId1))
+                    .select(book.id(), book.name())
+                    .stream(recorder.connection())
+            ) {
+                // Closing the stream must close the JDBC cursor resources even if rows are not consumed.
+            }
+            Assertions.assertEquals("[128]", recorder.fetchSizes().toString());
+            Assertions.assertEquals("[16]", recorder.queryTimeouts().toString());
+            Assertions.assertEquals(1, recorder.resultSetCloseCount());
+            Assertions.assertEquals(1, recorder.statementCloseCount());
+        });
+    }
+
+    @Test
+    public void testStreamFetcherWithJoinFetchedAssociation() {
+        BookTable book = BookTable.$;
+        connectAndExpect(
+                con -> {
+                    try (Stream<Book> stream = getSqlClient()
+                            .createQuery(book)
+                            .where(book.name().eq("GraphQL in Action"))
+                            .orderBy(book.edition())
+                            .select(
+                                    book.fetch(
+                                            BookFetcher.$
+                                                    .name()
+                                                    .store(
+                                                            ReferenceFetchType.JOIN_ALWAYS,
+                                                            BookStoreFetcher.$.name()
+                                                    )
+                                    )
+                            )
+                            .stream(con)
+                    ) {
+                        return stream.collect(Collectors.toList());
+                    }
+                },
+                ctx -> {
+                    ctx.rows(
+                            "[" +
+                                    "--->{\"id\":\"a62f7aa3-9490-4612-98b5-98aae0e77120\",\"name\":\"GraphQL in Action\",\"store\":{\"id\":\"2fa3955e-3e83-49b9-902e-0465c109c779\",\"name\":\"MANNING\"}}," +
+                                    "--->{\"id\":\"e37a8344-73bb-4b23-ba76-82eac11f03e6\",\"name\":\"GraphQL in Action\",\"store\":{\"id\":\"2fa3955e-3e83-49b9-902e-0465c109c779\",\"name\":\"MANNING\"}}," +
+                                    "--->{\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\",\"name\":\"GraphQL in Action\",\"store\":{\"id\":\"2fa3955e-3e83-49b9-902e-0465c109c779\",\"name\":\"MANNING\"}}" +
+                                    "]"
+                    );
+                }
+        );
+    }
+
+    @Test
+    public void testStreamFetcherRejectsSelectFetchedAssociation() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            UnsupportedOperationException ex = Assertions.assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> {
+                        try (Stream<Book> ignored = getSqlClient()
+                                .createQuery(book)
+                                .select(
+                                        book.fetch(
+                                                BookFetcher.$
+                                                        .name()
+                                                        .store(
+                                                                ReferenceFetchType.SELECT,
+                                                                BookStoreFetcher.$.name()
+                                                        )
+                                        )
+                                )
+                                .stream(con)
+                        ) {
+                            // The stream must not be created because this fetcher requires post-fetch.
+                        }
+                    }
+            );
+            Assertions.assertTrue(ex.getMessage().contains("post-fetch"));
+        });
+    }
+
+    @Test
+    public void testStreamTupleWithEntityAndEmbeddable() {
+        MachineTable machine = MachineTable.$;
+        connectAndExpect(
+                con -> {
+                    try (Stream<Tuple2<Machine, Location>> stream = getSqlClient()
+                            .createQuery(machine)
+                            .select(
+                                    machine.fetch(MachineFetcher.$.cpuFrequency()),
+                                    machine.location().fetch(LocationFetcher.$.host().port())
+                            )
+                            .stream(con)
+                    ) {
+                        return stream.collect(Collectors.toList());
+                    }
+                },
+                ctx -> {
+                    ctx.rows(rows -> {
+                        Assertions.assertEquals(1, rows.size());
+                        assertContentEquals(
+                                "Tuple2(_1={\"id\":1,\"cpuFrequency\":2}, _2={\"host\":\"localhost\",\"port\":8080})",
+                                rows.get(0)
+                        );
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testDefaultJdbcOptions() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            JdbcRecorder recorder = new JdbcRecorder(con);
+            getSqlClient(it -> {
+                it.setDefaultJdbcFetchSize(256);
+                it.setDefaultJdbcQueryTimeout(32);
+            })
+                    .createQuery(book)
+                    .where(book.id().eq(learningGraphQLId1))
+                    .select(book.id(), book.name())
+                    .execute(recorder.connection());
+            Assertions.assertEquals("[256]", recorder.fetchSizes().toString());
+            Assertions.assertEquals("[32]", recorder.queryTimeouts().toString());
+        });
+    }
+
+    @Test
+    public void testLocalJdbcOptionZeroOverridesDefault() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            JdbcRecorder recorder = new JdbcRecorder(con);
+            getSqlClient(it -> {
+                it.setDefaultJdbcFetchSize(256);
+                it.setDefaultJdbcQueryTimeout(32);
+            })
+                    .createQuery(book)
+                    .jdbcFetchSize(0)
+                    .jdbcQueryTimeout(0)
+                    .where(book.id().eq(learningGraphQLId1))
+                    .select(book.id(), book.name())
+                    .execute(recorder.connection());
+            Assertions.assertEquals("[0]", recorder.fetchSizes().toString());
+            Assertions.assertEquals("[0]", recorder.queryTimeouts().toString());
+        });
+    }
+
+    @Test
+    public void testUpdateReturningUsesLocalJdbcOptions() {
+        BookTable book = BookTable.$;
+        jdbc(con -> {
+            JdbcRecorder recorder = new JdbcRecorder(con);
+            getSqlClient()
+                    .createUpdate(book)
+                    .jdbcFetchSize(128)
+                    .jdbcQueryTimeout(16)
+                    .set(book.name(), "Learning GraphQL+")
+                    .where(book.id().eq(learningGraphQLId1))
+                    .returning(book.id(), book.name())
+                    .execute(recorder.connection());
+            Assertions.assertEquals("[128]", recorder.fetchSizes().toString());
+            Assertions.assertEquals("[16]", recorder.queryTimeouts().toString());
+        });
+    }
+
+    @Test
+    public void testJdbcOptionValidation() {
+        BookTable book = BookTable.$;
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient()
+                        .createQuery(book)
+                        .jdbcFetchSize(-1)
+                        .select(book.id())
+        );
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient()
+                        .createUpdate(book)
+                        .jdbcQueryTimeout(-1)
+        );
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient(it -> it.setDefaultJdbcFetchSize(0))
+        );
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient(it -> it.setDefaultJdbcFetchSize(-1))
+        );
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient(it -> it.setDefaultJdbcQueryTimeout(0))
+        );
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient(it -> it.setDefaultJdbcQueryTimeout(-1))
+        );
+    }
+
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/tuple/BookUpdateReturningTuple.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/tuple/BookUpdateReturningTuple.java
@@ -1,0 +1,15 @@
+package org.babyfish.jimmer.sql.tuple;
+
+import lombok.Data;
+import org.babyfish.jimmer.sql.TypedTuple;
+
+import java.util.UUID;
+
+@TypedTuple
+@Data
+public class BookUpdateReturningTuple {
+
+    private final UUID id;
+
+    private final String name;
+}

--- a/project/jimmer-sql/src/testFixtures/java/org/babyfish/jimmer/support/JdbcRecorder.java
+++ b/project/jimmer-sql/src/testFixtures/java/org/babyfish/jimmer/support/JdbcRecorder.java
@@ -1,0 +1,89 @@
+package org.babyfish.jimmer.support;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class JdbcRecorder {
+
+    private final Connection rawConnection;
+
+    private final List<ProxyRecorder<PreparedStatement>> statements = new ArrayList<>();
+
+    private final List<ProxyRecorder<ResultSet>> resultSets = new ArrayList<>();
+
+    public JdbcRecorder(Connection rawConnection) {
+        this.rawConnection = rawConnection;
+    }
+
+    public Connection connection() {
+        return ProxyRecorder
+                .of(Connection.class)
+                .delegatesTo(rawConnection)
+                .handles("prepareStatement", (method, args) ->
+                        statement((PreparedStatement) ProxyRecorder.invokeTarget(rawConnection, method, args))
+                )
+                .proxy();
+    }
+
+    public List<Object[]> statementCalls(String methodName) {
+        List<Object[]> calls = new ArrayList<>();
+        for (ProxyRecorder<PreparedStatement> statement : statements) {
+            calls.addAll(statement.calls(methodName));
+        }
+        return calls;
+    }
+
+    public List<Object[]> resultSetCalls(String methodName) {
+        List<Object[]> calls = new ArrayList<>();
+        for (ProxyRecorder<ResultSet> resultSet : resultSets) {
+            calls.addAll(resultSet.calls(methodName));
+        }
+        return calls;
+    }
+
+    public List<Integer> fetchSizes() {
+        List<Integer> fetchSizes = new ArrayList<>();
+        for (Object[] args : statementCalls("setFetchSize")) {
+            fetchSizes.add((Integer) args[0]);
+        }
+        return fetchSizes;
+    }
+
+    public List<Integer> queryTimeouts() {
+        List<Integer> queryTimeouts = new ArrayList<>();
+        for (Object[] args : statementCalls("setQueryTimeout")) {
+            queryTimeouts.add((Integer) args[0]);
+        }
+        return queryTimeouts;
+    }
+
+    public int statementCloseCount() {
+        return statementCalls("close").size();
+    }
+
+    public int resultSetCloseCount() {
+        return resultSetCalls("close").size();
+    }
+
+    private PreparedStatement statement(PreparedStatement rawStatement) {
+        ProxyRecorder<PreparedStatement> recorder = ProxyRecorder
+                .of(PreparedStatement.class)
+                .delegatesTo(rawStatement)
+                .handles("executeQuery", (method, args) ->
+                        resultSet((ResultSet) ProxyRecorder.invokeTarget(rawStatement, method, args))
+                );
+        statements.add(recorder);
+        return recorder.proxy();
+    }
+
+    private ResultSet resultSet(ResultSet rawResultSet) {
+        ProxyRecorder<ResultSet> recorder = ProxyRecorder
+                .of(ResultSet.class)
+                .delegatesTo(rawResultSet);
+        resultSets.add(recorder);
+        return recorder.proxy();
+    }
+}

--- a/project/jimmer-sql/src/testFixtures/java/org/babyfish/jimmer/support/ProxyRecorder.java
+++ b/project/jimmer-sql/src/testFixtures/java/org/babyfish/jimmer/support/ProxyRecorder.java
@@ -1,8 +1,7 @@
-package org.babyfish.jimmer.sql.common;
-
-import org.junit.jupiter.api.Assertions;
+package org.babyfish.jimmer.support;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
@@ -11,7 +10,11 @@ public final class ProxyRecorder<T> implements InvocationHandler {
 
     private final Class<T> type;
 
+    private Object target;
+
     private final Map<String, Object> returns = new HashMap<>();
+
+    private final Map<String, MethodHandler> handlers = new HashMap<>();
 
     private final Map<String, List<Object[]>> calls = new HashMap<>();
 
@@ -42,29 +45,52 @@ public final class ProxyRecorder<T> implements InvocationHandler {
         return this;
     }
 
+    public ProxyRecorder<T> delegatesTo(Object target) {
+        this.target = target;
+        return this;
+    }
+
+    public ProxyRecorder<T> handles(String methodName, MethodHandler handler) {
+        handlers.put(methodName, handler);
+        return this;
+    }
+
+    public List<Object[]> calls(String methodName) {
+        return calls.getOrDefault(methodName, Collections.emptyList());
+    }
+
     public void assertCalledOnce(String methodName) {
-        Assertions.assertEquals(
-                1,
-                calls.getOrDefault(methodName, Collections.emptyList()).size(),
-                "Expected method \"" + methodName + "\" to be called once"
-        );
+        int size = calls.getOrDefault(methodName, Collections.emptyList()).size();
+        if (size != 1) {
+            throw new AssertionError(
+                    "Expected method \"" + methodName + "\" to be called once, but it was called " + size + " time(s)"
+            );
+        }
     }
 
     public void assertCalledOnceWith(String methodName, Object... args) {
         assertCalledOnce(methodName);
-        Assertions.assertArrayEquals(args, calls.get(methodName).get(0));
+        if (!Arrays.equals(args, calls.get(methodName).get(0))) {
+            throw new AssertionError(
+                    "Expected method \"" + methodName + "\" to be called with " +
+                            Arrays.toString(args) +
+                            ", but got " +
+                            Arrays.toString(calls.get(methodName).get(0))
+            );
+        }
     }
 
     public void assertNeverCalled(String methodName) {
-        Assertions.assertEquals(
-                0,
-                calls.getOrDefault(methodName, Collections.emptyList()).size(),
-                "Expected method \"" + methodName + "\" not to be called"
-        );
+        int size = calls.getOrDefault(methodName, Collections.emptyList()).size();
+        if (size != 0) {
+            throw new AssertionError(
+                    "Expected method \"" + methodName + "\" not to be called, but it was called " + size + " time(s)"
+            );
+        }
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) {
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         String methodName = method.getName();
         if (method.getDeclaringClass() == Object.class) {
             switch (methodName) {
@@ -82,7 +108,29 @@ public final class ProxyRecorder<T> implements InvocationHandler {
         if (returns.containsKey(methodName)) {
             return returns.get(methodName);
         }
+        MethodHandler handler = handlers.get(methodName);
+        if (handler != null) {
+            return handler.invoke(method, args);
+        }
+        if (target != null) {
+            return invokeTarget(target, method, args);
+        }
         return defaultValue(method.getReturnType());
+    }
+
+    public static Object invokeTarget(Object target, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException ex) {
+            throw ex.getTargetException();
+        } catch (IllegalAccessException ex) {
+            throw new AssertionError("Cannot invoke delegated method: " + method, ex);
+        }
+    }
+
+    public interface MethodHandler {
+
+        Object invoke(Method method, Object[] args) throws Throwable;
     }
 
     private static Object[] copy(Object[] args) {


### PR DESCRIPTION
This PR adds two low-level row-result features:

- `createUpdate(...).returning(...)` for update statements that should return
  selected columns;
- streaming execution for query selections and update-returning selections.

## Update Returning

Java:

```java
List<Tuple2<Long, String>> rows = sql
        .createUpdate(BookTable.$)
        .set(BookTable.$.name(), "GraphQL+")
        .where(BookTable.$.name().eq("GraphQL"))
        .returning(BookTable.$.id(), BookTable.$.name())
        .execute();
```

Kotlin:

```kotlin
val rows = sql.executeUpdateReturning(Book::class) {
    set(table.name, "GraphQL+")
    where(table.name eq "GraphQL")
    returning(table.id, table.name)
}
```

The returning API is statement-oriented. It does not emulate returning with an
extra select: dialects without update-returning support fail with a clear error.

For joined inheritance, returned columns must belong to the physical table being
updated, matching the existing physical-table rule for update assignments.

## Streamable Results

Query selections and update-returning selections now expose row-result execution
as both list and stream:

```java
try (Stream<Tuple2<Long, String>> rows = sql
        .createQuery(BookTable.$)
        .where(BookTable.$.name().like("GraphQL%"))
        .select(BookTable.$.id(), BookTable.$.name())
        .stream()) {
    // consume rows lazily
}
```

```java
try (Stream<Tuple2<Long, String>> rows = sql
        .createUpdate(BookTable.$)
        .set(BookTable.$.name(), "GraphQL+")
        .where(BookTable.$.name().like("GraphQL%"))
        .returning(BookTable.$.id(), BookTable.$.name())
        .stream()) {
    // consume rows lazily
}
```

Kotlin exposes the same behavior through `stream(...)` on selection executables.

Streaming is supported only for selections that can be materialized from the
single JDBC result set. Fetcher fields that require post-fetch are rejected.
Simple scalar fields, embeddables, entities, and join-fetched associations are
allowed when they do not require post-fetch.

The returned `Stream` owns its JDBC `ResultSet` and `Statement`; closing the
stream releases them. User-supplied connections are not closed by Jimmer.

## JDBC Row Options

Row-result executions can configure JDBC read hints:

- Java builders: `jdbcFetchSize(...)`, `jdbcQueryTimeout(...)`;
- Kotlin DSL: `jdbc { fetchSize = ...; queryTimeout = ... }`;
- global SQL client defaults:
  - `setDefaultJdbcFetchSize(Integer?)`;
  - `setDefaultJdbcQueryTimeout(Integer?)`;
- Spring Boot properties:
  - `jimmer.jdbc.default-fetch-size`;
  - `jimmer.jdbc.default-query-timeout`.

These options apply to row-result execution, including ordinary list execution
and streaming execution. `null` means no local override, `0` means JDBC driver
default, and negative values are invalid.
