### PR TITLE
fix: only call asMemberOf when declaring type is generic

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableProp.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/immutable/meta/ImmutableProp.java
@@ -145,10 +145,15 @@ public class ImmutableProp implements BaseProp {
         this.declaringType = declaringType;
         this.executableElement = executableElement;
         getterName = executableElement.getSimpleName().toString();
-        returnType = ((ExecutableType) context.getTypes().asMemberOf(
-                (DeclaredType) declaringType.getTypeElement().asType(),
-                executableElement
-        )).getReturnType();
+        TypeElement enclosingTypeElement = (TypeElement) executableElement.getEnclosingElement();
+        if (enclosingTypeElement.getTypeParameters().isEmpty()) {
+            returnType = executableElement.getReturnType();
+        } else {
+            returnType = ((ExecutableType) context.getTypes().asMemberOf(
+                    (DeclaredType) declaringType.getTypeElement().asType(),
+                    executableElement
+            )).getReturnType();
+        }
         if (returnType.getKind() == TypeKind.VOID) {
             throw new MetaException(executableElement, "it cannot return void");
         }

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/meta/ImmutableProp.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/immutable/meta/ImmutableProp.kt
@@ -36,8 +36,11 @@ class ImmutableProp(
     private val inherited: Boolean = false
 ): BaseProp {
 
+    private val isDeclaringTypeGeneric: Boolean =
+        (propDeclaration.parentDeclaration as? KSClassDeclaration)?.typeParameters?.isNotEmpty() == true
+
     val resolvedType: KSType =
-        if (inherited) {
+        if (inherited && isDeclaringTypeGeneric) {
             propDeclaration.asMemberOf(declaringType.classDeclaration.asStarProjectedType())
         } else {
             propDeclaration.type.fastResolve()


### PR DESCRIPTION
## Summary

In `ImmutableProp`, `asMemberOf` was called unconditionally for inherited properties, but it's only needed when the property's original declaring type has generic type parameters. For non-generic types, use the return type directly.

## Changes

### KSP (`ImmutableProp.kt`)
- Added `isDeclaringTypeGeneric` check: inspects `propDeclaration.parentDeclaration` for type parameters
- Only calls `asMemberOf` when `inherited && isDeclaringTypeGeneric`

### APT (`ImmutableProp.java`)
- Added check on `executableElement.getEnclosingElement().getTypeParameters()`
- Non-generic: uses `executableElement.getReturnType()` directly
- Generic: calls `asMemberOf` to resolve type parameters in subclass context

## Verification
- KSP: `compileKotlin` passes
- APT: `ImmutableProp.java` compiles without errors