### PR TITLE
Add getProp() to TypedTransientResolver.Context

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/TypedTransientResolver.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/TypedTransientResolver.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql;
 
+import org.babyfish.jimmer.meta.ImmutableProp;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
@@ -59,5 +60,7 @@ public interface TypedTransientResolver<E, ID, V> extends TransientResolver<ID, 
     @ApiStatus.Experimental
     interface Context<E> {
         Collection<? extends E> getContent();
+
+        ImmutableProp getProp();
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/AbstractDataLoader.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/AbstractDataLoader.java
@@ -884,14 +884,21 @@ public abstract class AbstractDataLoader {
 
     private static final class TypedTransientResolverContextImpl<E> implements TypedTransientResolver.Context<E> {
         private final Collection<? extends E> content;
+        private final ImmutableProp prop;
 
-        public TypedTransientResolverContextImpl(Collection<? extends E> content) {
+        public TypedTransientResolverContextImpl(Collection<? extends E> content, ImmutableProp prop) {
             this.content = content;
+            this.prop = prop;
         }
 
         @Override
         public Collection<? extends E> getContent() {
             return content;
+        }
+
+        @Override
+        public ImmutableProp getProp() {
+            return prop;
         }
     }
 
@@ -909,7 +916,7 @@ public abstract class AbstractDataLoader {
         // not appended to the outer context that is still resolving this transient property.
         Map<Object, Object> valueMap = FetcherUtil.withoutFetcherContext(() -> {
             if (resolver instanceof TypedTransientResolver<?, ?, ?> && sources != null) {
-                TypedTransientResolver.Context<Object> context = new TypedTransientResolverContextImpl<>(sources);
+                TypedTransientResolver.Context<Object> context = new TypedTransientResolverContextImpl<>(sources, prop);
                 return ((TypedTransientResolver<Object, Object, Object>) resolver).resolve(ids, context);
             }
             return resolver.resolve(ids, ctx);


### PR DESCRIPTION
## Problem

`KTypedTransientResolver` requires three generic parameters `<E, ID, V>`, where `E` is the current entity type. In generic mapped-superclass scenarios, the concrete entity type is unknown at compile time, forcing users to erase or work around `E`.

Currently, `TypedTransientResolver.Context<E>` only exposes `getContent()` (the entity objects). If the resolver needs to know which concrete entity type/property is being resolved (e.g. for a shared breadcrumb resolver on `BaseTreeNode<T>`), it has no access to `ImmutableProp`.

## Change

Add `@Nullable ImmutableProp getProp()` to `TypedTransientResolver.Context<E>`, with a default implementation returning `null` for backward compatibility. The existing `TypedTransientResolverContextImpl` is updated to store and return the current prop.

## Usage

With this change, a generic resolver only needs to implement `KTypedTransientResolver`:

```kotlin
@OptIn(ExperimentalTypedTransientResolver::class)
@Component
class BaseTreeBreadcrumbResolver(
    sqlClient: KSqlClient,
) : KTypedTransientResolver<BaseTreeNode<*>, Long, String?> {

    override fun resolve(ids: Collection<Long>): Map<Long, String?> {
        error("needs context")
    }

    override fun resolve(
        ids: Collection<Long>,
        context: TypedTransientResolver.Context<BaseTreeNode<*>>,
    ): Map<Long, String?> {
        val declaringType = context.prop!!.declaringType  // the concrete entity type
        return breadcrumbSupport.resolveTexts(treeType = declaringType, leafIds = ids)
    }
}
```

No need to also implement `KTransientResolverContext` separately.
