### PR TITLE
Add Jimmer low query KSP processor

### DIFF
--- a/project/jimmer-bom/build.gradle.kts
+++ b/project/jimmer-bom/build.gradle.kts
@@ -17,5 +17,7 @@ dependencies {
         api(projects.jimmerSpringBootStarter)
         api(projects.jimmerSql)
         api(projects.jimmerSqlKotlin)
+        api(projects.jimmerLowQueryAnnotations)
+        api(projects.jimmerLowQueryProcessor)
     }
 }

--- a/project/jimmer-low-query-annotations/build.gradle.kts
+++ b/project/jimmer-low-query-annotations/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-convention`
+    `dokka-convention`
+}
+
+dependencies {
+    api(projects.jimmerSqlKotlin)
+}

--- a/project/jimmer-low-query-annotations/src/main/kotlin/org/babyfish/jimmer/lowquery/annotation/JimmerLowQuery.kt
+++ b/project/jimmer-low-query-annotations/src/main/kotlin/org/babyfish/jimmer/lowquery/annotation/JimmerLowQuery.kt
@@ -1,0 +1,437 @@
+package org.babyfish.jimmer.lowquery.annotation
+
+/**
+ * 配置一个 Jimmer 实体生成的低代码查询扩展函数。
+ *
+ * 实体字段上出现 @Eq、@Like、@In 等注解时也会自动参与生成；本注解负责覆盖函数名、可见性和 fetcher 策略。
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class JimmerLowQuery(
+    /**
+     * 生成的 KMutableRootQuery.ForEntity<E> 扩展函数名。
+     */
+    val functionName: String = "query",
+    /**
+     * 生成函数的可见性。
+     */
+    val visibility: JimmerLowQueryVisibility = JimmerLowQueryVisibility.PUBLIC,
+    /**
+     * select 阶段使用的 fetcher 策略。
+     */
+    val fetcher: JimmerLowQueryFetcher = JimmerLowQueryFetcher.ALL_SCALAR_FIELDS,
+    /**
+     * 生成的 KSqlClient 扩展函数名，用于通过实体对象创建查询。
+     */
+    val clientFunctionName: String = "createLowQuery",
+    /**
+     * 生成的 KSqlClient 入口函数可见性。
+     */
+    val clientVisibility: JimmerLowQueryVisibility = JimmerLowQueryVisibility.PUBLIC,
+)
+
+/**
+ * 标记实体字段需要参与低代码查询函数入参和 where 条件生成。
+ *
+ * 当标注在关联属性（@ManyToOne/@OneToMany）上时，通过 [targetField] 指定要穿透到目标实体的标量字段。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class JimmerLowQueryParam(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 当前参数对应的查询操作符。
+     */
+    val operator: JimmerLowQueryOperator = JimmerLowQueryOperator.EQ,
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     *
+     * 例如：`@JimmerLowQueryParam(targetField = "operatorId") val repairRecords: List<RepairTaskRecordDO>`
+     * 会生成 `repairRecordOperatorId: Long?` 参数，对应 `repairRecords { operatorId eq repairRecordOperatorId }`。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 标记实体字段参与 keyword 关键词检索。
+ *
+ * 同一个实体内所有标记字段会被低代码查询合并成 `keyword` 参数的 OR 模糊查询条件。
+ */
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Keyword
+
+/**
+ * 标记字段生成常用辅助查询方法。
+ *
+ * 标在字段上时按当前字段生成；标在实体类上时通过 [fields] 指定字段名，适合 `id` 这类继承字段。
+ */
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+@Repeatable
+annotation class JimmerFindBy(
+    /**
+     * 生成函数的参数名，留空时使用字段名。
+     */
+    val name: String = "",
+    /**
+     * 类级标注时要生成辅助查询的实体字段名。
+     */
+    val fields: Array<String> = [],
+    /**
+     * 类级标注多个字段时，是否生成组合条件辅助查询。
+     *
+     * false 表示每个字段分别生成一组 findBy 方法；true 表示生成一组 `field1 AND field2` 组合查询方法。
+     */
+    val composite: Boolean = false,
+    /**
+     * List 查询函数名，留空时生成 `find实体名By字段名`。
+     */
+    val listFunctionName: String = "",
+    /**
+     * 单条查询函数名，留空时生成 `findOneOrNull实体名By字段名`。
+     */
+    val oneFunctionName: String = "",
+    /**
+     * 生成函数的可见性。
+     */
+    val visibility: JimmerLowQueryVisibility = JimmerLowQueryVisibility.PUBLIC,
+    /**
+     * select 阶段使用的 fetcher 策略。
+     */
+    val fetcher: JimmerLowQueryFetcher = JimmerLowQueryFetcher.ALL_SCALAR_FIELDS,
+    /**
+     * 在 `allScalarFields()` 或 `allTableFields()` 之外额外显式加载的字段。
+     */
+    val extraFetchFields: Array<String> = [],
+)
+
+/**
+ * 字段等值查询，生成 `table.xxx eq param`。
+ *
+ * 当标注在关联属性（@ManyToOne/@OneToMany）上时，通过 [targetField] 指定要穿透到目标实体的标量字段。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Eq(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 常量表达式，保留给辅助查询生成器使用；不为空时，`@JimmerFindBy` 生成的辅助查询会改成固定条件。
+     */
+    val expression: String = "",
+    /**
+     * 常量表达式需要额外导入的类型全名。
+     */
+    val imports: Array<String> = [],
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段不等查询，生成 `table.xxx ne param`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Ne(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段模糊查询，默认生成 `table.xxx ilike(param, LikeMode.ANYWHERE)`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Like(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段前缀匹配查询，生成 `table.xxx like(param, LikeMode.START)`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class StartsWith(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段后缀匹配查询，生成 `table.xxx like(param, LikeMode.END)`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class EndsWith(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段大于查询，生成 `table.xxx gt param`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Gt(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段大于等于查询，生成 `table.xxx ge param`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Ge(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段小于查询，生成 `table.xxx lt param`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Lt(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段小于等于查询，生成 `table.xxx le param`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Le(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+    /**
+     * 默认生成可空参数，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段集合包含查询，生成 `table.xxx valueIn params`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class In(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名的简单复数形式。
+     */
+    val name: String = "",
+    /**
+     * 集合参数默认生成可空类型，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段集合排除查询，生成 `table.xxx valueNotIn params`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class NotIn(
+    /**
+     * 生成函数的参数名，留空时使用实体字段名的简单复数形式。
+     */
+    val name: String = "",
+    /**
+     * 集合参数默认生成可空类型，空值由动态谓词跳过；确需必填过滤时可显式设为 false。
+     */
+    val nullable: Boolean = true,
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段范围查询，生成 `table.xxx.between?(start, end)`。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class Between(
+    /**
+     * 起始边界参数名，留空时使用 `<字段名>Start`。
+     */
+    val startName: String = "",
+    /**
+     * 结束边界参数名，留空时使用 `<字段名>End`。
+     */
+    val endName: String = "",
+    /**
+     * 当标注在关联属性上时，指定要穿透到目标实体的标量字段名。
+     */
+    val targetField: String = "",
+)
+
+/**
+ * 字段时间范围查询，生成单个数组参数并按前两个元素做 `between?`。
+ */
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class TimeRange(
+    /**
+     * 范围参数名，留空时使用实体字段名。
+     */
+    val name: String = "",
+)
+
+/**
+ * 字段升序排序，priority 越小越靠前。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class OrderByAsc(
+    /**
+     * 排序优先级，数值越小越先排序。
+     */
+    val priority: Int = 0,
+)
+
+/**
+ * 字段降序排序，priority 越小越靠前。
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class OrderByDesc(
+    /**
+     * 排序优先级，数值越小越先排序。
+     */
+    val priority: Int = 0,
+)
+
+/**
+ * 低代码查询 where 操作符。
+ */
+enum class JimmerLowQueryOperator {
+    EQ,
+    NE,
+    LIKE,
+    STARTS_WITH,
+    ENDS_WITH,
+    GT,
+    GE,
+    LT,
+    LE,
+    IN,
+    NOT_IN,
+    BETWEEN,
+    TIME_RANGE,
+}
+
+/**
+ * 低代码查询 select 阶段 fetcher 策略。
+ */
+enum class JimmerLowQueryFetcher {
+    ALL_SCALAR_FIELDS,
+    ALL_TABLE_FIELDS,
+    TABLE,
+}
+
+/**
+ * 低代码查询生成函数可见性。
+ */
+enum class JimmerLowQueryVisibility {
+    PUBLIC,
+    INTERNAL,
+    PRIVATE,
+}

--- a/project/jimmer-low-query-annotations/src/main/kotlin/org/babyfish/jimmer/lowquery/runtime/JimmerLowQueryProvider.kt
+++ b/project/jimmer-low-query-annotations/src/main/kotlin/org/babyfish/jimmer/lowquery/runtime/JimmerLowQueryProvider.kt
@@ -1,0 +1,62 @@
+package org.babyfish.jimmer.lowquery.runtime
+
+import org.babyfish.jimmer.sql.kt.ast.query.KMutableRootQuery
+import kotlin.reflect.KClass
+
+/**
+ * Jimmer 低代码查询运行时提供者。
+ */
+interface JimmerLowQueryProvider<E : Any> {
+    /**
+     * 当前提供者关联的实体类型。
+     */
+    val entityType: KClass<E>
+
+    /**
+     * 实体字段到查询参数名的映射。
+     */
+    val parameterNames: Map<String, String>
+
+    /**
+     * 当前提供者是否会写入排序条件。
+     */
+    val hasOrderBy
+        get() = false
+
+    /**
+     * 将已加载实体字段转换为查询条件，并写入注解声明的排序。
+     */
+    fun apply(
+        query: KMutableRootQuery.ForEntity<E>,
+        entity: E,
+    )
+
+    /**
+     * 将无法塞进实体草稿的范围参数写入查询条件。
+     */
+    fun apply(
+        query: KMutableRootQuery.ForEntity<E>,
+        source: JimmerLowQueryParameterSource,
+    ) = Unit
+}
+
+/**
+ * 低代码查询请求参数读取源。
+ */
+interface JimmerLowQueryParameterSource {
+    /**
+     * 读取并转换单个查询参数。
+     */
+    fun <T : Any> value(
+        name: String,
+        type: KClass<T>,
+    ): T?
+
+    /**
+     * 读取并转换集合查询参数。
+     */
+    fun <T : Any> values(
+        name: String,
+        type: KClass<T>,
+    ): List<T>
+}

--- a/project/jimmer-low-query-processor/README.md
+++ b/project/jimmer-low-query-processor/README.md
@@ -1,0 +1,83 @@
+# Jimmer Low Query
+
+Jimmer Low Query is a KSP processor that generates typed Kotlin query helpers from Jimmer entity annotations.
+It is intended for admin/back-office filter pages where many endpoints share the same dynamic `where` and `orderBy` rules.
+
+## Modules
+
+- `jimmer-low-query-annotations`: query annotations and the optional runtime provider SPI.
+- `jimmer-low-query-processor`: KSP processor that reads Jimmer entities and writes generated Kotlin query extensions.
+
+## Gradle usage
+
+```kotlin
+dependencies {
+    implementation("org.babyfish.jimmer:jimmer-low-query-annotations:<jimmer-version>")
+    ksp("org.babyfish.jimmer:jimmer-low-query-processor:<jimmer-version>")
+}
+
+ksp {
+    // Optional. Defaults to <entity-package>.generated.lowquery
+    arg("jimmerLowQuery.generatedPackage", "com.example.generated.lowquery")
+}
+```
+
+## Entity annotations
+
+```kotlin
+import org.babyfish.jimmer.lowquery.annotation.Eq
+import org.babyfish.jimmer.lowquery.annotation.Keyword
+import org.babyfish.jimmer.lowquery.annotation.Like
+import org.babyfish.jimmer.lowquery.annotation.OrderByDesc
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+
+@Entity
+interface Book {
+    @Id
+    @OrderByDesc
+    val id: Long
+
+    @Like
+    @Keyword
+    val name: String
+
+    @Eq
+    val storeId: Long?
+}
+```
+
+The generated function is a `KMutableRootQuery.ForEntity<Book>` extension:
+
+```kotlin
+sqlClient.createQuery(Book::class) {
+    query(name = "GraphQL", storeId = 1L)
+}
+```
+
+It also generates a `KSqlClient.createLowQuery(entity)` overload. The entity overload uses `ImmutableObjects.isLoaded(entity, "property")`, so callers can pass a Jimmer draft containing only the properties that should participate in filtering.
+
+## Runtime provider
+
+When Spring `@Component` is visible on the compilation classpath, the processor also emits a `JimmerLowQueryProvider<E>` bean per entity. Generic controller code can use those providers without statically importing generated extension functions from downstream entity packages.
+
+## Supported annotations
+
+- `@Eq`, `@Ne`
+- `@Like`, `@StartsWith`, `@EndsWith`
+- `@Gt`, `@Ge`, `@Lt`, `@Le`
+- `@In`, `@NotIn`
+- `@Between`, `@TimeRange`
+- `@Keyword`
+- `@OrderByAsc`, `@OrderByDesc`
+- `@JimmerFindBy`
+
+If an entity has at least one low-query annotation, scalar business properties without explicit query annotations are generated as nullable equality parameters. Audit and infrastructure fields such as `id`, `createTime`, `updateTime`, `deleted`, and `tenantId` are excluded from implicit equality generation unless explicitly annotated.
+
+## Tests
+
+Run the focused test suite from the `project` directory:
+
+```bash
+./gradlew :jimmer-low-query-processor:test
+```

--- a/project/jimmer-low-query-processor/build.gradle.kts
+++ b/project/jimmer-low-query-processor/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-convention`
+    `dokka-convention`
+}
+
+dependencies {
+    implementation(projects.jimmerLowQueryAnnotations)
+    implementation(libs.ksp.symbolProcessing.api)
+
+    testImplementation(libs.kotlin.test)
+}
+
+tasks.test {
+    useJUnit()
+}

