### PR TITLE
fix(ksp): DTO 规范 null/notNull 操作符跳过 converter 生成，避免类型不匹配

### DIFF
--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -2050,6 +2050,8 @@ class DtoGenerator private constructor(
                 }
             }
 
+            "null", "notNull" -> BOOLEAN
+
             "valueIn", "valueNotIn" ->
                 LIST.parameterizedBy(baseProp.typeName())
 
@@ -2343,13 +2345,16 @@ class DtoGenerator private constructor(
 
     private val DtoProp<ImmutableType, ImmutableProp>.dtoConverterMetadata: ConverterMetadata?
         get() {
+            val funcName = getFuncName()
+            if ("null" == funcName || "notNull" == funcName) {
+                return null
+            }
             val baseProp = toTailProp().getBaseProp()
             val resolver = baseProp.ctx.resolver
             val metadata = baseProp.converterMetadata
             if (metadata != null) {
                 return metadata
             }
-            val funcName = getFuncName()
             if ("id" == funcName) {
                 val metadata = baseProp.targetType!!.idProp!!.converterMetadata
                 if (metadata != null && baseProp.isList && !dtoType.modifiers.contains(DtoModifier.SPECIFICATION)) {


### PR DESCRIPTION
为 KSP 的 dtoConverterMetadata 和 addSpecificationConverter 补充对 null/notNull 操作符的处理，与 Java APT 版本对齐。

当 DTO 规范使用 null(folderId) 或 notNull(folderId) 时，其 DTO 属性类型为 Boolean（表示是否过滤 null 值），而对应实体属性可能带有类型转换器。由于
PredicateApplier.isNull/isNotNull 的第二个参数是 boolean 而非实体属性值， 无需经过 converter 转换，否则生成的 _convert 函数会将 Boolean 转换为实体 属性类型（如 Long），导致编译期类型不匹配。

具体改动：
- dtoConverterMetadata: 对 null/notNull 操作符提前返回 null，跳过 converter 生成
- addSpecificationConverter: 对 null/notNull 操作符设定 baseTypeName = BOOLEAN

See also: Java APT 中对应的修复 (commit 3ca6ba8fa9, #735)