--- a/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryCollector.kt
+++ b/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryCollector.kt
@@ -1,0 +1,1077 @@
+package org.babyfish.jimmer.lowquery.processor
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.validate
+
+internal const val LOW_QUERY_ANNOTATION = "org.babyfish.jimmer.lowquery.annotation.JimmerLowQuery"
+internal const val LOW_QUERY_PARAM_ANNOTATION = "org.babyfish.jimmer.lowquery.annotation.JimmerLowQueryParam"
+private const val JIMMER_FIND_BY_ANNOTATION = "org.babyfish.jimmer.lowquery.annotation.JimmerFindBy"
+private const val JIMMER_ENTITY_ANNOTATION = "org.babyfish.jimmer.sql.Entity"
+private const val JIMMER_ID_ANNOTATION = "org.babyfish.jimmer.sql.Id"
+private const val JIMMER_ID_VIEW_ANNOTATION = "org.babyfish.jimmer.sql.IdView"
+private const val JIMMER_MAPPED_SUPERCLASS_ANNOTATION = "org.babyfish.jimmer.sql.MappedSuperclass"
+private const val JIMMER_TRANSIENT_ANNOTATION = "org.babyfish.jimmer.sql.Transient"
+private const val JIMMER_FORMULA_ANNOTATION = "org.babyfish.jimmer.Formula"
+private const val ANNOTATION_PACKAGE = "org.babyfish.jimmer.lowquery.annotation"
+private const val KEYWORD_ANNOTATION = "$ANNOTATION_PACKAGE.Keyword"
+private const val ORDER_BY_ASC_ANNOTATION = "$ANNOTATION_PACKAGE.OrderByAsc"
+private const val ORDER_BY_DESC_ANNOTATION = "$ANNOTATION_PACKAGE.OrderByDesc"
+private const val TIME_RANGE_ANNOTATION = "$ANNOTATION_PACKAGE.TimeRange"
+private const val CONSTANT_EQ_EXPRESSION_ANNOTATION = "expression"
+private const val CONSTANT_EQ_IMPORTS_ANNOTATION = "imports"
+private const val MAX_KEYWORD_ASSOCIATION_DEPTH = 2
+
+internal data class LowQueryCollectResult(
+    val entities: Set<LowQueryEntityMeta>,
+    val deferred: List<KSAnnotated>,
+    val hasErrors: Boolean,
+)
+
+internal class JimmerLowQueryCollector(
+    private val resolver: Resolver,
+    private val logger: KSPLogger,
+) {
+    private var hasErrors = false
+
+    fun collect(): LowQueryCollectResult {
+        val deferred = mutableListOf<KSAnnotated>()
+        val entitySymbols = linkedSetOf<KSClassDeclaration>()
+        resolver.getSymbolsWithAnnotation(LOW_QUERY_ANNOTATION)
+            .forEach { symbol ->
+                if (!symbol.validate()) {
+                    deferred += symbol
+                    return@forEach
+                }
+                val entity = symbol as? KSClassDeclaration
+                if (entity == null) {
+                    error("@JimmerLowQuery 只能标记 Jimmer 实体接口。", symbol)
+                    return@forEach
+                }
+                entitySymbols += entity
+            }
+        collectEntitiesFromPropertyAnnotations(LOW_QUERY_FIELD_ANNOTATIONS, deferred, entitySymbols)
+        collectEntitiesFromPropertyAnnotations(LOW_QUERY_ORDER_ANNOTATIONS, deferred, entitySymbols)
+        collectEntitiesFromPropertyAnnotations(setOf(KEYWORD_ANNOTATION), deferred, entitySymbols)
+        collectEntitiesFromPropertyAnnotations(setOf(JIMMER_FIND_BY_ANNOTATION), deferred, entitySymbols)
+        val entities = entitySymbols
+            .mapNotNull { entity -> collectEntity(entity) }
+            .toSet()
+        return LowQueryCollectResult(
+            entities = entities,
+            deferred = deferred,
+            hasErrors = hasErrors,
+        )
+    }
+
+    private fun collectEntitiesFromPropertyAnnotations(
+        annotationNames: Set<String>,
+        deferred: MutableList<KSAnnotated>,
+        entitySymbols: MutableSet<KSClassDeclaration>,
+    ) {
+        annotationNames.forEach { annotationName ->
+            resolver.getSymbolsWithAnnotation(annotationName)
+                .forEach { symbol ->
+                    if (!symbol.validate()) {
+                        deferred += symbol
+                        return@forEach
+                    }
+                    val classDeclaration = symbol as? KSClassDeclaration
+                    if (classDeclaration != null) {
+                        if (classDeclaration.isGeneratedSource()) {
+                            return@forEach
+                        }
+                        val classAnnotationAllowed = annotationName == TIME_RANGE_ANNOTATION ||
+                            annotationName == JIMMER_FIND_BY_ANNOTATION
+                        if (!classAnnotationAllowed || !classDeclaration.hasAnnotation(JIMMER_ENTITY_ANNOTATION)) {
+                            error("类级低代码查询注解只能标记 Jimmer 实体。", symbol)
+                            return@forEach
+                        }
+                        entitySymbols += classDeclaration
+                        return@forEach
+                    }
+                    val property = symbol as? KSPropertyDeclaration
+                    if (property == null) {
+                        error("低代码查询注解只能标记实体字段。", symbol)
+                        return@forEach
+                    }
+                    val entity = property.parentDeclaration as? KSClassDeclaration
+                    if (entity == null) {
+                        error("低代码查询注解只能标记实体字段。", property)
+                        return@forEach
+                    }
+                    if (!entity.hasAnnotation(JIMMER_ENTITY_ANNOTATION)) {
+                        if (property.isGeneratedSource() || entity.hasAnnotation(JIMMER_MAPPED_SUPERCLASS_ANNOTATION)) {
+                            return@forEach
+                        }
+                        error("低代码查询注解只能标记 Jimmer 实体字段。", property)
+                        return@forEach
+                    }
+                    entitySymbols += entity
+                }
+        }
+    }
+
+    private fun collectEntity(entity: KSClassDeclaration): LowQueryEntityMeta? {
+        if (!entity.hasAnnotation(JIMMER_ENTITY_ANNOTATION)) {
+            error("@JimmerLowQuery 只能用于带 @Entity 的 Jimmer 实体。", entity)
+            return null
+        }
+        val annotation = entity.findAnnotation(LOW_QUERY_ANNOTATION)
+        val packageName = entity.packageName.asString()
+        val simpleName = entity.simpleName.asString()
+        val qualifiedName = entity.qualifiedName?.asString()
+        if (qualifiedName.isNullOrBlank()) {
+            error("无法解析实体 $simpleName 的全限定名。", entity)
+            return null
+        }
+        val properties = entity.getAllProperties().toList()
+        val lowQueryTriggered = entity.isLowQueryTriggered(properties)
+        val fieldParams = properties
+            .flatMap { property -> collectParams(property, properties, lowQueryTriggered) }
+            .distinctBy { param -> param.parameterName }
+        val params = fieldParams + collectClassParams(entity, properties, fieldParams)
+        val orders = properties
+            .mapNotNull { property -> collectOrder(property) }
+            .sortedWith(compareBy<LowQueryOrderMeta> { it.priority }.thenBy { it.propertyName })
+        val keywordProps = collectKeywordProps(entity, properties)
+        val findBys = collectFindBys(entity, properties)
+        if (params.isEmpty() && orders.isEmpty() && keywordProps.isEmpty() && findBys.isEmpty()) {
+            error("$qualifiedName 至少需要一个 @Eq/@Like/@In、@Keyword、@JimmerLowQueryParam、@JimmerFindBy 或 @OrderByAsc/@OrderByDesc 字段。", entity)
+            return null
+        }
+        return LowQueryEntityMeta(
+            packageName = packageName,
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
+            functionName = annotation?.stringValue("functionName")?.takeIf { it.isNotBlank() } ?: "query",
+            clientFunctionName = annotation?.stringValue("clientFunctionName")?.takeIf { it.isNotBlank() }
+                ?: "createLowQuery",
+            visibility = annotation?.enumValue("visibility", LowQueryVisibility.PUBLIC) ?: LowQueryVisibility.PUBLIC,
+            clientVisibility = annotation?.enumValue("clientVisibility", LowQueryVisibility.PUBLIC)
+                ?: LowQueryVisibility.PUBLIC,
+            fetcher = annotation?.enumValue("fetcher", LowQueryFetcher.ALL_SCALAR_FIELDS)
+                ?: LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = params,
+            orders = orders,
+            keywordProps = keywordProps,
+            hasIdProperty = properties.any { property -> property.hasAnnotation(JIMMER_ID_ANNOTATION) },
+            findBys = findBys,
+        )
+    }
+
+    private fun collectParams(
+        property: KSPropertyDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        lowQueryTriggered: Boolean,
+    ): List<LowQueryParamMeta> {
+        val fieldAnnotations = property.findLowQueryFieldAnnotations()
+        if (fieldAnnotations.size > 1) {
+            error("字段 ${property.simpleName.asString()} 只能标记一个低代码查询 where 注解。", property)
+            return emptyList()
+        }
+        if (property.isCalculatedProperty()) {
+            if (fieldAnnotations.isNotEmpty()) {
+                error("Jimmer @Transient/@Formula 计算字段不能参与低代码查询。", property)
+            }
+            return emptyList()
+        }
+        val annotation = fieldAnnotations.singleOrNull()
+        if (annotation != null) {
+            return listOfNotNull(collectAnnotatedParam(property, annotation))
+        }
+        if (!lowQueryTriggered) {
+            return emptyList()
+        }
+        return collectDefaultParams(property, properties)
+    }
+
+    private fun collectFindBys(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+    ): List<LowQueryFindByMeta> {
+        val byProperty = properties.mapNotNull { property ->
+            val annotation = property.findAnnotation(JIMMER_FIND_BY_ANNOTATION) ?: return@mapNotNull null
+            collectFindBy(entity, properties, property, annotation)
+        }
+        val byClass = entity.annotations.flatMap { annotation ->
+            val qualifiedName = annotation.annotationType.resolve().declaration.qualifiedName?.asString()
+            if (qualifiedName != JIMMER_FIND_BY_ANNOTATION) {
+                return@flatMap emptyList()
+            }
+            collectClassFindBys(entity, properties, annotation)
+        }
+        return (byProperty + byClass)
+            .distinctBy { findBy -> findBy.listFunctionName to findBy.oneFunctionName }
+    }
+
+    private fun collectClassFindBys(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        annotation: KSAnnotation,
+    ): List<LowQueryFindByMeta> {
+        val fieldNames = annotation.stringArrayValue("fields")
+        if (fieldNames.isEmpty()) {
+            error("类级 @JimmerFindBy 必须通过 fields 指定实体字段。", entity)
+            return emptyList()
+        }
+        val composite = annotation.booleanValue("composite") == true
+        if (fieldNames.size > 1 && !composite && annotation.hasCustomFindByName()) {
+            error("类级 @JimmerFindBy 一次指定多个字段并分别生成时不能覆盖 name、listFunctionName 或 oneFunctionName。", entity)
+            return emptyList()
+        }
+        if (fieldNames.size > 1 && composite && !annotation.stringValue("name").isNullOrBlank()) {
+            error("类级 @JimmerFindBy 生成组合查询时不能用 name 覆盖多个参数名。", entity)
+            return emptyList()
+        }
+        val findByFields = collectFindByFields(entity, properties, fieldNames, annotation)
+        if (findByFields.size != fieldNames.size) {
+            return emptyList()
+        }
+        if (composite) {
+            return listOfNotNull(collectFindBy(entity, properties, findByFields, annotation, entity))
+        }
+        return findByFields.mapNotNull { field -> collectFindBy(entity, properties, listOf(field), annotation, entity) }
+    }
+
+    private fun collectFindBy(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        property: KSPropertyDeclaration,
+        annotation: KSAnnotation,
+    ): LowQueryFindByMeta? {
+        val field = collectFindByField(property, annotation) ?: return null
+        return collectFindBy(entity, properties, listOf(field), annotation, property)
+    }
+
+    private fun collectFindBy(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        fields: List<LowQueryFindByFieldMeta>,
+        annotation: KSAnnotation,
+        symbol: KSAnnotated,
+    ): LowQueryFindByMeta? {
+        if (fields.isEmpty()) {
+            return null
+        }
+        val extraFetchFieldNames = annotation.stringArrayValue("extraFetchFields")
+        val fetcher = annotation.enumValue("fetcher", LowQueryFetcher.ALL_SCALAR_FIELDS)
+        if (fetcher == LowQueryFetcher.TABLE && extraFetchFieldNames.isNotEmpty()) {
+            error("@JimmerFindBy(fetcher = TABLE) 不能再配置 extraFetchFields。", symbol)
+            return null
+        }
+        val extraFetchFields = collectExtraFetchFields(properties, extraFetchFieldNames, symbol)
+        if (extraFetchFields.size != extraFetchFieldNames.size) {
+            return null
+        }
+        val entitySimpleName = entity.simpleName.asString()
+        val propertySuffix = fields.joinToString("And") { field -> field.propertyName.replaceFirstChar(Char::uppercase) }
+        return LowQueryFindByMeta(
+            fields = fields,
+            listFunctionName = annotation.stringValue("listFunctionName")?.takeIf { it.isNotBlank() }
+                ?: "find${entitySimpleName}By$propertySuffix",
+            oneFunctionName = annotation.stringValue("oneFunctionName")?.takeIf { it.isNotBlank() }
+                ?: "findOneOrNull${entitySimpleName}By$propertySuffix",
+            visibility = annotation.enumValue("visibility", LowQueryVisibility.PUBLIC),
+            fetcher = fetcher,
+            extraFetchFields = extraFetchFields,
+        )
+    }
+
+    private fun collectExtraFetchFields(
+        properties: List<KSPropertyDeclaration>,
+        fieldNames: List<String>,
+        symbol: KSAnnotated,
+    ): List<LowQueryExtraFetchFieldMeta> = fieldNames.mapNotNull { fieldName ->
+        val property = properties.firstOrNull { property -> property.simpleName.asString() == fieldName }
+        if (property == null) {
+            error("@JimmerFindBy extraFetchFields 指定的字段不存在：$fieldName", symbol)
+            return@mapNotNull null
+        }
+        val kind = if (property.type.resolve().isAssociationType()) {
+            LowQueryExtraFetchFieldKind.ASSOCIATION
+        } else {
+            LowQueryExtraFetchFieldKind.SCALAR
+        }
+        LowQueryExtraFetchFieldMeta(
+            propertyName = fieldName,
+            kind = kind,
+        )
+    }
+
+    private fun collectFindByFields(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        fieldNames: List<String>,
+        annotation: KSAnnotation,
+    ): List<LowQueryFindByFieldMeta> = fieldNames.mapNotNull { fieldName ->
+        val property = properties.firstOrNull { property -> property.simpleName.asString() == fieldName }
+        if (property == null) {
+            error("类级 @JimmerFindBy 指定的字段不存在：$fieldName", entity)
+            return@mapNotNull null
+        }
+        collectFindByField(property, annotation)
+    }
+
+    private fun collectFindByField(
+        property: KSPropertyDeclaration,
+        annotation: KSAnnotation,
+    ): LowQueryFindByFieldMeta? {
+        val propertyName = property.simpleName.asString()
+        if (property.isCalculatedProperty()) {
+            error("Jimmer @Transient/@Formula 计算字段不能生成辅助查询方法。", property)
+            return null
+        }
+        val type = property.type.resolve()
+        if (!type.isScalarType()) {
+            error("@JimmerFindBy 只能用于标量字段：$propertyName", property)
+            return null
+        }
+        val parameterName = annotation.stringValue("name")?.takeIf { it.isNotBlank() } ?: propertyName
+        return LowQueryFindByFieldMeta(
+            propertyName = propertyName,
+            parameterName = parameterName,
+            typeName = type.renderType(forceNullable = false, preserveNullable = false),
+        )
+    }
+
+    private fun collectAnnotatedParam(
+        property: KSPropertyDeclaration,
+        annotation: KSAnnotation,
+    ): LowQueryParamMeta? {
+        val propertyName = property.simpleName.asString()
+        val operator = annotation.lowQueryOperator()
+        val type = property.type.resolve()
+        val targetFieldName = annotation.stringValue("targetField")?.takeIf { it.isNotBlank() }
+        val nullable = type.isMarkedNullable ||
+            annotation.booleanValue("nullable") != false ||
+            operator == LowQueryOperator.BETWEEN ||
+            operator == LowQueryOperator.TIME_RANGE
+        val expression = if (operator == LowQueryOperator.EQ) {
+            annotation.stringValue(CONSTANT_EQ_EXPRESSION_ANNOTATION)?.takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
+        val expressionImports = if (expression == null) {
+            emptyList()
+        } else {
+            annotation.stringArrayValue(CONSTANT_EQ_IMPORTS_ANNOTATION)
+        }
+        if (targetFieldName != null) {
+            return collectAnnotatedParamWithTargetField(property, annotation, propertyName, operator, targetFieldName, nullable, expression, expressionImports)
+        }
+        val scalarTypeName = type.renderType(forceNullable = false, preserveNullable = false)
+        val parameterName = annotation.parameterName(propertyName, operator)
+        val endParameterName = annotation.endParameterName(propertyName, operator)
+        return LowQueryParamMeta(
+            propertyName = propertyName,
+            parameterName = parameterName,
+            typeName = type.renderParamType(operator, nullable),
+            targetTypeName = scalarTypeName,
+            operator = operator,
+            nullable = nullable,
+            sourceApplies = true,
+            parameterAnnotations = property.renderParameterAnnotations(),
+            endParameterName = endParameterName,
+            endTypeName = if (endParameterName != null) {
+                type.renderParamType(operator, nullable)
+            } else {
+                null
+            },
+            expression = expression,
+            expressionImports = expressionImports,
+        )
+    }
+
+    /**
+     * 处理 targetField 穿透：将关联属性上的查询注解逐传到目标实体的标量字段。
+     */
+    private fun collectAnnotatedParamWithTargetField(
+        property: KSPropertyDeclaration,
+        annotation: KSAnnotation,
+        propertyName: String,
+        operator: LowQueryOperator,
+        targetFieldName: String,
+        nullable: Boolean,
+        expression: String?,
+        expressionImports: List<String>,
+    ): LowQueryParamMeta? {
+        val associationTarget = property.type.resolve().resolveAssociationTarget() ?: run {
+            error("targetField 只能在关联属性（@ManyToOne/@OneToMany）上使用，${propertyName} 不是关联属性。", property)
+            return null
+        }
+        val targetEntity = associationTarget.first
+        val pathKind = associationTarget.second
+        val targetProperties = targetEntity.getAllProperties().toList()
+        val targetProperty = targetProperties.firstOrNull { prop -> prop.simpleName.asString() == targetFieldName }
+        if (targetProperty == null) {
+            error("targetField \"$targetFieldName\" 在实体 ${targetEntity.simpleName.asString()} 中不存在。", property)
+            return null
+        }
+        if (targetProperty.isCalculatedProperty()) {
+            error("targetField \"$targetFieldName\" 不能是 @Transient/@Formula 计算字段。", property)
+            return null
+        }
+        val targetType = targetProperty.type.resolve()
+        if (!targetType.isScalarType()) {
+            error("targetField \"$targetFieldName\" 必须是标量字段，不能是关联属性。", property)
+            return null
+        }
+        val scalarTypeName = targetType.renderType(forceNullable = false, preserveNullable = false)
+        val parameterName = annotation.parameterName(targetFieldName, operator)
+        val endParameterName = annotation.endParameterName(targetFieldName, operator)
+        val parameterAnnotations = targetProperty.renderParameterAnnotations()
+        val scalarTablePath = listOf(propertyName, targetFieldName)
+        val scalarTablePathKinds = listOf(pathKind)
+        val scalarTablePathImportPackages = listOf(
+            property.packageName.asString(),
+            targetEntity.packageName.asString(),
+        )
+        val associationTypeIsNullable = property.type.resolve().isMarkedNullable
+        val targetFieldIsNullable = targetType.isMarkedNullable
+        val loadedPropertyName = if (pathKind == LowQueryTablePathKind.REFERENCE) propertyName else targetFieldName
+        val entityValuePath: List<String>
+        val entityValuePathNullable: List<Boolean>
+        val entityApplies: Boolean
+        if (pathKind == LowQueryTablePathKind.REFERENCE) {
+            entityValuePath = listOf(propertyName, targetFieldName)
+            entityValuePathNullable = listOf(associationTypeIsNullable, targetFieldIsNullable)
+            entityApplies = true
+        } else {
+            entityValuePath = listOf(targetFieldName)
+            entityValuePathNullable = listOf(targetFieldIsNullable)
+            entityApplies = false
+        }
+        return LowQueryParamMeta(
+            propertyName = targetFieldName,
+            parameterName = parameterName,
+            typeName = targetType.renderParamType(operator, nullable),
+            targetTypeName = scalarTypeName,
+            operator = operator,
+            nullable = nullable,
+            tablePropertyName = targetFieldName,
+            loadedPropertyName = loadedPropertyName,
+            entityValuePath = entityValuePath,
+            entityValuePathNullable = entityValuePathNullable,
+            sourceApplies = true,
+            entityApplies = entityApplies,
+            parameterAnnotations = parameterAnnotations,
+            endParameterName = endParameterName,
+            endTypeName = if (endParameterName != null) {
+                targetType.renderParamType(operator, nullable)
+            } else {
+                null
+            },
+            expression = expression,
+            expressionImports = expressionImports,
+            tablePath = scalarTablePath,
+            tablePathKinds = scalarTablePathKinds,
+            tablePathImportPackages = scalarTablePathImportPackages,
+        )
+    }
+
+    private fun collectDefaultParams(
+        property: KSPropertyDeclaration,
+        properties: List<KSPropertyDeclaration>,
+    ): List<LowQueryParamMeta> {
+        val propertyName = property.simpleName.asString()
+        if (propertyName in DEFAULT_QUERY_EXCLUDED_PROPERTIES) {
+            return emptyList()
+        }
+        if (property.hasAnnotation(JIMMER_ID_VIEW_ANNOTATION)) {
+            return emptyList()
+        }
+        val type = property.type.resolve()
+        if (type.isScalarType()) {
+            return listOf(property.toDefaultScalarParam(type))
+        }
+        return property.toDefaultAssociationIdParams(type, properties)
+    }
+
+    private fun KSPropertyDeclaration.toDefaultScalarParam(type: KSType): LowQueryParamMeta {
+        val propertyName = simpleName.asString()
+        val scalarTypeName = type.renderType(forceNullable = false, preserveNullable = false)
+        return LowQueryParamMeta(
+            propertyName = propertyName,
+            parameterName = propertyName,
+            typeName = type.renderParamType(LowQueryOperator.EQ, forceNullable = true),
+            targetTypeName = scalarTypeName,
+            operator = LowQueryOperator.EQ,
+            nullable = true,
+            sourceApplies = true,
+            parameterAnnotations = renderParameterAnnotations(),
+        )
+    }
+
+    private fun KSPropertyDeclaration.toDefaultAssociationIdParams(
+        type: KSType,
+        properties: List<KSPropertyDeclaration>,
+    ): List<LowQueryParamMeta> {
+        val associationTarget = type.resolveAssociationTarget() ?: return emptyList()
+        val targetEntity = associationTarget.first
+        val pathKind = associationTarget.second
+        val idProperty = targetEntity.getAllProperties().firstOrNull { targetProperty ->
+            targetProperty.hasAnnotation(JIMMER_ID_ANNOTATION)
+        } ?: return emptyList()
+        val idType = idProperty.type.resolve()
+        val propertyName = simpleName.asString()
+        val idViewPropertyName = findIdViewPropertyName(propertyName, properties)
+        val associatedIdName = if (pathKind == LowQueryTablePathKind.COLLECTION) {
+            idViewPropertyName?.singularAssociatedIdName() ?: "${propertyName.removeSuffix("s")}Id"
+        } else {
+            idViewPropertyName ?: "${propertyName}Id"
+        }
+        val scalarTablePath = listOf(propertyName, idProperty.simpleName.asString())
+        val scalarTablePathKinds = listOf(pathKind)
+        val scalarTablePathImportPackages = listOf(
+            packageName.asString(),
+            targetEntity.packageName.asString(),
+        )
+        val scalarParam = LowQueryParamMeta(
+            propertyName = associatedIdName,
+            parameterName = associatedIdName,
+            typeName = idType.renderParamType(LowQueryOperator.EQ, forceNullable = true),
+            targetTypeName = idType.renderType(forceNullable = false, preserveNullable = false),
+            operator = LowQueryOperator.EQ,
+            nullable = true,
+            tablePropertyName = associatedIdName,
+            loadedPropertyName = if (pathKind == LowQueryTablePathKind.REFERENCE) propertyName else associatedIdName,
+            entityValuePath = if (pathKind == LowQueryTablePathKind.REFERENCE) {
+                listOf(propertyName, idProperty.simpleName.asString())
+            } else {
+                listOf(associatedIdName)
+            },
+            entityValuePathNullable = if (pathKind == LowQueryTablePathKind.REFERENCE) {
+                listOf(type.isMarkedNullable, idType.isMarkedNullable)
+            } else {
+                emptyList()
+            },
+            sourceApplies = true,
+            entityApplies = pathKind == LowQueryTablePathKind.REFERENCE,
+            tablePath = scalarTablePath,
+            tablePathKinds = scalarTablePathKinds,
+            tablePathImportPackages = scalarTablePathImportPackages,
+        )
+        if (pathKind == LowQueryTablePathKind.REFERENCE) {
+            return listOf(scalarParam)
+        }
+        val collectionParamName = associatedIdName.defaultParameterName(LowQueryOperator.IN)
+        val collectionParam = scalarParam.copy(
+            propertyName = collectionParamName,
+            parameterName = collectionParamName,
+            typeName = idType.renderParamType(LowQueryOperator.IN, forceNullable = true),
+            operator = LowQueryOperator.IN,
+            loadedPropertyName = collectionParamName,
+            entityValuePath = listOf(collectionParamName),
+            entityValuePathNullable = emptyList(),
+            entityApplies = false,
+        )
+        return listOf(scalarParam, collectionParam)
+    }
+
+    private fun String.singularAssociatedIdName(): String {
+        if (endsWith("Ids") && length > 3) {
+            return removeSuffix("s")
+        }
+        if (endsWith("s") && length > 1) {
+            return removeSuffix("s")
+        }
+        return this
+    }
+
+    private fun findIdViewPropertyName(
+        associationPropertyName: String,
+        properties: List<KSPropertyDeclaration>,
+    ): String? {
+        return properties.firstOrNull { property ->
+            val annotation = property.findAnnotation(JIMMER_ID_VIEW_ANNOTATION) ?: return@firstOrNull false
+            annotation.stringValue("value") == associationPropertyName
+        }?.simpleName?.asString()
+    }
+
+    private fun collectClassParams(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+        fieldParams: List<LowQueryParamMeta>,
+    ): List<LowQueryParamMeta> {
+        return entity.annotations.mapNotNull { annotation ->
+            val qualifiedName = annotation.annotationType.resolve().declaration.qualifiedName?.asString()
+            if (qualifiedName != TIME_RANGE_ANNOTATION) {
+                return@mapNotNull null
+            }
+            val propertyName = annotation.stringValue("name")?.takeIf { it.isNotBlank() }
+            if (propertyName == null) {
+                error("类级 @TimeRange 必须通过 name 指定实体字段。", entity)
+                return@mapNotNull null
+            }
+            if (fieldParams.any { param -> param.propertyName == propertyName }) {
+                return@mapNotNull null
+            }
+            val property = properties.firstOrNull { property -> property.simpleName.asString() == propertyName }
+            if (property == null) {
+                error("类级 @TimeRange 指定的字段不存在：$propertyName", entity)
+                return@mapNotNull null
+            }
+            if (property.isCalculatedProperty()) {
+                error("类级 @TimeRange 不能指定 Jimmer @Transient/@Formula 计算字段：$propertyName", entity)
+                return@mapNotNull null
+            }
+            val type = property.type.resolve()
+            LowQueryParamMeta(
+                propertyName = propertyName,
+                parameterName = propertyName,
+                typeName = type.renderParamType(LowQueryOperator.TIME_RANGE, forceNullable = true),
+                targetTypeName = type.renderType(forceNullable = false, preserveNullable = false),
+                operator = LowQueryOperator.TIME_RANGE,
+                nullable = true,
+                parameterAnnotations = property.renderParameterAnnotations(),
+            )
+        }.toList()
+    }
+
+    private fun collectOrder(property: KSPropertyDeclaration): LowQueryOrderMeta? {
+        val orderAnnotations = property.findLowQueryOrderAnnotations()
+        if (orderAnnotations.size > 1) {
+            error("字段 ${property.simpleName.asString()} 只能标记一个低代码查询排序注解。", property)
+            return null
+        }
+        val annotation = orderAnnotations.singleOrNull() ?: return null
+        if (property.isCalculatedProperty()) {
+            error("Jimmer @Transient/@Formula 计算字段不能参与低代码查询排序。", property)
+            return null
+        }
+        val qualifiedName = annotation.annotationType.resolve().declaration.qualifiedName?.asString()
+        val direction = when (qualifiedName) {
+            ORDER_BY_ASC_ANNOTATION -> LowQueryOrderDirection.ASC
+            ORDER_BY_DESC_ANNOTATION -> LowQueryOrderDirection.DESC
+            else -> return null
+        }
+        return LowQueryOrderMeta(
+            propertyName = property.simpleName.asString(),
+            direction = direction,
+            priority = annotation.intValue("priority") ?: 0,
+        )
+    }
+
+    private fun collectKeywordProps(
+        entity: KSClassDeclaration,
+        properties: List<KSPropertyDeclaration>,
+    ): List<LowQueryKeywordMeta> {
+        val directProps = properties.mapNotNull { property -> collectDirectKeywordProp(property) }
+        val collectNestedAssociatedProps = directProps.isEmpty()
+        val associatedProps = properties.flatMap { property ->
+            collectAssociatedKeywordProps(entity, property, collectNestedAssociatedProps)
+        }
+        return (directProps + associatedProps)
+            .distinctBy { keyword -> keyword.tablePath }
+    }
+
+    private fun collectDirectKeywordProp(property: KSPropertyDeclaration): LowQueryKeywordMeta? {
+        if (!property.hasKeywordAnnotation()) {
+            return null
+        }
+        val propertyName = property.simpleName.asString()
+        if (!property.validateKeywordProp(propertyName)) {
+            return null
+        }
+        return LowQueryKeywordMeta(propertyName = propertyName)
+    }
+
+    private fun collectAssociatedKeywordProps(
+        entity: KSClassDeclaration,
+        property: KSPropertyDeclaration,
+        collectNestedAssociatedProps: Boolean,
+    ): List<LowQueryKeywordMeta> {
+        val entityName = entity.qualifiedName?.asString().orEmpty()
+        return collectAssociatedKeywordProps(
+            property = property,
+            visitedEntityNames = setOf(entityName),
+            tablePathPrefix = emptyList(),
+            tablePathKindPrefix = emptyList(),
+            tablePathImportPackagePrefix = emptyList(),
+            collectNestedAssociatedProps = collectNestedAssociatedProps,
+        )
+    }
+
+    private fun collectAssociatedKeywordProps(
+        property: KSPropertyDeclaration,
+        visitedEntityNames: Set<String>,
+        tablePathPrefix: List<String>,
+        tablePathKindPrefix: List<LowQueryTablePathKind>,
+        tablePathImportPackagePrefix: List<String>,
+        collectNestedAssociatedProps: Boolean,
+    ): List<LowQueryKeywordMeta> {
+        if (property.isCalculatedProperty()) {
+            return emptyList()
+        }
+        val association = property.type.resolve().resolveAssociationTarget() ?: return emptyList()
+        val targetEntity = association.first
+        val targetEntityName = targetEntity.qualifiedName?.asString().orEmpty()
+        if (targetEntityName in visitedEntityNames) {
+            return emptyList()
+        }
+        val associationDepth = tablePathKindPrefix.size + 1
+        if (associationDepth > MAX_KEYWORD_ASSOCIATION_DEPTH) {
+            return emptyList()
+        }
+        val associationName = property.simpleName.asString()
+        val tablePath = tablePathPrefix + associationName
+        val tablePathKinds = tablePathKindPrefix + association.second
+        val tablePathImportPackages = tablePathImportPackagePrefix + property.packageName.asString()
+        val nextVisitedEntityNames = visitedEntityNames + targetEntityName
+        val properties = targetEntity.getAllProperties().toList()
+        val directProps = properties.mapNotNull { targetProperty ->
+            if (!targetProperty.hasKeywordAnnotation()) {
+                return@mapNotNull null
+            }
+            val targetPropertyName = targetProperty.simpleName.asString()
+            if (!targetProperty.validateKeywordProp(targetPropertyName)) {
+                return@mapNotNull null
+            }
+            val keywordTablePath = tablePath + targetPropertyName
+            LowQueryKeywordMeta(
+                propertyName = keywordTablePath.joinToString("."),
+                tablePath = keywordTablePath,
+                tablePathKinds = tablePathKinds,
+                tablePathImportPackages = tablePathImportPackages + targetEntity.packageName.asString(),
+            )
+        }
+        if (associationDepth == MAX_KEYWORD_ASSOCIATION_DEPTH) {
+            return directProps
+        }
+        if (!collectNestedAssociatedProps || directProps.isEmpty()) {
+            return directProps
+        }
+        val nestedProps = properties.flatMap { targetProperty ->
+            collectAssociatedKeywordProps(
+                property = targetProperty,
+                visitedEntityNames = nextVisitedEntityNames,
+                tablePathPrefix = tablePath,
+                tablePathKindPrefix = tablePathKinds,
+                tablePathImportPackagePrefix = tablePathImportPackages,
+                collectNestedAssociatedProps = false,
+            )
+        }
+        return directProps + nestedProps
+    }
+
+    private fun KSPropertyDeclaration.validateKeywordProp(propertyName: String): Boolean {
+        if (isCalculatedProperty()) {
+            error("Jimmer @Transient/@Formula 计算字段不能参与 keyword 查询。", this)
+            return false
+        }
+        val type = this.type.resolve()
+        if (!type.isStringType()) {
+            error("@Keyword 只能标记 String 字段：$propertyName", this)
+            return false
+        }
+        return true
+    }
+
+    private fun KSPropertyDeclaration.hasKeywordAnnotation(): Boolean {
+        if (hasAnnotation(KEYWORD_ANNOTATION)) {
+            return true
+        }
+        return getter?.hasAnnotation(KEYWORD_ANNOTATION) == true
+    }
+
+    private fun KSType.resolveAssociationTarget(): Pair<KSClassDeclaration, LowQueryTablePathKind>? {
+        val directDeclaration = declaration as? KSClassDeclaration
+        if (directDeclaration?.hasAnnotation(JIMMER_ENTITY_ANNOTATION) == true) {
+            return directDeclaration to LowQueryTablePathKind.REFERENCE
+        }
+        val targetEntity = arguments.firstNotNullOfOrNull { argument ->
+            val argumentDeclaration = argument.type?.resolve()?.declaration as? KSClassDeclaration
+            argumentDeclaration?.takeIf { declaration -> declaration.hasAnnotation(JIMMER_ENTITY_ANNOTATION) }
+        } ?: return null
+        return targetEntity to LowQueryTablePathKind.COLLECTION
+    }
+
+    private fun KSAnnotated.findLowQueryFieldAnnotations(): List<KSAnnotation> {
+        return annotations.filter { annotation ->
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() in LOW_QUERY_FIELD_ANNOTATIONS
+        }.toList()
+    }
+
+    private fun KSAnnotated.findLowQueryOrderAnnotations(): List<KSAnnotation> {
+        return annotations.filter { annotation ->
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() in LOW_QUERY_ORDER_ANNOTATIONS
+        }.toList()
+    }
+
+    private fun KSClassDeclaration.isLowQueryTriggered(properties: List<KSPropertyDeclaration>): Boolean {
+        if (hasAnnotation(LOW_QUERY_ANNOTATION)) {
+            return true
+        }
+        if (hasAnnotation(TIME_RANGE_ANNOTATION)) {
+            return true
+        }
+        return properties.any { property ->
+            property.findLowQueryFieldAnnotations().isNotEmpty() ||
+                property.findLowQueryOrderAnnotations().isNotEmpty() ||
+                property.hasKeywordAnnotation()
+        }
+    }
+
+    private fun KSAnnotated.findAnnotation(qualifiedName: String): KSAnnotation? {
+        return annotations.firstOrNull { annotation ->
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() == qualifiedName
+        }
+    }
+
+    private fun KSAnnotated.hasAnnotation(qualifiedName: String): Boolean {
+        return findAnnotation(qualifiedName) != null
+    }
+
+    private fun KSPropertyDeclaration.isCalculatedProperty(): Boolean {
+        return hasAnnotation(JIMMER_TRANSIENT_ANNOTATION) ||
+            hasAnnotation(JIMMER_FORMULA_ANNOTATION) ||
+            getter?.hasAnnotation(JIMMER_TRANSIENT_ANNOTATION) == true ||
+            getter?.hasAnnotation(JIMMER_FORMULA_ANNOTATION) == true
+    }
+
+    private fun KSAnnotated.isGeneratedSource(): Boolean {
+        val path = when (this) {
+            is KSClassDeclaration -> containingFile?.filePath
+            is KSPropertyDeclaration -> containingFile?.filePath
+            else -> null
+        } ?: return false
+        return path.contains("/build/generated/") || path.contains("\\build\\generated\\")
+    }
+
+    private fun KSAnnotation.stringValue(name: String): String? {
+        val namedValue = arguments.firstOrNull { it.name?.asString() == name }?.value as? String
+        if (namedValue != null) {
+            return namedValue
+        }
+        if (name != "value") {
+            return null
+        }
+        return arguments.firstOrNull { it.name == null }?.value as? String
+    }
+
+    private fun KSAnnotation.booleanValue(name: String): Boolean? {
+        return arguments.firstOrNull { it.name?.asString() == name }?.value as? Boolean
+    }
+
+    private fun KSAnnotation.intValue(name: String): Int? {
+        return arguments.firstOrNull { it.name?.asString() == name }?.value as? Int
+    }
+
+    private fun KSAnnotation.stringArrayValue(name: String): List<String> {
+        val value = arguments.firstOrNull { it.name?.asString() == name }?.value
+        val values = value as? List<*> ?: return emptyList()
+        return values.filterIsInstance<String>().filter { item -> item.isNotBlank() }
+    }
+
+    private fun KSAnnotation.hasCustomFindByName(): Boolean {
+        return listOf("name", "listFunctionName", "oneFunctionName").any { name ->
+            !stringValue(name).isNullOrBlank()
+        }
+    }
+
+    private inline fun <reified E : Enum<E>> KSAnnotation.enumValue(name: String, defaultValue: E): E {
+        val value = arguments.firstOrNull { it.name?.asString() == name }?.value?.toString()
+        return enumValues<E>().firstOrNull { it.name == value } ?: defaultValue
+    }
+
+    private fun KSAnnotation.lowQueryOperator(): LowQueryOperator {
+        val qualifiedName = annotationType.resolve().declaration.qualifiedName?.asString()
+        if (qualifiedName == LOW_QUERY_PARAM_ANNOTATION) {
+            return enumValue("operator", LowQueryOperator.EQ)
+        }
+        return LOW_QUERY_OPERATOR_BY_ANNOTATION.getValue(checkNotNull(qualifiedName))
+    }
+
+    private fun KSAnnotation.parameterName(
+        propertyName: String,
+        operator: LowQueryOperator,
+    ): String {
+        val annotationName = when (operator) {
+            LowQueryOperator.BETWEEN -> "startName"
+            else -> "name"
+        }
+        return stringValue(annotationName)
+            ?.takeIf { it.isNotBlank() }
+            ?: propertyName.defaultParameterName(operator)
+    }
+
+    private fun KSAnnotation.endParameterName(
+        propertyName: String,
+        operator: LowQueryOperator,
+    ): String? {
+        if (operator != LowQueryOperator.BETWEEN) {
+            return null
+        }
+        return stringValue("endName")
+            ?.takeIf { it.isNotBlank() }
+            ?: "${propertyName}End"
+    }
+
+    private fun String.defaultParameterName(operator: LowQueryOperator): String {
+        return when (operator) {
+            LowQueryOperator.IN,
+            LowQueryOperator.NOT_IN -> {
+                if (endsWith("s")) {
+                    this
+                } else {
+                    "${this}s"
+                }
+            }
+            LowQueryOperator.BETWEEN -> "${this}Start"
+            else -> this
+        }
+    }
+
+
+    private fun KSType.isScalarType(): Boolean {
+        if (declaration is KSClassDeclaration && (declaration as KSClassDeclaration).hasAnnotation(JIMMER_ENTITY_ANNOTATION)) {
+            return false
+        }
+        if (arguments.isNotEmpty()) {
+            return false
+        }
+        val qualifiedName = declaration.qualifiedName?.asString() ?: return false
+        if (qualifiedName in DEFAULT_QUERY_SCALAR_TYPES) {
+            return true
+        }
+        return declaration.packageName.asString() == "java.time" ||
+            declaration.packageName.asString() == "java.math" ||
+            (declaration as? KSClassDeclaration)?.classKind?.name == "ENUM_CLASS"
+    }
+
+    private fun KSType.isStringType(): Boolean {
+        val qualifiedName = declaration.qualifiedName?.asString() ?: return false
+        return qualifiedName == "kotlin.String" || qualifiedName == "java.lang.String"
+    }
+
+    private fun KSType.isAssociationType(): Boolean {
+        val directDeclaration = declaration as? KSClassDeclaration
+        if (directDeclaration?.hasAnnotation(JIMMER_ENTITY_ANNOTATION) == true) {
+            return true
+        }
+        return arguments.any { argument ->
+            val argumentDeclaration = argument.type?.resolve()?.declaration as? KSClassDeclaration
+            argumentDeclaration?.hasAnnotation(JIMMER_ENTITY_ANNOTATION) == true
+        }
+    }
+
+    private fun KSType.renderParamType(operator: LowQueryOperator, forceNullable: Boolean): String {
+        val scalarType = renderType(forceNullable = false, preserveNullable = false)
+        if (operator == LowQueryOperator.IN || operator == LowQueryOperator.NOT_IN) {
+            val nullableSuffix = if (forceNullable) "?" else ""
+            return "Collection<$scalarType>$nullableSuffix"
+        }
+        if (operator == LowQueryOperator.BETWEEN) {
+            return renderType(forceNullable = true, preserveNullable = false)
+        }
+        if (operator == LowQueryOperator.TIME_RANGE) {
+            return "Array<$scalarType>?"
+        }
+        return renderType(forceNullable = forceNullable, preserveNullable = true)
+    }
+
+    private fun KSPropertyDeclaration.renderParameterAnnotations(): List<String> {
+        val allAnnotations = annotations.toList() + getter?.annotations.orEmpty().toList()
+        return allAnnotations.mapNotNull { annotation ->
+            annotation.renderParameterAnnotation()
+        }
+    }
+
+    private fun KSAnnotation.renderParameterAnnotation(): String? {
+        return null
+    }
+
+    private fun KSType.renderType(forceNullable: Boolean, preserveNullable: Boolean): String {
+        val declaration = declaration
+        val qualifiedName = declaration.qualifiedName?.asString()
+        val baseName = when {
+            qualifiedName == null -> toString().removeSuffix("?")
+            declaration.packageName.asString() == "kotlin" -> declaration.simpleName.asString()
+            else -> qualifiedName
+        }
+        val typeArguments = arguments
+            .mapNotNull { it.type?.resolve()?.renderType(forceNullable = false, preserveNullable = true) }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(prefix = "<", postfix = ">")
+            ?: ""
+        val nullableSuffix = if (forceNullable || preserveNullable && isMarkedNullable) "?" else ""
+        return "$baseName$typeArguments$nullableSuffix"
+    }
+
+    private fun String.escapeString(): String =
+        replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+
+    private fun error(message: String, symbol: KSAnnotated) {
+        hasErrors = true
+        logger.error(message, symbol)
+    }
+
+    private companion object {
+        private val LOW_QUERY_OPERATOR_BY_ANNOTATION = mapOf(
+            "$ANNOTATION_PACKAGE.Eq" to LowQueryOperator.EQ,
+            "$ANNOTATION_PACKAGE.Ne" to LowQueryOperator.NE,
+            "$ANNOTATION_PACKAGE.Like" to LowQueryOperator.LIKE,
+            "$ANNOTATION_PACKAGE.StartsWith" to LowQueryOperator.STARTS_WITH,
+            "$ANNOTATION_PACKAGE.EndsWith" to LowQueryOperator.ENDS_WITH,
+            "$ANNOTATION_PACKAGE.Gt" to LowQueryOperator.GT,
+            "$ANNOTATION_PACKAGE.Ge" to LowQueryOperator.GE,
+            "$ANNOTATION_PACKAGE.Lt" to LowQueryOperator.LT,
+            "$ANNOTATION_PACKAGE.Le" to LowQueryOperator.LE,
+            "$ANNOTATION_PACKAGE.In" to LowQueryOperator.IN,
+            "$ANNOTATION_PACKAGE.NotIn" to LowQueryOperator.NOT_IN,
+            "$ANNOTATION_PACKAGE.Between" to LowQueryOperator.BETWEEN,
+            "$ANNOTATION_PACKAGE.TimeRange" to LowQueryOperator.TIME_RANGE,
+        )
+
+        private val LOW_QUERY_FIELD_ANNOTATIONS =
+            LOW_QUERY_OPERATOR_BY_ANNOTATION.keys + LOW_QUERY_PARAM_ANNOTATION
+
+        private val LOW_QUERY_ORDER_ANNOTATIONS = setOf(
+            ORDER_BY_ASC_ANNOTATION,
+            ORDER_BY_DESC_ANNOTATION,
+        )
+
+        private val DEFAULT_QUERY_EXCLUDED_PROPERTIES = setOf(
+            "id",
+            "createTime",
+            "updateTime",
+            "updater",
+            "updaterId",
+            "creator",
+            "creatorId",
+            "deleted",
+            "deletedTime",
+            "tenantId",
+        )
+
+        private val DEFAULT_QUERY_SCALAR_TYPES = setOf(
+            "kotlin.String",
+            "kotlin.Boolean",
+            "kotlin.Byte",
+            "kotlin.Short",
+            "kotlin.Int",
+            "kotlin.Long",
+            "kotlin.Float",
+            "kotlin.Double",
+            "kotlin.UByte",
+            "kotlin.UShort",
+            "kotlin.UInt",
+            "kotlin.ULong",
+            "java.lang.String",
+            "java.lang.Boolean",
+            "java.lang.Byte",
+            "java.lang.Short",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Float",
+            "java.lang.Double",
+        )
+    }
+}

--- a/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryGenerator.kt
+++ b/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryGenerator.kt
@@ -1,0 +1,871 @@
+package org.babyfish.jimmer.lowquery.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+
+internal class JimmerLowQueryGenerator(
+    private val codeGenerator: CodeGenerator,
+) {
+    fun generate(
+        entities: Set<LowQueryEntityMeta>,
+        generatedPackage: String?,
+        springComponentAvailable: Boolean = false,
+    ) {
+        entities.groupBy { it.outputPackage(generatedPackage) }
+            .forEach { (packageName, packageEntities) ->
+                val fileName = packageName.substringAfterLast('.').replaceFirstChar(Char::uppercase) + "JimmerLowQueries"
+                createFile(packageName, fileName).use { stream ->
+                    val code = buildFile(packageName, packageEntities.sortedBy { it.qualifiedName }, springComponentAvailable)
+                    stream.write(code.toByteArray())
+                }
+            }
+    }
+
+    private fun LowQueryEntityMeta.outputPackage(generatedPackage: String?): String {
+        return generatedPackage?.takeIf { it.isNotBlank() } ?: "$packageName.generated.lowquery"
+    }
+
+    private fun createFile(packageName: String, fileName: String) =
+        codeGenerator.createNewFile(Dependencies.ALL_FILES, packageName, fileName, "kt")
+
+    private fun buildFile(
+        packageName: String,
+        entities: List<LowQueryEntityMeta>,
+        springComponentAvailable: Boolean,
+    ): String {
+        val hasSourceParams = entities.any { entity ->
+            entity.keywordProps.isNotEmpty() ||
+                entity.params.any { param -> param.sourceApplies || param.isRangeParam() }
+        }
+        val hasKeywordParams = entities.any { entity -> entity.keywordProps.isNotEmpty() }
+        return buildString {
+            appendLine("@file:Suppress(\"unused\")")
+            appendLine()
+            appendLine("package $packageName")
+            appendLine()
+            appendLine("import org.babyfish.jimmer.ImmutableObjects")
+            appendLine("import org.babyfish.jimmer.sql.ast.LikeMode")
+            appendLine("import org.babyfish.jimmer.sql.kt.KSqlClient")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.asc")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.desc")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.eq")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`eq?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`ge?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`gt?`")
+            if (hasKeywordParams) {
+                appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.ilike")
+            }
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`ilike?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`le?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`like?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`lt?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`ne?`")
+            if (hasKeywordParams) {
+                appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.or")
+            }
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`valueIn?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`valueNotIn?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.expression.`between?`")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.query.KConfigurableRootQuery")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.query.KMutableRootQuery")
+            appendLine("import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable")
+            if (springComponentAvailable) {
+                appendLine("import org.springframework.stereotype.Component")
+                if (hasSourceParams) {
+                    appendLine("import org.babyfish.jimmer.lowquery.runtime.JimmerLowQueryParameterSource")
+                }
+                appendLine("import org.babyfish.jimmer.lowquery.runtime.JimmerLowQueryProvider")
+                appendLine("import kotlin.reflect.KClass")
+            }
+            if (hasKeywordParams) {
+            }
+            entities.flatMap { entity ->
+                listOf(entity.qualifiedName, "${entity.packageName}.fetchBy") +
+                    entity.params.flatMap { param -> param.tableImportNames(entity.packageName) } +
+                    entity.keywordProps.flatMap { keyword -> keyword.tableImportNames(entity.packageName) } +
+                    entity.orderProperties().map { propertyName -> "${entity.packageName}.${propertyName.escapeIdentifier()}" } +
+                    entity.findByProperties().map { propertyName -> "${entity.packageName}.${propertyName.escapeIdentifier()}" } +
+                    entity.expressionImports()
+            }
+                .distinct()
+                .sorted()
+                .forEach { appendLine("import $it") }
+            appendLine()
+            entities.forEachIndexed { index, entity ->
+                val sections = mutableListOf<String>()
+                if (entity.hasLowQuerySurface()) {
+                    sections += entity.buildFunction()
+                    sections += entity.buildApplyParamsFunction()
+                    sections += entity.buildApplyFunction()
+                    sections += entity.buildClientFunction()
+                    if (springComponentAvailable) {
+                        sections += entity.buildSpringProvider()
+                    }
+                }
+                if (entity.findBys.isNotEmpty()) {
+                    sections += entity.buildFindByFunctions()
+                }
+                append(sections.joinToString("\n\n"))
+                if (index != entities.lastIndex) {
+                    appendLine()
+                    appendLine()
+                }
+            }
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildFunction(): String {
+        val parameters = renderQueryParameters()
+        val parameterLines = parameters.joinToString(",\n") { parameter -> "    $parameter" }
+        val orderByLine = buildOrderByLine("    ")
+        val returnType = "KConfigurableRootQuery<KNonNullTable<$simpleName>, $simpleName>"
+        return buildString {
+            appendLine("@JvmName(\"${functionName}For${simpleName}LowQuery\")")
+            if (parameters.isEmpty()) {
+                appendLine("${visibility.code} fun KMutableRootQuery.ForEntity<$simpleName>.${functionName.escapeIdentifier()}(): $returnType {")
+                appendLine("    ${applyParamsFunctionName()}()")
+            } else {
+                appendLine("${visibility.code} fun KMutableRootQuery.ForEntity<$simpleName>.${functionName.escapeIdentifier()}(")
+                appendLine(parameterLines)
+                appendLine("): $returnType {")
+                appendLine("    ${applyParamsFunctionName()}(${buildApplyParamArguments()})")
+            }
+            if (orderByLine != null) {
+                appendLine(orderByLine)
+            }
+            appendLine("    return ${buildSelectExpression()}")
+            append("}")
+        }
+    }
+
+
+    private fun LowQueryEntityMeta.buildApplyParamsFunction(): String {
+        val parameters = renderQueryParameters()
+        val parameterLines = parameters.joinToString(",\n") { parameter -> "    $parameter" }
+        val whereLines = buildList {
+            addAll(params.map { param -> param.buildWhereLine() })
+            buildKeywordWhereBlock("    ", KEYWORD_PARAMETER_NAME)?.let(::add)
+        }.joinToString("\n")
+        return buildString {
+            if (parameters.isEmpty()) {
+                appendLine("public fun KMutableRootQuery.ForEntity<$simpleName>.${applyParamsFunctionName()}() {")
+            } else {
+                appendLine("public fun KMutableRootQuery.ForEntity<$simpleName>.${applyParamsFunctionName()}(")
+                appendLine(parameterLines)
+                appendLine(") {")
+            }
+            if (whereLines.isNotEmpty()) {
+                appendLine(whereLines)
+            }
+            append("}")
+        }
+    }
+
+
+    private fun LowQueryEntityMeta.buildClientFunction(): String {
+        val annotation = "@JvmName(\"${clientFunctionName}For${simpleName}ByEntity\")"
+        val extraParameterLines = renderEntityFunctionPlainParameters()
+        return buildString {
+            appendLine(annotation)
+            appendLine("${clientVisibility.code} fun KSqlClient.${clientFunctionName.escapeIdentifier()}(")
+            appendLine("    entity: $simpleName${if (extraParameterLines.isEmpty()) "" else ","}")
+            extraParameterLines.forEachIndexed { index, parameter ->
+                val suffix = if (index == extraParameterLines.lastIndex) "" else ","
+                appendLine("    $parameter$suffix")
+            }
+            appendLine("): KConfigurableRootQuery<KNonNullTable<$simpleName>, $simpleName> {")
+            appendLine("    return createQuery($simpleName::class) {")
+            appendLine("        applyLowQuery(${buildApplyLowQueryArguments("entity")})")
+            appendLine("        ${buildSelectExpression()}")
+            appendLine("    }")
+            append("}")
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildApplyFunction(): String {
+        val whereLines = buildList {
+            addAll(params.filter { param -> param.entityApplies }.map { param -> param.buildEntityWhereBlock() })
+            if (needsStandaloneKeywordParameter()) {
+                buildKeywordWhereBlock("        ", KEYWORD_PARAMETER_NAME)?.let(::add)
+            }
+        }.joinToString("\n")
+        val orderByLine = buildOrderByLine("    ")
+        val extraParameterLines = renderEntityFunctionPlainParameters()
+        return buildString {
+            appendLine("private fun KMutableRootQuery.ForEntity<$simpleName>.applyLowQuery(")
+            appendLine("    entity: $simpleName${if (extraParameterLines.isEmpty()) "" else ","}")
+            extraParameterLines.forEachIndexed { index, parameter ->
+                val suffix = if (index == extraParameterLines.lastIndex) "" else ","
+                appendLine("    $parameter$suffix")
+            }
+            appendLine(") {")
+            if (whereLines.isNotEmpty()) {
+                appendLine(whereLines)
+            }
+            if (orderByLine != null) {
+                appendLine(orderByLine)
+            }
+            append("}")
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildSpringProvider(): String {
+        val providerName = "${simpleName}JimmerLowQueryProvider"
+        val beanName = "$qualifiedName.$providerName"
+        val parameterMap = params
+            .filterNot { param -> param.isRangeParam() }
+            .joinToString(", ") { param ->
+                "\"${param.propertyName.escapeString()}\" to \"${param.parameterName.escapeString()}\""
+            }
+        val sourceWhereLines = params
+            .filter { param -> param.sourceApplies || param.isRangeParam() }
+            .map { param -> param.buildSourceWhereBlock() }
+            .plus(listOfNotNull(buildSourceKeywordWhereBlock()))
+            .joinToString("\n")
+        return buildString {
+            appendLine("@Component(\"${beanName.escapeString()}\")")
+            appendLine("public class $providerName : JimmerLowQueryProvider<$simpleName> {")
+            appendLine("    override val entityType: KClass<$simpleName> = $simpleName::class")
+            appendLine()
+            appendLine("    override val parameterNames: Map<String, String> = mapOf($parameterMap)")
+            appendLine()
+            appendLine("    override val hasOrderBy: Boolean = ${buildOrderItems().isNotEmpty()}")
+            appendLine()
+            appendLine("    override fun apply(")
+            appendLine("        query: KMutableRootQuery.ForEntity<$simpleName>,")
+            appendLine("        entity: $simpleName")
+            appendLine("    ) {")
+            appendLine("        query.applyLowQuery(entity)")
+            appendLine("    }")
+            if (sourceWhereLines.isNotEmpty()) {
+                appendLine()
+                appendLine("    override fun apply(")
+                appendLine("        query: KMutableRootQuery.ForEntity<$simpleName>,")
+                appendLine("        source: JimmerLowQueryParameterSource")
+                appendLine("    ) {")
+                appendLine("        query.run {")
+                appendLine(sourceWhereLines)
+                appendLine("        }")
+                appendLine("    }")
+            }
+            append("}")
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildSelectExpression(): String {
+        return when (fetcher) {
+            LowQueryFetcher.ALL_SCALAR_FIELDS -> "select(table.fetchBy { allScalarFields() })"
+            LowQueryFetcher.ALL_TABLE_FIELDS -> "select(table.fetchBy { allTableFields() })"
+            LowQueryFetcher.TABLE -> "select(table)"
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildOrderByLine(indent: String): String? {
+        val orderItems = buildOrderItems()
+        if (orderItems.isEmpty()) {
+            return null
+        }
+        val expressions = orderItems.joinToString(", ") { order ->
+            val functionName = when (order.direction) {
+                LowQueryOrderDirection.ASC -> "asc"
+                LowQueryOrderDirection.DESC -> "desc"
+            }
+            "table.${order.propertyName.escapeIdentifier()}.$functionName()"
+        }
+        return "${indent}orderBy($expressions)"
+    }
+
+    private fun LowQueryEntityMeta.buildOrderItems(): List<LowQueryOrderMeta> {
+        if (orders.isNotEmpty()) {
+            return orders
+        }
+        if (!hasIdProperty) {
+            return emptyList()
+        }
+        return listOf(
+            LowQueryOrderMeta(
+                propertyName = "id",
+                direction = LowQueryOrderDirection.DESC,
+                priority = Int.MAX_VALUE,
+            ),
+        )
+    }
+
+    private fun LowQueryEntityMeta.orderProperties(): List<String> {
+        return buildOrderItems().map { order -> order.propertyName }
+    }
+
+    private fun LowQueryEntityMeta.findByProperties(): List<String> {
+        return findBys.flatMap { findBy ->
+            findBy.fields.map { field -> field.propertyName } +
+                findBy.extraFetchFields.map { field -> field.propertyName }
+        }
+    }
+
+    private fun LowQueryEntityMeta.hasLowQuerySurface(): Boolean {
+        return params.isNotEmpty() || orders.isNotEmpty() || keywordProps.isNotEmpty()
+    }
+
+    private fun LowQueryEntityMeta.applyParamsFunctionName(): String = "apply${simpleName}LowQueryParams"
+
+    private fun LowQueryEntityMeta.buildFindByFunctions(): String {
+        return findBys.joinToString("\n\n") { findBy ->
+            buildString {
+                append(findBy.buildListFunction(this@buildFindByFunctions))
+                appendLine()
+                appendLine()
+                append(findBy.buildOneFunction(this@buildFindByFunctions))
+            }
+        }
+    }
+
+    private fun LowQueryFindByMeta.buildListFunction(entity: LowQueryEntityMeta): String {
+        val parameterFields = fields.filterNot { field -> entity.hasFixedExpression(field.propertyName) }
+        val fixedWhereLines = entity.fixedExpressionWhereLines("        ")
+        return buildString {
+            appendLine("@JvmName(\"${listFunctionName}For${entity.simpleName}${buildFindByJvmNameSuffix()}List\")")
+            if (parameterFields.isEmpty()) {
+                appendLine("${visibility.code} fun KSqlClient.${listFunctionName.escapeIdentifier()}(): List<${entity.simpleName}> {")
+            } else {
+                appendLine("${visibility.code} fun KSqlClient.${listFunctionName.escapeIdentifier()}(")
+                parameterFields.forEach { field ->
+                    appendLine("    ${field.parameterName.escapeIdentifier()}: ${field.typeName},")
+                }
+                appendLine("): List<${entity.simpleName}> {")
+            }
+            appendLine("    return executeQuery(${entity.simpleName}::class) {")
+            parameterFields.forEach { field ->
+                appendLine("        where(table.${field.propertyName.escapeIdentifier()} eq ${field.parameterName.escapeIdentifier()})")
+            }
+            fixedWhereLines.forEach { line ->
+                appendLine(line)
+            }
+            buildOrderByLine("        ", entity)?.let { orderByLine ->
+                appendLine(orderByLine)
+            }
+            append(buildSelectBlock("        "))
+            appendLine("    }")
+            append("}")
+        }
+    }
+
+    private fun LowQueryFindByMeta.buildOneFunction(entity: LowQueryEntityMeta): String {
+        val parameterFields = fields.filterNot { field -> entity.hasFixedExpression(field.propertyName) }
+        val fixedWhereLines = entity.fixedExpressionWhereLines("        ")
+        return buildString {
+            appendLine("@JvmName(\"${oneFunctionName}For${entity.simpleName}${buildFindByJvmNameSuffix()}OneOrNull\")")
+            if (parameterFields.isEmpty()) {
+                appendLine("${visibility.code} fun KSqlClient.${oneFunctionName.escapeIdentifier()}(): ${entity.simpleName}? {")
+            } else {
+                appendLine("${visibility.code} fun KSqlClient.${oneFunctionName.escapeIdentifier()}(")
+                parameterFields.forEach { field ->
+                    appendLine("    ${field.parameterName.escapeIdentifier()}: ${field.typeName},")
+                }
+                appendLine("): ${entity.simpleName}? {")
+            }
+            appendLine("    return createQuery(${entity.simpleName}::class) {")
+            parameterFields.forEach { field ->
+                appendLine("        where(table.${field.propertyName.escapeIdentifier()} eq ${field.parameterName.escapeIdentifier()})")
+            }
+            fixedWhereLines.forEach { line ->
+                appendLine(line)
+            }
+            buildOrderByLine("        ", entity)?.let { orderByLine ->
+                appendLine(orderByLine)
+            }
+            append(buildSelectBlock("        "))
+            appendLine("    }.fetchOneOrNull()")
+            append("}")
+        }
+    }
+
+    private fun LowQueryFindByMeta.buildFindBySuffix(): String =
+        fields.joinToString("And") { field -> field.propertyName.replaceFirstChar(Char::uppercase) }
+
+    private fun LowQueryFindByMeta.buildFindByJvmNameSuffix(): String {
+        val suffix = buildFindBySuffix()
+        if (suffix.isBlank()) {
+            return ""
+        }
+        return "By$suffix"
+    }
+
+    private fun LowQueryEntityMeta.hasFixedExpression(propertyName: String): Boolean {
+        return params.any { param ->
+            param.propertyName == propertyName && !param.expression.isNullOrBlank()
+        }
+    }
+
+    private fun LowQueryEntityMeta.fixedExpressionWhereLines(indent: String): List<String> {
+        return params
+            .filter { param -> !param.expression.isNullOrBlank() }
+            .map { param ->
+                "${indent}where(table.${param.propertyName.escapeIdentifier()} eq ${param.expression})"
+            }
+    }
+
+    private fun LowQueryFindByMeta.buildOrderByLine(
+        indent: String,
+        entity: LowQueryEntityMeta,
+    ): String? {
+        val orderItems = entity.buildOrderItems()
+        if (orderItems.isEmpty()) {
+            return null
+        }
+        val expressions = orderItems.joinToString(", ") { order ->
+            val functionName = when (order.direction) {
+                LowQueryOrderDirection.ASC -> "asc"
+                LowQueryOrderDirection.DESC -> "desc"
+            }
+            "table.${order.propertyName.escapeIdentifier()}.$functionName()"
+        }
+        return "${indent}orderBy($expressions)"
+    }
+
+    private fun LowQueryEntityMeta.expressionImports(): List<String> {
+        return params
+            .filter { param -> !param.expression.isNullOrBlank() }
+            .flatMap { param -> param.expressionImports }
+    }
+
+    private fun LowQueryFindByMeta.buildSelectBlock(indent: String): String {
+        val baseFetchLine = when (fetcher) {
+            LowQueryFetcher.ALL_SCALAR_FIELDS -> "allScalarFields()"
+            LowQueryFetcher.ALL_TABLE_FIELDS -> "allTableFields()"
+            LowQueryFetcher.TABLE -> null
+        }
+        if (baseFetchLine == null) {
+            return "${indent}select(table)\n"
+        }
+        if (extraFetchFields.isEmpty()) {
+            return "${indent}select(table.fetchBy { $baseFetchLine })\n"
+        }
+        return buildString {
+            appendLine("${indent}select(table.fetchBy {")
+            appendLine("$indent    $baseFetchLine")
+            extraFetchFields.forEach { field ->
+                when (field.kind) {
+                    LowQueryExtraFetchFieldKind.SCALAR -> appendLine("$indent    ${field.propertyName.escapeIdentifier()}()")
+                    LowQueryExtraFetchFieldKind.ASSOCIATION -> appendLine("$indent    ${field.propertyName.escapeIdentifier()} { allScalarFields() }")
+                }
+            }
+            appendLine("$indent})")
+        }
+    }
+
+    private fun LowQueryParamMeta.buildWhereLine(): String {
+        val parameter = parameterName.escapeIdentifier()
+        val condition = buildTableConditionExpression { property ->
+            when (operator) {
+                LowQueryOperator.EQ -> "$property `eq?` $parameter"
+                LowQueryOperator.NE -> "$property `ne?` $parameter"
+                LowQueryOperator.LIKE -> "$property.`ilike?`($parameter, LikeMode.ANYWHERE)"
+                LowQueryOperator.STARTS_WITH -> "$property.`like?`($parameter, LikeMode.START)"
+                LowQueryOperator.ENDS_WITH -> "$property.`like?`($parameter, LikeMode.END)"
+                LowQueryOperator.GT -> "$property `gt?` $parameter"
+                LowQueryOperator.GE -> "$property `ge?` $parameter"
+                LowQueryOperator.LT -> "$property `lt?` $parameter"
+                LowQueryOperator.LE -> "$property `le?` $parameter"
+                LowQueryOperator.IN -> "$property `valueIn?` $parameter"
+                LowQueryOperator.NOT_IN -> "$property `valueNotIn?` $parameter"
+                LowQueryOperator.BETWEEN -> "$property.`between?`($parameter, ${requiredEndParameterName().escapeIdentifier()})"
+                LowQueryOperator.TIME_RANGE -> {
+                    val start = "$parameter?.getOrNull(0)"
+                    val end = "$parameter?.getOrNull(1)"
+                    "$property.`between?`($start, $end)"
+                }
+            }
+        }
+        return "    where($condition)"
+    }
+
+    private fun LowQueryParamMeta.buildEntityWhereBlock(): String {
+        val entityValue = entityValueExpression()
+        val condition = buildTableConditionExpression { property ->
+            when (operator) {
+                LowQueryOperator.EQ -> "$property `eq?` $entityValue"
+                LowQueryOperator.NE -> "$property `ne?` $entityValue"
+                LowQueryOperator.LIKE -> "$property.`ilike?`($entityValue, LikeMode.ANYWHERE)"
+                LowQueryOperator.STARTS_WITH -> "$property.`like?`($entityValue, LikeMode.START)"
+                LowQueryOperator.ENDS_WITH -> "$property.`like?`($entityValue, LikeMode.END)"
+                LowQueryOperator.GT -> "$property `gt?` $entityValue"
+                LowQueryOperator.GE -> "$property `ge?` $entityValue"
+                LowQueryOperator.LT -> "$property `lt?` $entityValue"
+                LowQueryOperator.LE -> "$property `le?` $entityValue"
+                LowQueryOperator.IN -> "$property `valueIn?` $entityValue"
+                LowQueryOperator.NOT_IN -> "$property `valueNotIn?` $entityValue"
+                LowQueryOperator.BETWEEN -> {
+                    val parameter = parameterName.escapeIdentifier()
+                    val endParameter = requiredEndParameterName().escapeIdentifier()
+                    "$property.`between?`($parameter, $endParameter)"
+                }
+                LowQueryOperator.TIME_RANGE -> {
+                    val parameter = parameterName.escapeIdentifier()
+                    "$property.`between?`($parameter?.getOrNull(0), $parameter?.getOrNull(1))"
+                }
+            }
+        }
+        return buildString {
+            if (operator == LowQueryOperator.BETWEEN || operator == LowQueryOperator.TIME_RANGE) {
+                append("        where($condition)")
+                return@buildString
+            }
+            appendLine("        if (ImmutableObjects.isLoaded(entity, \"${loadedPropertyName.escapeString()}\")) {")
+            appendLine("            where($condition)")
+            append("        }")
+        }
+    }
+
+    private fun LowQueryParamMeta.buildSourceWhereBlock(): String {
+        val parameter = parameterName.escapeIdentifier()
+        return when (operator) {
+            LowQueryOperator.EQ -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `eq?` $parameter" })
+            LowQueryOperator.NE -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `ne?` $parameter" })
+            LowQueryOperator.LIKE -> buildSingleSourceWhereBlock(
+                parameter,
+                buildTableConditionExpression { property -> "$property.`ilike?`($parameter, LikeMode.ANYWHERE)" },
+            )
+            LowQueryOperator.STARTS_WITH -> buildSingleSourceWhereBlock(
+                parameter,
+                buildTableConditionExpression { property -> "$property.`like?`($parameter, LikeMode.START)" },
+            )
+            LowQueryOperator.ENDS_WITH -> buildSingleSourceWhereBlock(
+                parameter,
+                buildTableConditionExpression { property -> "$property.`like?`($parameter, LikeMode.END)" },
+            )
+            LowQueryOperator.GT -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `gt?` $parameter" })
+            LowQueryOperator.GE -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `ge?` $parameter" })
+            LowQueryOperator.LT -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `lt?` $parameter" })
+            LowQueryOperator.LE -> buildSingleSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `le?` $parameter" })
+            LowQueryOperator.IN -> buildCollectionSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `valueIn?` $parameter" })
+            LowQueryOperator.NOT_IN -> buildCollectionSourceWhereBlock(parameter, buildTableConditionExpression { property -> "$property `valueNotIn?` $parameter" })
+            LowQueryOperator.BETWEEN -> {
+                val endName = requiredEndParameterName().escapeIdentifier()
+                val condition = buildTableConditionExpression { property ->
+                    "$property.`between?`($parameter, $endName)"
+                }
+                """
+            val $parameter = source.value("${parameterName.escapeString()}", $targetTypeName::class)
+            val $endName = source.value("${requiredEndParameterName().escapeString()}", $targetTypeName::class)
+            where($condition)""".trimIndent().prependIndent("            ")
+            }
+            LowQueryOperator.TIME_RANGE -> {
+                val condition = buildTableConditionExpression { property ->
+                    "$property.`between?`($parameter.getOrNull(0), $parameter.getOrNull(1))"
+                }
+                """
+            val $parameter = source.values("${parameterName.escapeString()}", $targetTypeName::class)
+            where($condition)""".trimIndent().prependIndent("            ")
+            }
+        }
+    }
+
+    private fun LowQueryEntityMeta.renderQueryParameters(): List<String> {
+        val parameterLines = params.map { param -> param.renderParameter() }.toMutableList()
+        if (needsStandaloneKeywordParameter()) {
+            parameterLines += "$KEYWORD_PARAMETER_NAME: String? = null"
+        }
+        return parameterLines
+    }
+
+    private fun LowQueryEntityMeta.renderEntityFunctionPlainParameters(): List<String> {
+        val parameterLines = params
+            .filter { param -> param.isRangeParam() }
+            .flatMap { param -> param.renderPlainParameters() }
+            .toMutableList()
+        if (needsStandaloneKeywordParameter()) {
+            parameterLines += "$KEYWORD_PARAMETER_NAME: String? = null"
+        }
+        return parameterLines
+    }
+
+    private fun LowQueryEntityMeta.needsStandaloneKeywordParameter(): Boolean {
+        if (keywordProps.isEmpty()) {
+            return false
+        }
+        return params.none { param ->
+            param.parameterName == KEYWORD_PARAMETER_NAME ||
+                param.endParameterName == KEYWORD_PARAMETER_NAME
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildKeywordWhereBlock(
+        indent: String,
+        parameterName: String,
+    ): String? {
+        if (keywordProps.isEmpty()) {
+            return null
+        }
+        val parameter = parameterName.escapeIdentifier()
+        val trimmedName = "${parameterName}Trimmed".escapeIdentifier()
+        val conditions = keywordProps.map { keyword ->
+            keyword.buildTableConditionExpression { property ->
+                "$property.`ilike?`($trimmedName, LikeMode.ANYWHERE)"
+            }
+        }
+        return buildString {
+            appendLine("${indent}val $trimmedName = $parameter?.trim()?.takeIf { it.isNotEmpty() }")
+            appendLine("${indent}if ($trimmedName != null) {")
+            if (conditions.size == 1) {
+                appendLine("${indent}    where(${conditions.single()})")
+            } else {
+                appendLine("${indent}    where(")
+                appendLine("${indent}        or(")
+                conditions.forEachIndexed { index, condition ->
+                    val suffix = if (index == conditions.lastIndex) "" else ","
+                    appendLine("${indent}            $condition$suffix")
+                }
+                appendLine("${indent}        ),")
+                appendLine("${indent}    )")
+            }
+            append("${indent}}")
+        }
+    }
+
+    private fun LowQueryEntityMeta.buildSourceKeywordWhereBlock(): String? {
+        if (keywordProps.isEmpty()) {
+            return null
+        }
+        val keywordWhereBlock = buildKeywordWhereBlock("            ", KEYWORD_PARAMETER_NAME) ?: return null
+        return buildString {
+            appendLine("            val $KEYWORD_PARAMETER_NAME = source.value(\"$KEYWORD_PARAMETER_NAME\", String::class)")
+            append(keywordWhereBlock)
+        }
+    }
+
+    private fun LowQueryParamMeta.buildTableConditionExpression(
+        terminalCondition: (String) -> String,
+    ): String {
+        if (tablePath.size <= 1) {
+            return terminalCondition("table.${tablePath.firstOrNull().orEmpty().escapeIdentifier()}")
+        }
+        return buildTablePathExpression("table", 0, terminalCondition)
+    }
+
+    private fun LowQueryKeywordMeta.buildTableConditionExpression(
+        terminalCondition: (String) -> String,
+    ): String {
+        if (tablePath.size <= 1) {
+            return terminalCondition("table.${tablePath.firstOrNull().orEmpty().escapeIdentifier()}")
+        }
+        return buildTablePathExpression("table", 0, terminalCondition)
+    }
+
+    private fun LowQueryParamMeta.buildTablePathExpression(
+        receiver: String,
+        index: Int,
+        terminalCondition: (String) -> String,
+    ): String {
+        val propertyName = tablePath.getOrNull(index).orEmpty().escapeIdentifier()
+        if (index == tablePath.lastIndex) {
+            return terminalCondition("$receiver.$propertyName")
+        }
+        return when (tablePathKinds.getOrNull(index) ?: LowQueryTablePathKind.REFERENCE) {
+            LowQueryTablePathKind.REFERENCE -> buildTablePathExpression("$receiver.$propertyName", index + 1, terminalCondition)
+            LowQueryTablePathKind.COLLECTION -> "$receiver.$propertyName { ${buildTablePathExpression("this", index + 1, terminalCondition)} }"
+        }
+    }
+
+    private fun LowQueryKeywordMeta.buildTablePathExpression(
+        receiver: String,
+        index: Int,
+        terminalCondition: (String) -> String,
+    ): String {
+        val propertyName = tablePath.getOrNull(index).orEmpty().escapeIdentifier()
+        if (index == tablePath.lastIndex) {
+            return terminalCondition("$receiver.$propertyName")
+        }
+        return when (tablePathKinds.getOrNull(index) ?: LowQueryTablePathKind.REFERENCE) {
+            LowQueryTablePathKind.REFERENCE -> buildTablePathExpression("$receiver.$propertyName", index + 1, terminalCondition)
+            LowQueryTablePathKind.COLLECTION -> "$receiver.$propertyName { ${buildTablePathExpression("this", index + 1, terminalCondition)} }"
+        }
+    }
+
+    private fun LowQueryParamMeta.tableImportNames(entityPackageName: String): List<String> {
+        if (tablePath.isEmpty()) {
+            return emptyList()
+        }
+        return tablePath.distinct().mapIndexed { index, propertyName ->
+            val importPackageName = tablePathImportPackages.getOrNull(index) ?: entityPackageName
+            "$importPackageName.${propertyName.escapeIdentifier()}"
+        }
+    }
+
+    private fun LowQueryKeywordMeta.tableImportNames(entityPackageName: String): List<String> {
+        if (tablePath.isEmpty()) {
+            return emptyList()
+        }
+        return tablePath.distinct().mapIndexed { index, propertyName ->
+            val importPackageName = tablePathImportPackages.getOrNull(index) ?: entityPackageName
+            "$importPackageName.${propertyName.escapeIdentifier()}"
+        }
+    }
+
+    private fun LowQueryParamMeta.buildSingleSourceWhereBlock(
+        localName: String,
+        condition: String,
+    ): String {
+        return """
+            val $localName = source.value("${parameterName.escapeString()}", $targetTypeName::class)
+            where($condition)""".trimIndent().prependIndent("            ")
+    }
+
+    private fun LowQueryParamMeta.buildCollectionSourceWhereBlock(
+        localName: String,
+        condition: String,
+    ): String {
+        return """
+            val $localName = source.values("${parameterName.escapeString()}", $targetTypeName::class)
+            if ($localName.isNotEmpty()) {
+                where($condition)
+            }""".trimIndent().prependIndent("            ")
+    }
+
+    private fun LowQueryParamMeta.entityValueExpression(): String {
+        if (entityValuePath.size <= 1) {
+            val property = "entity.${entityValuePath.firstOrNull().orEmpty().escapeIdentifier()}"
+            return when (operator) {
+                LowQueryOperator.IN,
+                LowQueryOperator.NOT_IN -> "listOfNotNull($property)"
+
+                else -> property
+            }
+        }
+        val property = entityValuePath.entityValueAccessExpression(entityValuePathNullable)
+        return when (operator) {
+            LowQueryOperator.IN,
+            LowQueryOperator.NOT_IN -> "listOfNotNull($property)"
+
+            else -> property
+        }
+    }
+
+    private fun List<String>.entityValueAccessExpression(nullablePath: List<Boolean>): String {
+        val path = this
+        if (path.isEmpty()) {
+            return "entity"
+        }
+        return buildString {
+            append("entity.")
+            append(path.first().escapeIdentifier())
+            path.drop(1).forEachIndexed { index, part ->
+                val previousIsNullable = nullablePath.getOrNull(index) ?: true
+                if (previousIsNullable) {
+                    append("?.")
+                } else {
+                    append(".")
+                }
+                append(part.orEmpty().escapeIdentifier())
+            }
+        }
+    }
+
+    private fun LowQueryParamMeta.renderParameter(): String {
+        val annotations = renderParameterAnnotations()
+        val defaultValue = if (nullable) " = null" else ""
+        val firstParameter = "$annotations${parameterName.escapeIdentifier()}: $typeName$defaultValue"
+        val endName = endParameterName ?: return firstParameter
+        val endType = endTypeName ?: typeName
+        return "$firstParameter,\n    ${endName.escapeIdentifier()}: $endType = null"
+    }
+
+    private fun LowQueryParamMeta.renderPlainParameters(): List<String> {
+        val defaultValue = if (nullable) " = null" else ""
+        val firstParameter = "${parameterName.escapeIdentifier()}: $typeName$defaultValue"
+        val endName = endParameterName ?: return listOf(firstParameter)
+        val endType = endTypeName ?: typeName
+        return listOf(firstParameter, "${endName.escapeIdentifier()}: $endType = null")
+    }
+
+    private fun LowQueryParamMeta.renderParameterAnnotations(): String {
+        if (parameterAnnotations.isEmpty()) {
+            return ""
+        }
+        return parameterAnnotations.joinToString(separator = " ") + " "
+    }
+
+    private fun LowQueryParamMeta.requiredEndParameterName(): String =
+        endParameterName ?: error("范围查询缺少结束参数名：$propertyName")
+
+    private fun LowQueryParamMeta.isRangeParam(): Boolean =
+        operator == LowQueryOperator.BETWEEN || operator == LowQueryOperator.TIME_RANGE
+
+    private fun LowQueryEntityMeta.buildApplyParamArguments(): String {
+        val arguments = params.flatMap { param ->
+            val arguments = mutableListOf(
+                "${param.parameterName.escapeIdentifier()} = ${param.parameterName.escapeIdentifier()}",
+            )
+            val endName = param.endParameterName
+            if (endName != null) {
+                arguments += "${endName.escapeIdentifier()} = ${endName.escapeIdentifier()}"
+            }
+            arguments
+        }.toMutableList()
+        if (needsStandaloneKeywordParameter()) {
+            arguments += "$KEYWORD_PARAMETER_NAME = $KEYWORD_PARAMETER_NAME"
+        }
+        return arguments.joinToString(", ")
+    }
+
+
+    private fun LowQueryEntityMeta.buildApplyLowQueryArguments(entityArgument: String): String {
+        val arguments = mutableListOf(entityArgument)
+        params.filter { it.isRangeParam() }.forEach { param ->
+            arguments += "${param.parameterName.escapeIdentifier()} = ${param.parameterName.escapeIdentifier()}"
+            val endName = param.endParameterName
+            if (endName != null) {
+                arguments += "${endName.escapeIdentifier()} = ${endName.escapeIdentifier()}"
+            }
+        }
+        if (needsStandaloneKeywordParameter()) {
+            arguments += "$KEYWORD_PARAMETER_NAME = $KEYWORD_PARAMETER_NAME"
+        }
+        return arguments.joinToString(", ")
+    }
+
+    private fun String.escapeIdentifier(): String {
+        if (this in KOTLIN_KEYWORDS) {
+            return "`$this`"
+        }
+        return this
+    }
+
+    private fun String.escapeString(): String =
+        replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+
+    private companion object {
+        private const val KEYWORD_PARAMETER_NAME = "keyword"
+
+        private val KOTLIN_KEYWORDS = setOf(
+            "as",
+            "break",
+            "class",
+            "continue",
+            "do",
+            "else",
+            "false",
+            "for",
+            "fun",
+            "if",
+            "in",
+            "interface",
+            "is",
+            "null",
+            "object",
+            "package",
+            "return",
+            "super",
+            "this",
+            "throw",
+            "true",
+            "try",
+            "typealias",
+            "typeof",
+            "val",
+            "var",
+            "when",
+            "while",
+        )
+    }
+}

--- a/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryMeta.kt
+++ b/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryMeta.kt
@@ -1,0 +1,118 @@
+package org.babyfish.jimmer.lowquery.processor
+
+internal enum class LowQueryOperator {
+    EQ,
+    NE,
+    LIKE,
+    STARTS_WITH,
+    ENDS_WITH,
+    GT,
+    GE,
+    LT,
+    LE,
+    IN,
+    NOT_IN,
+    BETWEEN,
+    TIME_RANGE,
+}
+
+internal enum class LowQueryFetcher {
+    ALL_SCALAR_FIELDS,
+    ALL_TABLE_FIELDS,
+    TABLE,
+}
+
+internal enum class LowQueryVisibility(
+    val code: String,
+) {
+    PUBLIC("public"),
+    INTERNAL("internal"),
+    PRIVATE("private"),
+}
+
+internal enum class LowQueryOrderDirection {
+    ASC,
+    DESC,
+}
+
+internal enum class LowQueryTablePathKind {
+    REFERENCE,
+    COLLECTION,
+}
+
+internal enum class LowQueryExtraFetchFieldKind {
+    SCALAR,
+    ASSOCIATION,
+}
+
+internal data class LowQueryParamMeta(
+    val propertyName: String,
+    val parameterName: String,
+    val typeName: String,
+    val targetTypeName: String,
+    val operator: LowQueryOperator,
+    val nullable: Boolean,
+    val tablePropertyName: String = propertyName,
+    val loadedPropertyName: String = propertyName,
+    val entityValuePath: List<String> = listOf(propertyName),
+    val entityValuePathNullable: List<Boolean> = emptyList(),
+    val sourceApplies: Boolean = false,
+    val entityApplies: Boolean = true,
+    val parameterAnnotations: List<String> = emptyList(),
+    val endParameterName: String? = null,
+    val endTypeName: String? = null,
+    val expression: String? = null,
+    val expressionImports: List<String> = emptyList(),
+    val tablePath: List<String> = listOf(tablePropertyName),
+    val tablePathKinds: List<LowQueryTablePathKind> = emptyList(),
+    val tablePathImportPackages: List<String> = emptyList(),
+)
+
+internal data class LowQueryOrderMeta(
+    val propertyName: String,
+    val direction: LowQueryOrderDirection,
+    val priority: Int,
+)
+
+internal data class LowQueryKeywordMeta(
+    val propertyName: String,
+    val tablePath: List<String> = listOf(propertyName),
+    val tablePathKinds: List<LowQueryTablePathKind> = emptyList(),
+    val tablePathImportPackages: List<String> = emptyList(),
+)
+
+internal data class LowQueryFindByFieldMeta(
+    val propertyName: String,
+    val parameterName: String,
+    val typeName: String,
+)
+
+internal data class LowQueryFindByMeta(
+    val fields: List<LowQueryFindByFieldMeta>,
+    val listFunctionName: String,
+    val oneFunctionName: String,
+    val visibility: LowQueryVisibility,
+    val fetcher: LowQueryFetcher,
+    val extraFetchFields: List<LowQueryExtraFetchFieldMeta>,
+)
+
+internal data class LowQueryExtraFetchFieldMeta(
+    val propertyName: String,
+    val kind: LowQueryExtraFetchFieldKind,
+)
+
+internal data class LowQueryEntityMeta(
+    val packageName: String,
+    val simpleName: String,
+    val qualifiedName: String,
+    val functionName: String,
+    val clientFunctionName: String,
+    val visibility: LowQueryVisibility,
+    val clientVisibility: LowQueryVisibility,
+    val fetcher: LowQueryFetcher,
+    val params: List<LowQueryParamMeta>,
+    val orders: List<LowQueryOrderMeta>,
+    val keywordProps: List<LowQueryKeywordMeta> = emptyList(),
+    val hasIdProperty: Boolean = false,
+    val findBys: List<LowQueryFindByMeta> = emptyList(),
+)

--- a/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryProcessorProvider.kt
+++ b/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryProcessorProvider.kt
@@ -1,0 +1,45 @@
+package org.babyfish.jimmer.lowquery.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import org.babyfish.jimmer.lowquery.processor.context.Settings
+
+class JimmerLowQueryProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        Settings.fromOptions(environment.options)
+        return object : SymbolProcessor {
+            private val entities = linkedSetOf<LowQueryEntityMeta>()
+            private var hasErrors = false
+            private var springComponentAvailable = false
+
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                springComponentAvailable = springComponentAvailable || resolver.hasClass(SPRING_COMPONENT_CLASS)
+                val collector = JimmerLowQueryCollector(resolver, environment.logger)
+                val result = collector.collect()
+                entities += result.entities
+                hasErrors = hasErrors || result.hasErrors
+                return result.deferred
+            }
+
+            override fun finish() {
+                if (hasErrors || entities.isEmpty()) {
+                    return
+                }
+                JimmerLowQueryGenerator(environment.codeGenerator)
+                    .generate(entities, Settings.jimmerLowQueryGeneratedPackage, springComponentAvailable)
+            }
+        }
+    }
+
+    private fun Resolver.hasClass(qualifiedName: String): Boolean {
+        val name = getKSNameFromString(qualifiedName)
+        return getClassDeclarationByName(name) != null
+    }
+
+    private companion object {
+        private const val SPRING_COMPONENT_CLASS = "org.springframework.stereotype.Component"
+    }
+}

--- a/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/context/Settings.kt
+++ b/project/jimmer-low-query-processor/src/main/kotlin/org/babyfish/jimmer/lowquery/processor/context/Settings.kt
@@ -1,0 +1,11 @@
+package org.babyfish.jimmer.lowquery.processor.context
+
+object Settings {
+    var jimmerLowQueryGeneratedPackage: String? = null
+        private set
+
+    fun fromOptions(options: Map<String, String>) {
+        jimmerLowQueryGeneratedPackage = options["jimmerLowQuery.generatedPackage"]
+            ?.takeIf(String::isNotBlank)
+    }
+}

--- a/project/jimmer-low-query-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/project/jimmer-low-query-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+org.babyfish.jimmer.lowquery.processor.JimmerLowQueryProcessorProvider

--- a/project/jimmer-low-query-processor/src/test/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryGeneratorTest.kt
+++ b/project/jimmer-low-query-processor/src/test/kotlin/org/babyfish/jimmer/lowquery/processor/JimmerLowQueryGeneratorTest.kt
@@ -1,0 +1,816 @@
+package org.babyfish.jimmer.lowquery.processor
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+
+class JimmerLowQueryGeneratorTest {
+    @Test
+    fun `generator emits typed query extension`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "SystemConfig",
+            qualifiedName = "demo.system.SystemConfig",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PRIVATE,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "configKey",
+                    parameterName = "key",
+                    typeName = "String",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.EQ,
+                    nullable = false,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "package demo.system.generated.lowquery")
+        assertContains(code, "import demo.system.configKey")
+        assertContains(code, "@JvmName(\"queryForSystemConfigLowQuery\")")
+        assertContains(code, "private fun KMutableRootQuery.ForEntity<SystemConfig>.query(")
+        assertContains(code, "key: String")
+        assertContains(code, "applySystemConfigLowQueryParams(key = key)")
+        assertContains(code, "public fun KMutableRootQuery.ForEntity<SystemConfig>.applySystemConfigLowQueryParams(")
+        assertContains(code, "where(table.configKey `eq?` key)")
+        assertContains(code, "return select(table.fetchBy { allScalarFields() })")
+        assertContains(code, "@JvmName(\"createLowQueryForSystemConfigByEntity\")")
+        assertContains(code, "public fun KSqlClient.createLowQuery(")
+        assertContains(code, "entity: SystemConfig")
+        assertContains(code, "private fun KMutableRootQuery.ForEntity<SystemConfig>.applyLowQuery(")
+        assertContains(code, "return createQuery(SystemConfig::class) {")
+        assertContains(code, "applyLowQuery(entity)")
+        assertContains(code, "if (ImmutableObjects.isLoaded(entity, \"configKey\"))")
+        assertContains(code, "where(table.configKey `eq?` entity.configKey)")
+        assertContains(code, "select(table.fetchBy { allScalarFields() })")
+    }
+
+
+    @Test
+    fun `generator defaults to id desc order when entity has id property`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "SystemConfig",
+            qualifiedName = "demo.system.SystemConfig",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "configKey",
+                    parameterName = "key",
+                    typeName = "String?",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                ),
+            ),
+            orders = emptyList(),
+            hasIdProperty = true,
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.system.id")
+        assertContains(code, "orderBy(table.id.desc())")
+        assertContains(code, "override val hasOrderBy: Boolean = true")
+    }
+
+    @Test
+    fun `generator emits spring provider when spring component exists`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "SystemConfig",
+            qualifiedName = "demo.system.SystemConfig",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "configKey",
+                    parameterName = "key",
+                    typeName = "String",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.EQ,
+                    nullable = false,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import org.springframework.stereotype.Component")
+        assertContains(code, "import org.babyfish.jimmer.lowquery.runtime.JimmerLowQueryProvider")
+        assertContains(code, "@Component(\"demo.system.SystemConfig.SystemConfigJimmerLowQueryProvider\")")
+        assertContains(code, "public class SystemConfigJimmerLowQueryProvider : JimmerLowQueryProvider<SystemConfig>")
+        assertContains(code, "override val entityType: KClass<SystemConfig> = SystemConfig::class")
+        assertContains(code, "override val parameterNames: Map<String, String> = mapOf(\"configKey\" to \"key\")")
+        assertContains(code, "query.applyLowQuery(entity)")
+    }
+
+    @Test
+    fun `generator skips nullable condition when null`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.device",
+            simpleName = "Device",
+            qualifiedName = "demo.device.Device",
+            functionName = "queryByName",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_TABLE_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "name",
+                    parameterName = "name",
+                    typeName = "String?",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.LIKE,
+                    nullable = true,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = "demo.generated")
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "package demo.generated")
+        assertContains(code, "name: String? = null")
+        assertContains(code, "where(table.name.`ilike?`(name, LikeMode.ANYWHERE))")
+        assertContains(code, "return select(table.fetchBy { allTableFields() })")
+    }
+
+    @Test
+    fun `generator emits collection parameter for in operator`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "SystemConfig",
+            qualifiedName = "demo.system.SystemConfig",
+            functionName = "queryByIds",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.TABLE,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "id",
+                    parameterName = "ids",
+                    typeName = "Collection<Long>",
+                    targetTypeName = "Long",
+                    operator = LowQueryOperator.IN,
+                    nullable = false,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "ids: Collection<Long>")
+        assertContains(code, "where(table.id `valueIn?` ids)")
+        assertContains(code, "return select(table)")
+    }
+
+    @Test
+    fun `source collection predicate skips missing values`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "SystemUser",
+            qualifiedName = "demo.system.SystemUser",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "roleIds",
+                    parameterName = "roleIds",
+                    typeName = "Collection<Long>?",
+                    targetTypeName = "Long",
+                    operator = LowQueryOperator.IN,
+                    nullable = true,
+                    tablePropertyName = "id",
+                    sourceApplies = true,
+                    tablePath = listOf("roles", "id"),
+                    tablePathKinds = listOf(LowQueryTablePathKind.COLLECTION),
+                    tablePathImportPackages = listOf("demo.system.role"),
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "val roleIds = source.values(\"roleIds\", Long::class)")
+        assertContains(code, "if (roleIds.isNotEmpty())")
+        assertContains(code, "where(table.roles { this.id `valueIn?` roleIds })")
+    }
+
+    @Test
+    fun `generator emits order by expressions`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.power",
+            simpleName = "PowerRuntimeStatus",
+            qualifiedName = "demo.power.PowerRuntimeStatus",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.TABLE,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "code",
+                    parameterName = "code",
+                    typeName = "String?",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                ),
+            ),
+            orders = listOf(
+                LowQueryOrderMeta(
+                    propertyName = "snapshotTime",
+                    direction = LowQueryOrderDirection.DESC,
+                    priority = 0,
+                ),
+                LowQueryOrderMeta(
+                    propertyName = "id",
+                    direction = LowQueryOrderDirection.DESC,
+                    priority = 1,
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.power.snapshotTime")
+        assertContains(code, "import demo.power.id")
+        assertContains(code, "orderBy(table.snapshotTime.desc(), table.id.desc())")
+        assertContains(code, "override val hasOrderBy: Boolean = true")
+    }
+
+    @Test
+    fun `generator emits between and time range predicates`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.notice",
+            simpleName = "Notice",
+            qualifiedName = "demo.notice.Notice",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "createTime",
+                    parameterName = "beginTime",
+                    typeName = "java.time.LocalDateTime?",
+                    targetTypeName = "java.time.LocalDateTime",
+                    operator = LowQueryOperator.BETWEEN,
+                    nullable = true,
+                    endParameterName = "endTime",
+                    endTypeName = "java.time.LocalDateTime?",
+                ),
+                LowQueryParamMeta(
+                    propertyName = "publishedTime",
+                    parameterName = "publishedTime",
+                    typeName = "Array<java.time.LocalDateTime>?",
+                    targetTypeName = "java.time.LocalDateTime",
+                    operator = LowQueryOperator.TIME_RANGE,
+                    nullable = true,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "beginTime: java.time.LocalDateTime? = null")
+        assertContains(code, "endTime: java.time.LocalDateTime? = null")
+        assertContains(code, "publishedTime: Array<java.time.LocalDateTime>? = null")
+        assertContains(code, "applyNoticeLowQueryParams(beginTime = beginTime, endTime = endTime, publishedTime = publishedTime)")
+        assertContains(code, "where(table.createTime.`between?`(beginTime, endTime))")
+        assertContains(code, "where(table.publishedTime.`between?`(publishedTime?.getOrNull(0), publishedTime?.getOrNull(1)))")
+        assertContains(code, "entity: Notice,")
+        assertContains(code, "applyLowQuery(entity, beginTime = beginTime, endTime = endTime, publishedTime = publishedTime)")
+    }
+
+    @Test
+    fun `generator emits default scalar and association id predicates`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.order",
+            simpleName = "Order",
+            qualifiedName = "demo.order.Order",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "status",
+                    parameterName = "status",
+                    typeName = "Int?",
+                    targetTypeName = "Int",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                    sourceApplies = true,
+                ),
+                LowQueryParamMeta(
+                    propertyName = "tenantId",
+                    parameterName = "tenantId",
+                    typeName = "Long?",
+                    targetTypeName = "Long",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                    tablePropertyName = "tenantId",
+                    loadedPropertyName = "tenant",
+                    entityValuePath = listOf("tenant", "id"),
+                    entityValuePathNullable = listOf(false, false),
+                    sourceApplies = true,
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.order.status")
+        assertContains(code, "import demo.order.tenantId")
+        assertContains(code, "status: Int? = null")
+        assertContains(code, "tenantId: Long? = null")
+        assertContains(code, "where(table.status `eq?` status)")
+        assertContains(code, "where(table.tenantId `eq?` tenantId)")
+        assertContains(code, "if (ImmutableObjects.isLoaded(entity, \"tenant\"))")
+        assertContains(code, "where(table.tenantId `eq?` entity.tenant.id)")
+        assertContains(code, "override val parameterNames: Map<String, String> = mapOf(\"status\" to \"status\", \"tenantId\" to \"tenantId\")")
+        assertContains(code, "val status = source.value(\"status\", Int::class)")
+        assertContains(code, "val tenantId = source.value(\"tenantId\", Long::class)")
+    }
+
+    @Test
+    fun `generator emits association id predicate through reference path`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.rule",
+            simpleName = "RuleCondition",
+            qualifiedName = "demo.rule.RuleCondition",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "modelId",
+                    parameterName = "modelId",
+                    typeName = "Long?",
+                    targetTypeName = "Long",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                    tablePropertyName = "modelId",
+                    loadedPropertyName = "thingModel",
+                    entityValuePath = listOf("thingModel", "id"),
+                    entityValuePathNullable = listOf(true, false),
+                    sourceApplies = true,
+                    tablePath = listOf("thingModel", "id"),
+                    tablePathKinds = listOf(LowQueryTablePathKind.REFERENCE),
+                    tablePathImportPackages = listOf("demo.rule", "demo.thingmodel"),
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.rule.thingModel")
+        assertContains(code, "import demo.thingmodel.id")
+        assertContains(code, "modelId: Long? = null")
+        assertContains(code, "where(table.thingModel.id `eq?` modelId)")
+        assertContains(code, "if (ImmutableObjects.isLoaded(entity, \"thingModel\"))")
+        assertContains(code, "where(table.thingModel.id `eq?` entity.thingModel?.id)")
+        assertContains(code, "val modelId = source.value(\"modelId\", Long::class)")
+    }
+
+    @Test
+    fun `generator emits collection path predicate as implicit sub query`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.product",
+            simpleName = "Product",
+            qualifiedName = "demo.product.Product",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "thingModelIdentifier",
+                    parameterName = "thingModelIdentifier",
+                    typeName = "String?",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.LIKE,
+                    nullable = true,
+                    loadedPropertyName = "thingModels",
+                    entityValuePath = listOf("thingModelIdentifier"),
+                    sourceApplies = true,
+                    tablePath = listOf("thingModels", "identifier"),
+                    tablePathKinds = listOf(LowQueryTablePathKind.COLLECTION),
+                    tablePathImportPackages = listOf("demo.product", "demo.thingmodel"),
+                ),
+            ),
+            orders = emptyList(),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.product.thingModels")
+        assertContains(code, "import demo.thingmodel.identifier")
+        assertContains(code, "where(table.thingModels { this.identifier.`ilike?`(thingModelIdentifier, LikeMode.ANYWHERE) })")
+    }
+
+    @Test
+    fun `generator emits keyword predicate for keyword props and associated keyword props`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.dict",
+            simpleName = "DictType",
+            qualifiedName = "demo.dict.DictType",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "type",
+                    parameterName = "type",
+                    typeName = "String?",
+                    targetTypeName = "String",
+                    operator = LowQueryOperator.LIKE,
+                    nullable = true,
+                    sourceApplies = true,
+                ),
+            ),
+            orders = emptyList(),
+            keywordProps = listOf(
+                LowQueryKeywordMeta(
+                    propertyName = "name",
+                ),
+                LowQueryKeywordMeta(
+                    propertyName = "dataList.label",
+                    tablePath = listOf("dataList", "label"),
+                    tablePathKinds = listOf(LowQueryTablePathKind.COLLECTION),
+                    tablePathImportPackages = listOf("demo.dict", "demo.dict"),
+                ),
+                LowQueryKeywordMeta(
+                    propertyName = "dataList.device.name",
+                    tablePath = listOf("dataList", "device", "name"),
+                    tablePathKinds = listOf(LowQueryTablePathKind.COLLECTION, LowQueryTablePathKind.REFERENCE),
+                    tablePathImportPackages = listOf("demo.dict", "demo.record", "demo.device"),
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator)
+            .generate(setOf(entity), generatedPackage = null, springComponentAvailable = true)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import org.babyfish.jimmer.sql.kt.ast.expression.ilike")
+        assertContains(code, "import org.babyfish.jimmer.sql.kt.ast.expression.or")
+        assertContains(code, "import demo.dict.dataList")
+        assertContains(code, "import demo.record.device")
+        assertContains(code, "import demo.dict.label")
+        assertContains(code, "import demo.dict.name")
+        assertContains(code, "import demo.device.name")
+        assertContains(code, "keyword: String? = null")
+        assertContains(code, "applyDictTypeLowQueryParams(type = type, keyword = keyword)")
+        assertContains(code, "val keywordTrimmed = keyword?.trim()?.takeIf { it.isNotEmpty() }")
+        assertContains(code, "table.name.`ilike?`(keywordTrimmed, LikeMode.ANYWHERE)")
+        assertContains(code, "table.dataList { this.label.`ilike?`(keywordTrimmed, LikeMode.ANYWHERE) }")
+        assertContains(code, "table.dataList { this.device.name.`ilike?`(keywordTrimmed, LikeMode.ANYWHERE) }")
+        assertContains(code, "val keyword = source.value(\"keyword\", String::class)")
+    }
+
+    @Test
+    fun `generator emits find by helpers`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.system",
+            simpleName = "User",
+            qualifiedName = "demo.system.User",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = emptyList(),
+            orders = emptyList(),
+            findBys = listOf(
+                LowQueryFindByMeta(
+                    fields = listOf(
+                        LowQueryFindByFieldMeta(
+                            propertyName = "username",
+                            parameterName = "username",
+                            typeName = "String",
+                        ),
+                    ),
+                    listFunctionName = "findUserByUsername",
+                    oneFunctionName = "findOneOrNullUserByUsername",
+                    visibility = LowQueryVisibility.PUBLIC,
+                    fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+                    extraFetchFields = emptyList(),
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.system.User")
+        assertContains(code, "import demo.system.username")
+        assertContains(code, "public fun KSqlClient.findUserByUsername(")
+        assertContains(code, "): List<User> {")
+        assertContains(code, "return executeQuery(User::class) {")
+        assertContains(code, "where(table.username eq username)")
+        assertContains(code, "select(table.fetchBy { allScalarFields() })")
+        assertFalse(code.contains("password()"))
+        assertContains(code, "public fun KSqlClient.findOneOrNullUserByUsername(")
+        assertContains(code, "): User? {")
+        assertContains(code, "return createQuery(User::class) {")
+        assertContains(code, "}.fetchOneOrNull()")
+        assertFalse(code.contains(".firstOrNull()"))
+        assertFalse(code.contains("applyUserLowQueryParams"))
+    }
+
+    @Test
+    fun `generator emits composite find by helpers`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.social",
+            simpleName = "AuthSocialUser",
+            qualifiedName = "demo.social.AuthSocialUser",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = emptyList(),
+            orders = emptyList(),
+            findBys = listOf(
+                LowQueryFindByMeta(
+                    fields = listOf(
+                        LowQueryFindByFieldMeta(
+                            propertyName = "type",
+                            parameterName = "type",
+                            typeName = "Int",
+                        ),
+                        LowQueryFindByFieldMeta(
+                            propertyName = "code",
+                            parameterName = "code",
+                            typeName = "String",
+                        ),
+                        LowQueryFindByFieldMeta(
+                            propertyName = "state",
+                            parameterName = "state",
+                            typeName = "String",
+                        ),
+                    ),
+                    listFunctionName = "findAuthSocialUserByTypeAndCodeAndState",
+                    oneFunctionName = "findOneOrNullAuthSocialUserByTypeAndCodeAndState",
+                    visibility = LowQueryVisibility.PUBLIC,
+                    fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+                    extraFetchFields = emptyList(),
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.social.type")
+        assertContains(code, "import demo.social.code")
+        assertContains(code, "import demo.social.state")
+        assertContains(code, "@JvmName(\"findAuthSocialUserByTypeAndCodeAndStateForAuthSocialUserByTypeAndCodeAndStateList\")")
+        assertContains(code, "public fun KSqlClient.findAuthSocialUserByTypeAndCodeAndState(")
+        assertContains(code, "type: Int")
+        assertContains(code, "code: String")
+        assertContains(code, "state: String")
+        assertContains(code, "where(table.type eq type)")
+        assertContains(code, "where(table.code eq code)")
+        assertContains(code, "where(table.state eq state)")
+        assertContains(code, "public fun KSqlClient.findOneOrNullAuthSocialUserByTypeAndCodeAndState(")
+        assertContains(code, "}.fetchOneOrNull()")
+    }
+
+    @Test
+    fun `generator emits find by helper constant eq predicates and entity order by`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.dict",
+            simpleName = "DictData",
+            qualifiedName = "demo.dict.DictData",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "status",
+                    parameterName = "status",
+                    typeName = "Int?",
+                    targetTypeName = "Int",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                    expression = "CommonStatusEnum.ENABLE.status",
+                    expressionImports = listOf("demo.common.CommonStatusEnum"),
+                ),
+            ),
+            orders = listOf(
+                LowQueryOrderMeta(
+                    propertyName = "sort",
+                    direction = LowQueryOrderDirection.ASC,
+                    priority = 0,
+                ),
+            ),
+            findBys = listOf(
+                LowQueryFindByMeta(
+                    fields = listOf(
+                        LowQueryFindByFieldMeta(
+                            propertyName = "dictType",
+                            parameterName = "dictType",
+                            typeName = "String",
+                        ),
+                    ),
+                    listFunctionName = "findDictDataByDictType",
+                    oneFunctionName = "findOneOrNullDictDataByDictType",
+                    visibility = LowQueryVisibility.PUBLIC,
+                    fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+                    extraFetchFields = emptyList(),
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.common.CommonStatusEnum")
+        assertContains(code, "import demo.dict.dictType")
+        assertContains(code, "import demo.dict.sort")
+        assertContains(code, "import demo.dict.status")
+        assertContains(code, "where(table.dictType eq dictType)")
+        assertContains(code, "where(table.status eq CommonStatusEnum.ENABLE.status)")
+        assertContains(code, "orderBy(table.sort.asc())")
+        assertContains(code, "select(table.fetchBy { allScalarFields() })")
+    }
+
+    @Test
+    fun `generator emits no arg find by helper when field has constant eq expression`() {
+        val codeGenerator = RecordingCodeGenerator()
+        val entity = LowQueryEntityMeta(
+            packageName = "demo.project",
+            simpleName = "IotProjectDO",
+            qualifiedName = "demo.project.IotProjectDO",
+            functionName = "query",
+            clientFunctionName = "createLowQuery",
+            visibility = LowQueryVisibility.PUBLIC,
+            clientVisibility = LowQueryVisibility.PUBLIC,
+            fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+            params = listOf(
+                LowQueryParamMeta(
+                    propertyName = "status",
+                    parameterName = "status",
+                    typeName = "Int?",
+                    targetTypeName = "Int",
+                    operator = LowQueryOperator.EQ,
+                    nullable = true,
+                    expression = "CommonStatusEnum.ENABLE.status",
+                    expressionImports = listOf("demo.common.CommonStatusEnum"),
+                ),
+            ),
+            orders = emptyList(),
+            hasIdProperty = true,
+            findBys = listOf(
+                LowQueryFindByMeta(
+                    fields = listOf(
+                        LowQueryFindByFieldMeta(
+                            propertyName = "status",
+                            parameterName = "status",
+                            typeName = "Int",
+                        ),
+                    ),
+                    listFunctionName = "findIotProjectDOByStatus",
+                    oneFunctionName = "findOneOrNullIotProjectDOByStatus",
+                    visibility = LowQueryVisibility.PUBLIC,
+                    fetcher = LowQueryFetcher.ALL_SCALAR_FIELDS,
+                    extraFetchFields = emptyList(),
+                ),
+            ),
+        )
+
+        JimmerLowQueryGenerator(codeGenerator).generate(setOf(entity), generatedPackage = null)
+
+        val code = codeGenerator.generated.values.single().toString(Charsets.UTF_8.name())
+        assertContains(code, "import demo.common.CommonStatusEnum")
+        assertContains(code, "import demo.project.id")
+        assertContains(code, "import demo.project.status")
+        assertContains(code, "public fun KSqlClient.findIotProjectDOByStatus(): List<IotProjectDO> {")
+        assertFalse(code.contains("public fun KSqlClient.findIotProjectDOByStatus(\n    status: Int,"))
+        assertContains(code, "where(table.status eq CommonStatusEnum.ENABLE.status)")
+        assertContains(code, "orderBy(table.id.desc())")
+        assertContains(code, "select(table.fetchBy { allScalarFields() })")
+    }
+}
+
+private class RecordingCodeGenerator : CodeGenerator {
+    val generated = linkedMapOf<String, ByteArrayOutputStream>()
+
+    override val generatedFile: Collection<java.io.File>
+        get() = emptyList()
+
+    override fun createNewFile(
+        dependencies: Dependencies,
+        packageName: String,
+        fileName: String,
+        extensionName: String,
+    ): OutputStream {
+        val stream = ByteArrayOutputStream()
+        generated["$packageName.$fileName.$extensionName"] = stream
+        return stream
+    }
+
+    override fun createNewFileByPath(
+        dependencies: Dependencies,
+        path: String,
+        extensionName: String,
+    ): OutputStream {
+        val stream = ByteArrayOutputStream()
+        generated["$path.$extensionName"] = stream
+        return stream
+    }
+
+    override fun associate(
+        sources: List<com.google.devtools.ksp.symbol.KSFile>,
+        packageName: String,
+        fileName: String,
+        extensionName: String,
+    ) = Unit
+
+    override fun associateByPath(
+        sources: List<com.google.devtools.ksp.symbol.KSFile>,
+        path: String,
+        extensionName: String,
+    ) = Unit
+
+    override fun associateWithClasses(
+        classes: List<com.google.devtools.ksp.symbol.KSClassDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String,
+    ) = Unit
+}

--- a/project/settings.gradle.kts
+++ b/project/settings.gradle.kts
@@ -13,6 +13,8 @@ include(
     "jimmer-dto-compiler",
     "jimmer-client-swagger",
     "jimmer-client-scalar",
+    "jimmer-low-query-annotations",
+    "jimmer-low-query-processor",
 )
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Summary

Adds a low-query KSP processor for Kotlin Jimmer entities.

- Adds `jimmer-low-query-annotations` with query annotations and the optional runtime provider SPI.
- Adds `jimmer-low-query-processor` to generate typed query extensions, entity-driven `KSqlClient.createLowQuery(...)` helpers, Spring providers, keyword search, ordering, range predicates, association-id predicates, and `findBy` helpers.
- Registers the new artifacts in settings and the BOM.
- Documents usage in `project/jimmer-low-query-processor/README.md`.

## Tests

```bash
./gradlew :jimmer-low-query-annotations:compileKotlin :jimmer-low-query-processor:test
```
