### PR TITLE
Add Jimmer DDL compiler

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+addzero = "2026.06.24"
 antlr = "4.13.0"
 buildconfig = "5.3.5"
 caffeine = "2.9.1"
@@ -34,6 +35,22 @@ swaggerUi = "5.31.0"
 scalar = "0.5.47"
 
 [libraries]
+
+addzero-lsi-core = { group = "site.addzero", name = "lsi-core", version.ref = "addzero" }
+addzero-lsi-ksp = { group = "site.addzero", name = "lsi-ksp", version.ref = "addzero" }
+addzero-lsi-apt = { group = "site.addzero", name = "lsi-apt", version.ref = "addzero" }
+addzero-ddlgenerator-core = { group = "site.addzero", name = "ddlgenerator-core", version.ref = "addzero" }
+addzero-ddlgenerator-lsi-adaptor = { group = "site.addzero", name = "ddlgenerator-lsi-adaptor", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-mysql = { group = "site.addzero", name = "ddlgenerator-dialect-mysql", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-postgresql = { group = "site.addzero", name = "ddlgenerator-dialect-postgresql", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-h2 = { group = "site.addzero", name = "ddlgenerator-dialect-h2", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-sqlite = { group = "site.addzero", name = "ddlgenerator-dialect-sqlite", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-sqlserver = { group = "site.addzero", name = "ddlgenerator-dialect-sqlserver", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-oracle = { group = "site.addzero", name = "ddlgenerator-dialect-oracle", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-dm = { group = "site.addzero", name = "ddlgenerator-dialect-dm", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-kingbase = { group = "site.addzero", name = "ddlgenerator-dialect-kingbase", version.ref = "addzero" }
+addzero-ddlgenerator-dialect-taos = { group = "site.addzero", name = "ddlgenerator-dialect-taos", version.ref = "addzero" }
+addzero-tool-database-model = { group = "site.addzero", name = "tool-database-model", version.ref = "addzero" }
 antlr = { group = "org.antlr", name = "antlr4", version.ref = "antlr" }
 
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }

--- a/project/jimmer-bom/build.gradle.kts
+++ b/project/jimmer-bom/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         api(projects.jimmerCore)
         api(projects.jimmerCoreKotlin)
         api(projects.jimmerDtoCompiler)
+        api(projects.jimmerDdlCompiler)
         api(projects.jimmerKsp)
         api(projects.jimmerMapstructApt)
         api(projects.jimmerSpringBootStarter)

--- a/project/jimmer-ddl-compiler/README.md
+++ b/project/jimmer-ddl-compiler/README.md
@@ -1,0 +1,76 @@
+# Jimmer DDL Compiler
+
+Jimmer DDL Compiler is a compile-time DDL generator for Jimmer entities. It can run as either a Kotlin KSP processor or a Java APT processor, convert Jimmer entity metadata into the LSI model, and render dialect-specific schema SQL.
+
+## Module
+
+- `jimmer-ddl-compiler`: processor artifact containing the KSP provider, APT provider, DDL compiler, schema snapshot handling, and tests.
+
+## Gradle usage
+
+Kotlin/KSP:
+
+```kotlin
+dependencies {
+    ksp("org.babyfish.jimmer:jimmer-ddl-compiler:<jimmer-version>")
+}
+
+ksp {
+    arg("jimmerDdl.enabled", "true")
+    arg("jimmerDdl.databaseType", "postgresql")
+    arg("jimmerDdl.outputFormat", "flyway")
+    arg("jimmerDdl.outputDir", "$projectDir/build/generated/jimmer-ddl/main/resources/db/migration")
+    arg("jimmerDdl.version", "1001")
+    arg("jimmerDdl.description", "jimmer_auto_ddl_generated")
+}
+```
+
+Java/APT:
+
+```kotlin
+dependencies {
+    annotationProcessor("org.babyfish.jimmer:jimmer-ddl-compiler:<jimmer-version>")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-AjimmerDdl.enabled=true")
+    options.compilerArgs.add("-AjimmerDdl.databaseType=postgresql")
+}
+```
+
+## Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `jimmerDdl.enabled` | `true` | Enables or disables generation. |
+| `jimmerDdl.profiles` | empty | Comma-separated profile names. Each profile can override options through `jimmerDdl.profile.<name>.<option>`. |
+| `jimmerDdl.databaseType` | `auto` | Dialect code such as `postgresql`, `mysql`, `h2`, `sqlite`, `sqlserver`, `oracle`, `dm`, `kingbase`, or `taos`. `auto` resolves from JDBC URL when available. |
+| `jimmerDdl.outputFormat` | `flyway` | `flyway` writes `V<version>__<description>.sql`; `plain` writes `<description>.sql`. |
+| `jimmerDdl.outputDir` | `build/generated/jimmer-ddl/main/resources/db/migration` | Output directory for generated SQL. |
+| `jimmerDdl.version` | `1001` | Flyway version prefix. |
+| `jimmerDdl.description` | `jimmer_auto_ddl_generated` | Output file description. |
+| `jimmerDdl.includePackages` | empty | Optional comma-separated package allow-list. |
+| `jimmerDdl.excludePackages` | empty | Optional comma-separated package deny-list. |
+| `jimmerDdl.includeForeignKeys` | `true` | Generates foreign key statements when the dialect supports them. |
+| `jimmerDdl.includeIndexes` | `true` | Generates index statements. |
+| `jimmerDdl.includeComments` | `true` | Generates comments. |
+| `jimmerDdl.includeSequences` | `true` | Generates sequences. |
+| `jimmerDdl.includeManyToManyTables` | `true` | Generates Jimmer many-to-many junction tables. |
+| `jimmerDdl.compareDatabase` | `true` | Reads the configured database and emits diff SQL. If the database cannot be read, it falls back to offline DDL. |
+| `jimmerDdl.nullabilityRepairOnly` | `false` | Limits risky offline alteration planning to nullability repair. |
+| `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored in the snapshot. |
+| `jimmerDdl.jdbcUrl` / `jdbcUsername` / `jdbcPassword` / `jdbcSchema` / `jdbcDriver` | empty | Explicit JDBC settings used by database comparison. |
+| `jimmerDdl.springResourcePath` | empty | Optional Spring resource path used to discover datasource settings. |
+| `jimmerDdl.springProfile` | `local` | Spring profile used when reading YAML datasource settings. |
+
+## Snapshot model
+
+The compiler writes a generated snapshot to `build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties`. The snapshot records entity-to-table mappings and table hashes so subsequent builds can emit incremental SQL, including table renames caused by `@Table(name = ...)` changes.
+
+## Tests
+
+Run the focused test suite from the `project` directory:
+
+```bash
+./gradlew :jimmer-ddl-compiler:test
+```

--- a/project/jimmer-ddl-compiler/build.gradle.kts
+++ b/project/jimmer-ddl-compiler/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    `kotlin-convention`
+    `dokka-convention`
+}
+
+dependencies {
+    implementation(libs.addzero.lsi.core)
+    implementation(libs.addzero.lsi.ksp)
+    implementation(libs.addzero.lsi.apt)
+    implementation(libs.addzero.ddlgenerator.core)
+    implementation(libs.addzero.ddlgenerator.lsi.adaptor)
+    implementation(libs.addzero.ddlgenerator.dialect.mysql)
+    implementation(libs.addzero.ddlgenerator.dialect.postgresql)
+    implementation(libs.addzero.ddlgenerator.dialect.h2)
+    implementation(libs.addzero.ddlgenerator.dialect.sqlite)
+    implementation(libs.addzero.ddlgenerator.dialect.sqlserver)
+    implementation(libs.addzero.ddlgenerator.dialect.oracle)
+    implementation(libs.addzero.ddlgenerator.dialect.dm)
+    implementation(libs.addzero.ddlgenerator.dialect.kingbase)
+    implementation(libs.addzero.ddlgenerator.dialect.taos)
+    implementation(libs.addzero.tool.database.model)
+    implementation(libs.ksp.symbolProcessing.api)
+
+    testImplementation(libs.kotlin.test)
+}
+
+tasks.test {
+    useJUnit()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-Xskip-metadata-version-check")
+    }
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompiler.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompiler.kt
@@ -1,0 +1,492 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.ddlgenerator.core.dialect.AutoDdlDialects
+import site.addzero.ddlgenerator.core.diff.AddComment
+import site.addzero.ddlgenerator.core.diff.AddForeignKey
+import site.addzero.ddlgenerator.core.diff.AlterColumn
+import site.addzero.ddlgenerator.core.diff.AutoDdlOperation
+import site.addzero.ddlgenerator.core.diff.CreateIndex
+import site.addzero.ddlgenerator.core.diff.CreateSequence
+import site.addzero.ddlgenerator.core.diff.CreateTable
+import site.addzero.ddlgenerator.core.diff.SchemaDiffPlanner
+import site.addzero.ddlgenerator.core.model.AutoDdlColumn
+import site.addzero.ddlgenerator.core.model.AutoDdlComment
+import site.addzero.ddlgenerator.core.model.AutoDdlCommentTargetType
+import site.addzero.ddlgenerator.core.model.AutoDdlLogicalType
+import site.addzero.ddlgenerator.core.model.AutoDdlSchema
+import site.addzero.ddlgenerator.core.model.AutoDdlTable
+import site.addzero.ddlgenerator.core.options.AutoDdlDiffOptions
+import site.addzero.ddlgenerator.lsi.LsiAutoDdlSchemaAdapter
+import site.addzero.lsi.clazz.LsiClass
+import site.addzero.lsi.field.LsiField
+import site.addzero.util.db.DatabaseType
+
+object JimmerDdlCompiler {
+    fun compile(
+        classes: Collection<LsiClass>,
+        settings: JimmerDdlCompilerSettings,
+        relationTargetClasses: Collection<LsiClass> = classes,
+    ): JimmerDdlCompilerResult {
+        if (!settings.enabled) {
+            return JimmerDdlCompilerResult.empty(settings)
+        }
+
+        val entities = classes.toJimmerDdlLsiClasses()
+            .filter { it.isJimmerEntity() }
+            .filter { settings.includesClass(it.qualifiedName) }
+            .distinctBy { it.qualifiedName ?: it.simpleName.orEmpty() }
+            .sortedBy { it.qualifiedName ?: it.simpleName.orEmpty() }
+        if (entities.isEmpty()) {
+            return JimmerDdlCompilerResult.empty(settings)
+        }
+        val relationTargetEntities = relationTargetClasses.toJimmerDdlLsiClasses()
+            .filter { it.isJimmerEntity() }
+            .distinctBy { it.qualifiedName ?: it.simpleName.orEmpty() }
+            .sortedBy { it.qualifiedName ?: it.simpleName.orEmpty() }
+
+        val schema = buildSchema(
+            entities = entities,
+            relationTargetEntities = relationTargetEntities,
+            settings = settings,
+        )
+        val changePlan = JimmerDdlEntityTableSnapshot.planSchemaChanges(
+            entities = entities,
+            schema = schema,
+            settings = settings,
+        )
+        if (!settings.compareDatabase && !changePlan.hasChanges) {
+            return JimmerDdlCompilerResult.empty(
+                settings = settings,
+                entities = entities,
+                schema = schema,
+            )
+        }
+
+        val plan = generateDdl(
+            schema = schema,
+            changePlan = changePlan,
+            settings = settings,
+        )
+        val sql = plan.statements.joinToString(separator = "\n")
+            .trim()
+            .let { content ->
+                if (content.isBlank()) {
+                    content
+                } else {
+                    content + "\n"
+                }
+            }
+        return JimmerDdlCompilerResult(
+            settings = settings,
+            entities = entities,
+            schema = schema,
+            snapshotSchema = plan.snapshotSchema,
+            statements = plan.statements,
+            sql = sql,
+            warnings = plan.warnings,
+        )
+    }
+
+    private fun generateDdl(
+        schema: AutoDdlSchema,
+        changePlan: JimmerDdlSchemaChangePlan,
+        settings: JimmerDdlCompilerSettings,
+    ): JimmerDdlCompilePlan {
+        val renameOperations = changePlan.renameOperations
+        val operationPlan = if (settings.compareDatabase && settings.jdbc.url.isNotBlank()) {
+            generateComparedOperations(
+                schema = schema,
+                settings = settings,
+                renamedTables = renameOperations.associate { operation ->
+                    operation.newTableName.lowercase() to operation.oldTableName
+                },
+            )
+        } else {
+            buildOfflineIncrementalOperationPlan(
+                schema = schema,
+                changePlan = changePlan,
+                settings = settings,
+            )
+        }
+        val renamedTableNames = renameOperations.map { operation -> operation.newTableName.lowercase() }.toSet()
+        val operations = operationPlan.operations.filterNot { operation ->
+            operation is CreateTable && operation.table.name.lowercase() in renamedTableNames
+        }
+        val statements = buildRenameTableStatements(renameOperations, settings) +
+            AutoDdlDialects.require(settings.databaseType).render(operations) +
+            buildPostgreSqlNullabilityRepairStatements(schema, settings)
+        return JimmerDdlCompilePlan(
+            statements = statements,
+            snapshotSchema = operationPlan.snapshotSchema ?: schema,
+            warnings = operationPlan.warnings,
+        )
+    }
+
+    private fun buildOfflineIncrementalOperationPlan(
+        schema: AutoDdlSchema,
+        changePlan: JimmerDdlSchemaChangePlan,
+        settings: JimmerDdlCompilerSettings,
+    ): JimmerDdlOperationPlan {
+        val diffSchema = schema.filterTables(changePlan.changedTableNames)
+        val operations = buildOfflineIncrementalOperations(
+            schema = diffSchema,
+            changePlan = changePlan,
+            settings = settings,
+        )
+        return JimmerDdlOperationPlan(
+            operations = operations,
+            snapshotSchema = schema,
+        )
+    }
+
+    private fun generateComparedOperations(
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+        renamedTables: Map<String, String>,
+    ): JimmerDdlOperationPlan {
+        return runCatching {
+            val actualSchema = JimmerDdlDatabaseSchemaReader.read(
+                settings = settings,
+                desiredSchema = schema,
+                renamedTables = renamedTables,
+            )
+            val operations = SchemaDiffPlanner.plan(
+                schema,
+                actualSchema,
+                AutoDdlDiffOptions(settings.options, true, emptyList(), emptyList())
+            )
+            JimmerDdlOperationPlan(operations = operations)
+        }.getOrElse { cause ->
+            JimmerDdlOperationPlan(
+                operations = buildOfflineOperations(schema, settings),
+                warnings = listOf("Jimmer DDL database comparison failed; fallback to offline DDL generation: ${cause.message ?: cause::class.qualifiedName}"),
+            )
+        }
+    }
+
+    private fun buildSchema(
+        entities: List<LsiClass>,
+        relationTargetEntities: List<LsiClass>,
+        settings: JimmerDdlCompilerSettings,
+    ): AutoDdlSchema {
+        val baseSchema = LsiAutoDdlSchemaAdapter.from(entities)
+        val junctionTables = if (settings.includeManyToManyTables) {
+            scanManyToManyTables(entities, relationTargetEntities)
+        } else {
+            emptyList()
+        }
+        return AutoDdlSchema(
+            (baseSchema.tables + junctionTables).distinctBy { table -> table.name.lowercase() },
+            baseSchema.sequences,
+        )
+    }
+
+    private fun scanManyToManyTables(
+        entities: List<LsiClass>,
+        relationTargetEntities: List<LsiClass>,
+    ): List<AutoDdlTable> {
+        val relationTargetByQualifiedName = relationTargetEntities
+            .mapNotNull { entity -> entity.qualifiedName?.takeIf { it.isNotBlank() }?.let { it to entity } }
+            .toMap()
+        val relationTargetBySimpleName = relationTargetEntities
+            .mapNotNull { entity -> entity.simpleName?.takeIf { it.isNotBlank() }?.let { it to entity } }
+            .toMap()
+        return entities.flatMap { entity ->
+            val ownerIdField = entity.findIdField() ?: return@flatMap emptyList()
+            entity.allDdlFields()
+                .filter { field -> field.hasAnnotation("org.babyfish.jimmer.sql.ManyToMany", "ManyToMany") }
+                .mapNotNull { field ->
+                    val targetType = field.type?.typeParameters?.firstOrNull() ?: field.type
+                    val targetClass = targetType?.lsiClass ?: field.fieldTypeClass
+                    ?: targetType?.qualifiedName?.let(relationTargetByQualifiedName::get)
+                    ?: targetType?.simpleName?.let(relationTargetBySimpleName::get)
+                    ?: return@mapNotNull null
+                    val targetIdField = targetClass.findIdField() ?: return@mapNotNull null
+                    val fieldName = field.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                    val ownerName = entity.simpleName.orEmpty().toSnakeCase()
+                    val targetName = targetClass.simpleName.orEmpty().toSnakeCase()
+                    val leftColumnName = "${ownerName}_id"
+                    val rightColumnName = "${targetName}_id"
+                    AutoDdlTable(
+                        "${ownerName}_${fieldName.toSnakeCase()}_mapping",
+                        listOf(
+                            AutoDdlColumn(leftColumnName, ownerIdField.toLogicalType(), false, null, null, null, null, null, false, false, null, null),
+                            AutoDdlColumn(rightColumnName, targetIdField.toLogicalType(), false, null, null, null, null, null, false, false, null, null),
+                        ),
+                        emptyList(),
+                        emptyList(),
+                        null,
+                        null,
+                    )
+                }
+        }
+    }
+
+    private fun LsiClass.allDdlFields(): List<LsiField> {
+        val inherited = (superClasses + interfaces).flatMap { parent -> parent.allDdlFields() }
+        return inherited + fields
+    }
+
+    private fun LsiClass.findIdField(): LsiField? {
+        return allDdlFields().firstOrNull { field -> field.hasAnnotation("org.babyfish.jimmer.sql.Id", "Id") }
+    }
+
+    private fun LsiField.hasAnnotation(
+        qualifiedName: String,
+        simpleName: String,
+    ): Boolean {
+        return annotations.any { annotation -> annotation.qualifiedName == qualifiedName || annotation.simpleName == simpleName }
+    }
+
+    private fun LsiField.toLogicalType(): AutoDdlLogicalType {
+        return when (typeName ?: type?.simpleName) {
+            "Byte" -> AutoDdlLogicalType.INT8
+            "Short" -> AutoDdlLogicalType.INT16
+            "Int", "Integer" -> AutoDdlLogicalType.INT32
+            "Long" -> AutoDdlLogicalType.INT64
+            "Float" -> AutoDdlLogicalType.FLOAT32
+            "Double" -> AutoDdlLogicalType.FLOAT64
+            "Boolean" -> AutoDdlLogicalType.BOOLEAN
+            else -> AutoDdlLogicalType.STRING
+        }
+    }
+
+    private fun LsiClass.guessJimmerTableName(): String {
+        val tableName = annotations.firstNotNullOfOrNull { annotation ->
+            if (annotation.qualifiedName != "org.babyfish.jimmer.sql.Table" && annotation.simpleName != "Table") {
+                return@firstNotNullOfOrNull null
+            }
+            annotation.getAttribute("name")?.toString()?.takeIf { it.isNotBlank() }
+        }
+        return tableName ?: simpleName.orEmpty().toSnakeCase()
+    }
+
+    private fun buildOfflineOperations(
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ): List<AutoDdlOperation> {
+        return buildList {
+            if (settings.options.includeSequences) {
+                schema.sequences.forEach { sequence ->
+                    add(CreateSequence(sequence))
+                }
+            }
+
+            schema.tables.forEach { table ->
+                add(CreateTable(table))
+            }
+
+            if (settings.options.includeIndexes) {
+                schema.tables.forEach { table ->
+                    table.indexes.forEach { index ->
+                        add(CreateIndex(table.name, index))
+                    }
+                }
+            }
+
+            if (settings.options.includeForeignKeys) {
+                schema.tables.forEach { table ->
+                    table.foreignKeys.forEach { foreignKey ->
+                        add(AddForeignKey(table.name, foreignKey))
+                    }
+                }
+            }
+
+            if (settings.options.includeComments) {
+                schema.tables.forEach { table ->
+                    val tableComment = table.comment
+                    if (!tableComment.isNullOrBlank()) {
+                        add(
+                            AddComment(
+                                AutoDdlComment(
+                                    AutoDdlCommentTargetType.TABLE,
+                                    tableComment,
+                                    table.name,
+                                    null,
+                                    null,
+                                )
+                            )
+                        )
+                    }
+                    table.columns
+                        .filter { column -> !column.comment.isNullOrBlank() }
+                        .forEach { column ->
+                            add(
+                                AddComment(
+                                    AutoDdlComment(
+                                        AutoDdlCommentTargetType.COLUMN,
+                                        column.comment.orEmpty(),
+                                        table.name,
+                                        column.name,
+                                        null,
+                                    )
+                                )
+                            )
+                        }
+                }
+            }
+        }
+    }
+
+    private fun buildOfflineIncrementalOperations(
+        schema: AutoDdlSchema,
+        changePlan: JimmerDdlSchemaChangePlan,
+        settings: JimmerDdlCompilerSettings,
+    ): List<AutoDdlOperation> {
+        val previousSchema = changePlan.previous.toSchemaFor(
+            schema = schema,
+            renameOperations = changePlan.renameOperations,
+        )
+        if (previousSchema.tables.isEmpty() && previousSchema.sequences.isEmpty()) {
+            return buildOfflineOperations(schema, settings)
+        }
+        return SchemaDiffPlanner.plan(
+            schema,
+            previousSchema,
+            AutoDdlDiffOptions(settings.options, true, emptyList(), emptyList())
+        )
+    }
+
+    private fun buildRenameTableStatements(
+        renameOperations: List<RenameTable>,
+        settings: JimmerDdlCompilerSettings,
+    ): List<String> {
+        return renameOperations.map { operation ->
+            when (settings.databaseType) {
+                DatabaseType.SQLSERVER -> "EXEC sp_rename '${operation.oldTableName}', '${operation.newTableName}';"
+                else -> "ALTER TABLE ${quoteIdentifier(operation.oldTableName, settings.databaseType)} RENAME TO ${quoteIdentifier(operation.newTableName, settings.databaseType)};"
+            }
+        }
+    }
+
+    private fun buildPostgreSqlNullabilityRepairStatements(
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ): List<String> {
+        if (settings.databaseType != DatabaseType.POSTGRESQL) {
+            return emptyList()
+        }
+        return schema.tables.flatMap { table ->
+            table.columns
+                .filter { column -> column.nullable }
+                .map { column ->
+                    "ALTER TABLE ${quoteIdentifier(table.name, settings.databaseType)} ALTER COLUMN ${quoteIdentifier(column.name, settings.databaseType)} DROP NOT NULL;"
+                }
+        }
+    }
+
+    private fun quoteIdentifier(
+        name: String,
+        databaseType: DatabaseType,
+    ): String {
+        val escaped = name.replace("\"", "\"\"")
+        return when (databaseType) {
+            DatabaseType.MYSQL, DatabaseType.TIDB, DatabaseType.OCEANBASE, DatabaseType.POLARDB -> "`$name`"
+            DatabaseType.SQLSERVER -> "[$name]"
+            else -> "\"$escaped\""
+        }
+    }
+
+    private fun AutoDdlSchema.filterTables(tableNames: Set<String>): AutoDdlSchema {
+        if (tableNames.isEmpty()) {
+            return AutoDdlSchema(emptyList(), sequences)
+        }
+        val normalizedTableNames = tableNames.map { tableName -> tableName.lowercase() }.toSet()
+        return AutoDdlSchema(
+            tables.filter { table -> table.name.lowercase() in normalizedTableNames },
+            sequences,
+        )
+    }
+
+    private fun JimmerDdlSnapshot.toSchemaFor(
+        schema: AutoDdlSchema,
+        renameOperations: List<RenameTable>,
+    ): AutoDdlSchema {
+        val oldTableNameByNewName = renameOperations.associate { operation ->
+            operation.newTableName.lowercase() to operation.oldTableName.lowercase()
+        }
+        val tables = schema.tables.mapNotNull { table ->
+            val lookupName = oldTableNameByNewName[table.name.lowercase()] ?: table.name.lowercase()
+            tableSchemas[lookupName]?.let { previous ->
+                previous.copy(table.name, previous.columns, previous.foreignKeys, previous.indexes, previous.comment, previous.junction)
+            }
+        }
+        return AutoDdlSchema(tables, schema.sequences)
+    }
+}
+
+data class RenameTable(
+    val oldTableName: String,
+    val newTableName: String,
+)
+
+private fun LsiClass.isJimmerEntity(): Boolean {
+    return annotations.any { annotation -> annotation.qualifiedName == "org.babyfish.jimmer.sql.Entity" || annotation.simpleName == "Entity" }
+}
+
+private data class JimmerDdlOperationPlan(
+    val operations: List<AutoDdlOperation>,
+    val snapshotSchema: AutoDdlSchema? = null,
+    val warnings: List<String> = emptyList(),
+)
+
+private data class JimmerDdlCompilePlan(
+    val statements: List<String>,
+    val snapshotSchema: AutoDdlSchema,
+    val warnings: List<String> = emptyList(),
+)
+
+private data class JimmerDdlColumnKey(
+    val tableName: String,
+    val columnName: String,
+)
+
+data class JimmerDdlCompilerResult(
+    val settings: JimmerDdlCompilerSettings,
+    val entities: List<LsiClass>,
+    val schema: AutoDdlSchema,
+    val snapshotSchema: AutoDdlSchema,
+    val statements: List<String>,
+    val sql: String,
+    val warnings: List<String> = emptyList(),
+) {
+    val isEmpty
+        get() = entities.isEmpty() || sql.isBlank()
+
+    companion object {
+        fun empty(
+            settings: JimmerDdlCompilerSettings,
+            entities: List<LsiClass> = emptyList(),
+            schema: AutoDdlSchema = AutoDdlSchema(emptyList(), emptyList()),
+        ): JimmerDdlCompilerResult {
+            return JimmerDdlCompilerResult(
+                settings = settings,
+                entities = entities,
+                schema = schema,
+                snapshotSchema = schema,
+                statements = emptyList(),
+                sql = "",
+                warnings = emptyList(),
+            )
+        }
+    }
+}
+
+private fun String.toSnakeCase(): String {
+    if (isBlank()) {
+        return this
+    }
+    val builder = StringBuilder()
+    for (index in indices) {
+        val char = this[index]
+        if (char in 'A'..'Z') {
+            if (index > 0 && builder.lastOrNull() != '_') {
+                builder.append('_')
+            }
+            builder.append(char.lowercaseChar())
+        } else {
+            builder.append(char)
+        }
+    }
+    return builder.toString()
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
@@ -1,0 +1,50 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import java.io.File
+
+object JimmerDdlCompilerFiles {
+    private const val SNAPSHOT_DIR_NAME = ".jimmer-ddl"
+    private const val SNAPSHOT_FILE_NAME = "entity-table-snapshot.properties"
+
+    fun resolveOutputFile(settings: JimmerDdlCompilerSettings): File {
+        val outputDir = File(settings.outputDir)
+        return File(outputDir, settings.outputFileName)
+    }
+
+    fun resolveSnapshotFile(settings: JimmerDdlCompilerSettings): File? {
+        val projectDir = settings.outputDir.toProjectDir() ?: return null
+        return projectDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+    }
+
+    fun resolveGeneratedSnapshotFile(settings: JimmerDdlCompilerSettings): File {
+        val resourcesDir = settings.outputDir.toGeneratedResourcesDir()
+        return resourcesDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+    }
+
+    fun writeOutputFile(
+        settings: JimmerDdlCompilerSettings,
+        sql: String,
+    ): File {
+        val outputFile = resolveOutputFile(settings)
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(sql)
+        return outputFile
+    }
+
+    private fun String.toProjectDir(): File? {
+        val absoluteOutputDir = File(this).absoluteFile.path
+        return absoluteOutputDir
+            .substringBefore("${File.separator}build${File.separator}", missingDelimiterValue = "")
+            .takeIf { it.isNotBlank() }
+            ?.let(::File)
+    }
+
+    private fun String.toGeneratedResourcesDir(): File {
+        val outputDir = File(this).absoluteFile
+        val parent = outputDir.parentFile
+        if (outputDir.name == "migration" && parent?.name == "db") {
+            return parent.parentFile ?: outputDir
+        }
+        return outputDir
+    }
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerLsi.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerLsi.kt
@@ -1,0 +1,155 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.lsi.anno.LsiAnnotation
+import site.addzero.lsi.clazz.LsiClass
+import site.addzero.lsi.field.LsiField
+import site.addzero.lsi.method.LsiMethod
+import site.addzero.lsi.type.LsiType
+
+fun Collection<LsiClass>.toJimmerDdlLsiClasses(): List<LsiClass> {
+    val cache = linkedMapOf<String, LsiClass>()
+    return filter { it.isJimmerEntityType() }
+        .map { it.toJimmerDdlLsiClass(cache) }
+        .distinctBy { it.qualifiedName ?: it.simpleName.orEmpty() }
+}
+
+private fun LsiClass.toJimmerDdlLsiClass(cache: MutableMap<String, LsiClass>): LsiClass {
+    val key = qualifiedName ?: simpleName.orEmpty()
+    cache[key]?.let { return it }
+
+    val convertedSuperClasses = (superClasses + interfaces)
+        .filter { it.isJimmerType() }
+        .map { it.toJimmerDdlLsiClass(cache) }
+    val fieldCandidates = fields.ifEmpty {
+        methods.mapNotNull { it.toMethodBackedField(cache) }
+    }
+    val converted = JimmerDdlLsiClass(
+        delegate = this,
+        ddlFields = fieldCandidates,
+        ddlSuperClasses = convertedSuperClasses,
+    )
+    cache[key] = converted
+    return converted
+}
+
+private class JimmerDdlLsiClass(
+    private val delegate: LsiClass,
+    private val ddlFields: List<LsiField>,
+    private val ddlSuperClasses: List<LsiClass>,
+) : LsiClass {
+    override val simpleName get() = delegate.simpleName
+    override val qualifiedName get() = delegate.qualifiedName
+    override val comment get() = delegate.comment
+    override val fields get() = ddlFields
+    override val annotations get() = delegate.annotations
+    override val isInterface get() = delegate.isInterface
+    override val isEnum get() = delegate.isEnum
+    override val isCollectionType get() = delegate.isCollectionType
+    override val isPojo get() = delegate.isPojo
+    override val superClasses get() = ddlSuperClasses
+    override val interfaces get() = delegate.interfaces
+    override val methods get() = delegate.methods
+    override val fileName get() = delegate.fileName
+    override val isObject get() = delegate.isObject
+    override val isCompanionObject get() = delegate.isCompanionObject
+}
+
+private fun LsiMethod.toMethodBackedField(cache: MutableMap<String, LsiClass>): LsiField? {
+    if (isStatic || parameters.isNotEmpty()) {
+        return null
+    }
+    val propertyName = name?.toJimmerPropertyName() ?: return null
+    if (propertyName.isBlank() || propertyName == "class") {
+        return null
+    }
+    return MethodBackedLsiField(propertyName, this, cache)
+}
+
+private class MethodBackedLsiField(
+    private val propertyName: String,
+    private val method: LsiMethod,
+    private val cache: MutableMap<String, LsiClass>,
+) : LsiField {
+    override val name get() = propertyName
+    override val type get() = method.returnType
+    override val typeName get() = method.returnTypeName
+    override val comment get() = method.comment
+    override val annotations get() = method.annotations
+    override val isStatic get() = method.isStatic
+    override val isConstant get() = false
+    override val isEnum get() = method.returnType?.lsiClass?.isEnum ?: false
+    override val isVar get() = false
+    override val isLateInit get() = false
+    override val isCollectionType get() = method.returnType?.isCollectionType ?: false
+    override val defaultValue: String? get() = null
+    override val columnName: String? get() = annotations.columnNameFromAnnotations() ?: propertyName.toSnakeCase()
+    override val declaringClass get() = method.declaringClass
+    override val fieldTypeClass get() = method.returnType?.lsiClass?.toJimmerDdlLsiClass(cache)
+    override val isNestedObject get() = !isCollectionType && fieldTypeClass?.isPojo == true
+    override val children get() = if (isNestedObject) fieldTypeClass?.fields.orEmpty() else emptyList()
+}
+
+private fun String.toJimmerPropertyName(): String {
+    if (startsWith("get") && length > 3) {
+        return substring(3).replaceFirstChar(Char::lowercase)
+    }
+    if (startsWith("is") && length > 2) {
+        return substring(2).replaceFirstChar(Char::lowercase)
+    }
+    return this
+}
+
+private fun List<LsiAnnotation>.columnNameFromAnnotations(): String? {
+    return firstNotNullOfOrNull { annotation ->
+        if (!annotation.simpleName.equals("Column", ignoreCase = true)) {
+            return@firstNotNullOfOrNull null
+        }
+        annotation.getAttribute("name")
+            ?.toString()
+            ?.takeIf { it.isNotBlank() }
+    }
+}
+
+private fun String.toSnakeCase(): String {
+    if (isBlank()) {
+        return this
+    }
+    val builder = StringBuilder()
+    for (index in indices) {
+        val char = this[index]
+        if (char in 'A'..'Z') {
+            if (index > 0 && builder.lastOrNull() != '_') {
+                builder.append('_')
+            }
+            builder.append(char.lowercaseChar())
+        } else {
+            builder.append(char)
+        }
+    }
+    return builder.toString()
+}
+
+
+private fun LsiClass.isJimmerEntityType(): Boolean {
+    return annotations.any { annotation -> annotation.qualifiedName == "org.babyfish.jimmer.sql.Entity" || annotation.simpleName == "Entity" }
+}
+
+private fun LsiClass.isJimmerType(): Boolean {
+    return annotations.any { annotation ->
+        annotation.qualifiedName in JIMMER_TYPE_ANNOTATIONS || annotation.simpleName in JIMMER_TYPE_SIMPLE_NAMES
+    }
+}
+
+private val JIMMER_TYPE_ANNOTATIONS = setOf(
+    "org.babyfish.jimmer.sql.Entity",
+    "org.babyfish.jimmer.sql.MappedSuperclass",
+    "org.babyfish.jimmer.sql.Embeddable",
+    "org.babyfish.jimmer.Immutable",
+)
+
+private val JIMMER_TYPE_SIMPLE_NAMES = setOf(
+    "Entity",
+    "MappedSuperclass",
+    "Embeddable",
+    "Immutable",
+)

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSettings.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSettings.kt
@@ -1,0 +1,445 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.ddlgenerator.core.options.AutoDdlOptions
+import site.addzero.util.db.DatabaseType
+import java.io.File
+import java.util.Properties
+
+private const val DEFAULT_OUTPUT_DIR = "build/generated/jimmer-ddl/main/resources/db/migration"
+private const val DEFAULT_VERSION = "1001"
+private const val DEFAULT_DESCRIPTION = "jimmer_auto_ddl_generated"
+private const val DEFAULT_SPRING_PROFILE = "local"
+private val DEFAULT_DATABASE_TYPE = DatabaseType.POSTGRESQL
+
+enum class JimmerDdlOutputFormat {
+    PLAIN,
+    FLYWAY;
+
+    companion object {
+        fun parse(value: String): JimmerDdlOutputFormat {
+            return entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+                ?: FLYWAY
+        }
+    }
+}
+
+data class JimmerDdlJdbcSettings(
+    val url: String = "",
+    val username: String = "",
+    val password: String = "",
+    val schema: String? = null,
+    val driverClassName: String? = null,
+) {
+    val configured
+        get() = url.isNotBlank()
+}
+
+data class JimmerDdlCompilerSettings(
+    val enabled: Boolean = true,
+    val databaseType: DatabaseType = DEFAULT_DATABASE_TYPE,
+    val outputFormat: JimmerDdlOutputFormat = JimmerDdlOutputFormat.FLYWAY,
+    val outputDir: String = DEFAULT_OUTPUT_DIR,
+    val version: String = DEFAULT_VERSION,
+    val description: String = DEFAULT_DESCRIPTION,
+    val includePackages: List<String> = emptyList(),
+    val excludePackages: List<String> = emptyList(),
+    val options: AutoDdlOptions = AutoDdlOptions(),
+    val includeManyToManyTables: Boolean = true,
+    val compareDatabase: Boolean = true,
+    val nullabilityRepairOnly: Boolean = false,
+    val sourceFingerprint: String? = null,
+    val jdbc: JimmerDdlJdbcSettings = JimmerDdlJdbcSettings(),
+) {
+    fun includesClass(qualifiedName: String?): Boolean {
+        if (qualifiedName.isNullOrBlank()) {
+            return includePackages.isEmpty()
+        }
+
+        if (excludePackages.any { packagePrefix -> qualifiedName.isInPackagePrefix(packagePrefix) }) {
+            return false
+        }
+
+        if (includePackages.isEmpty()) {
+            return true
+        }
+
+        return includePackages.any { packagePrefix -> qualifiedName.isInPackagePrefix(packagePrefix) }
+    }
+
+    val outputFileName: String
+        get() {
+            val normalizedDescription = description
+                .ifBlank { DEFAULT_DESCRIPTION }
+                .replace(Regex("[^A-Za-z0-9_]+"), "_")
+                .trim('_')
+                .ifBlank { DEFAULT_DESCRIPTION }
+            return when (outputFormat) {
+                JimmerDdlOutputFormat.FLYWAY -> "V${version.ifBlank { DEFAULT_VERSION }}__${normalizedDescription}.sql"
+                JimmerDdlOutputFormat.PLAIN -> "${normalizedDescription}.sql"
+            }
+        }
+
+    companion object {
+        fun allFromOptions(options: Map<String, String>): List<JimmerDdlCompilerSettings> {
+            val profileNames = options.option("jimmerDdl.profiles", defaultValue = "").toValueList()
+            if (profileNames.isEmpty()) {
+                return listOf(fromOptions(options))
+            }
+            return profileNames.map { profileName ->
+                fromProfileOptions(options, profileName)
+            }
+        }
+
+        fun fromOptions(options: Map<String, String>): JimmerDdlCompilerSettings {
+            val outputDir = options.option(
+                newKey = "jimmerDdl.outputDir",
+                defaultValue = DEFAULT_OUTPUT_DIR,
+            )
+            val springProfile = options.option("jimmerDdl.springProfile", defaultValue = DEFAULT_SPRING_PROFILE)
+            val jdbc = resolveJdbcSettings(options = options, profileName = null, outputDir = outputDir, springProfile = springProfile)
+            return JimmerDdlCompilerSettings(
+                enabled = options.option("jimmerDdl.enabled", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                databaseType = resolveDatabaseType(options = options, profileName = null, jdbc = jdbc),
+                outputFormat = JimmerDdlOutputFormat.parse(options.option("jimmerDdl.outputFormat", defaultValue = "flyway")),
+                outputDir = outputDir,
+                version = options.option("jimmerDdl.version", defaultValue = DEFAULT_VERSION),
+                description = options.option("jimmerDdl.description", defaultValue = DEFAULT_DESCRIPTION),
+                includePackages = options.option("jimmerDdl.includePackages", defaultValue = "").toPackageFilters(),
+                excludePackages = options.option("jimmerDdl.excludePackages", defaultValue = "").toPackageFilters(),
+                options = AutoDdlOptions(
+                    options.option("jimmerDdl.includeForeignKeys", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.option("jimmerDdl.includeIndexes", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.option("jimmerDdl.includeComments", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.option("jimmerDdl.includeSequences", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                ),
+                includeManyToManyTables = options.option("jimmerDdl.includeManyToManyTables", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                compareDatabase = options.option("jimmerDdl.compareDatabase", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                nullabilityRepairOnly = options.option("jimmerDdl.nullabilityRepairOnly", defaultValue = "false").toBooleanStrictOrNull() ?: false,
+                sourceFingerprint = options.option("jimmerDdl.sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() },
+                jdbc = jdbc,
+            )
+        }
+
+        private fun fromProfileOptions(
+            options: Map<String, String>,
+            profileName: String,
+        ): JimmerDdlCompilerSettings {
+            val outputDir = options.profileOption(
+                profileName = profileName,
+                key = "outputDir",
+                defaultValue = DEFAULT_OUTPUT_DIR,
+            )
+            val springProfile = options.profileOption(profileName, "springProfile", defaultValue = DEFAULT_SPRING_PROFILE)
+            val jdbc = resolveJdbcSettings(options = options, profileName = profileName, outputDir = outputDir, springProfile = springProfile)
+            return JimmerDdlCompilerSettings(
+                enabled = options.profileOption(profileName, "enabled", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                databaseType = resolveDatabaseType(options = options, profileName = profileName, jdbc = jdbc),
+                outputFormat = JimmerDdlOutputFormat.parse(options.profileOption(profileName, "outputFormat", defaultValue = "flyway")),
+                outputDir = outputDir,
+                version = options.profileOption(profileName, "version", defaultValue = DEFAULT_VERSION),
+                description = options.profileOption(profileName, "description", defaultValue = "${profileName}_generated"),
+                includePackages = options.profileOption(profileName, "includePackages", defaultValue = "").toPackageFilters(),
+                excludePackages = options.profileOption(profileName, "excludePackages", defaultValue = "").toPackageFilters(),
+                options = AutoDdlOptions(
+                    options.profileOption(profileName, "includeForeignKeys", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.profileOption(profileName, "includeIndexes", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.profileOption(profileName, "includeComments", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                    options.profileOption(profileName, "includeSequences", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                ),
+                includeManyToManyTables = options.profileOption(profileName, "includeManyToManyTables", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                compareDatabase = options.profileOption(profileName, "compareDatabase", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                nullabilityRepairOnly = options.profileOption(profileName, "nullabilityRepairOnly", defaultValue = "false").toBooleanStrictOrNull() ?: false,
+                sourceFingerprint = options.profileOption(profileName, "sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() }
+                    ?: options.option("jimmerDdl.sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() },
+                jdbc = jdbc,
+            )
+        }
+
+        private fun resolveDatabaseType(
+            options: Map<String, String>,
+            profileName: String?,
+            jdbc: JimmerDdlJdbcSettings,
+        ): DatabaseType {
+            val rawValue = if (profileName == null) {
+                options.option(newKey = "jimmerDdl.databaseType", defaultValue = "auto")
+            } else {
+                options.profileOption(profileName, key = "databaseType", defaultValue = "auto")
+            }
+            parseExplicitDatabaseType(rawValue)?.let { return it }
+
+            return jdbc.url.takeIf { it.isNotBlank() }?.let { DatabaseType.fromUrl(it) }
+                ?: DEFAULT_DATABASE_TYPE
+        }
+
+        private fun resolveJdbcSettings(
+            options: Map<String, String>,
+            profileName: String?,
+            outputDir: String,
+            springProfile: String,
+        ): JimmerDdlJdbcSettings {
+            val explicitUrl = optionByProfile(options, profileName, "jdbcUrl", defaultValue = "")
+            val explicitUsername = optionByProfile(options, profileName, "jdbcUsername", defaultValue = "")
+            val explicitPassword = optionByProfile(options, profileName, "jdbcPassword", defaultValue = "")
+            val explicitSchema = optionByProfile(options, profileName, "jdbcSchema", defaultValue = "")
+            val explicitDriver = optionByProfile(options, profileName, "jdbcDriver", defaultValue = "")
+            if (explicitUrl.isNotBlank()) {
+                return JimmerDdlJdbcSettings(
+                    url = explicitUrl,
+                    username = explicitUsername,
+                    password = explicitPassword,
+                    schema = explicitSchema.takeIf { it.isNotBlank() },
+                    driverClassName = explicitDriver.takeIf { it.isNotBlank() },
+                )
+            }
+
+            val springResourcePath = optionByProfile(options, profileName, "springResourcePath", defaultValue = "")
+            val discovered = springResourcePath
+                .takeIf { it.isNotBlank() }
+                ?.let { readJdbcSettingsFromPath(it, springProfile) }
+                ?: readJdbcSettingsFromProjectResources(outputDir, springProfile)
+                ?: JimmerDdlJdbcSettings()
+            return discovered.copy(
+                schema = explicitSchema.takeIf { it.isNotBlank() } ?: discovered.schema,
+                driverClassName = explicitDriver.takeIf { it.isNotBlank() } ?: discovered.driverClassName,
+            )
+        }
+
+        private fun optionByProfile(
+            options: Map<String, String>,
+            profileName: String?,
+            key: String,
+            defaultValue: String,
+        ): String {
+            if (profileName == null) {
+                return options.option("jimmerDdl.$key", defaultValue)
+            }
+            return options.profileOption(profileName, key, defaultValue)
+        }
+
+        private fun readJdbcSettingsFromProjectResources(
+            outputDir: String,
+            springProfile: String,
+        ): JimmerDdlJdbcSettings? {
+            val absoluteOutputDir = File(outputDir).absoluteFile.path
+            val projectDir = absoluteOutputDir.substringBefore("${File.separator}build${File.separator}", missingDelimiterValue = "")
+                .takeIf { it.isNotBlank() }
+                ?.let(::File)
+                ?: return null
+            return listOf(
+                projectDir.resolve("src/main/resources"),
+                projectDir.resolve("src/main/resources/config"),
+            ).firstNotNullOfOrNull { path -> readJdbcSettingsFromPath(path, springProfile) }
+        }
+
+        private fun readJdbcSettingsFromPath(path: String, springProfile: String): JimmerDdlJdbcSettings? {
+            return readJdbcSettingsFromPath(File(path), springProfile)
+        }
+
+        private fun readJdbcSettingsFromPath(file: File, springProfile: String): JimmerDdlJdbcSettings? {
+            if (!file.exists()) {
+                return null
+            }
+            val files = when {
+                file.isFile -> listOf(file)
+                file.isDirectory -> file.walkTopDown()
+                    .maxDepth(5)
+                    .filter { candidate -> candidate.isFile && candidate.isSpringConfigFile() }
+                    .sortedWith(
+                        compareBy<File> { candidate -> candidate.datasourceConfigPriority() }
+                            .thenBy { candidate -> candidate.relativeToOrSelf(file).invariantSeparatorsPath }
+                    )
+                    .toList()
+                else -> emptyList()
+            }
+            return files.firstNotNullOfOrNull { candidate ->
+                candidate.readSpringJdbcSettings(springProfile)
+            }
+        }
+
+        private fun File.readSpringJdbcSettings(springProfile: String): JimmerDdlJdbcSettings? {
+            val props = if (extension.equals("properties", ignoreCase = true)) {
+                parsePropertiesConfig()
+            } else {
+                parseYamlConfig(readText(), springProfile)
+            }
+            return props.toJdbcSettings()
+        }
+
+        private fun File.parsePropertiesConfig(): Map<String, String> {
+            return inputStream().use { input ->
+                Properties().apply { load(input) }
+            }.entries.associate { (key, value) -> key.toString() to value.toString() }
+        }
+
+        private fun parseYamlConfig(text: String, springProfile: String): Map<String, String> {
+            val defaults = linkedMapOf<String, String>()
+            val profiles = linkedMapOf<String, String>()
+            text.normalizeYamlProfileKey()
+                .split(Regex("(?m)^---\\s*$"))
+                .forEach { document ->
+                    val props = parseYamlDocument(document)
+                    if (props.isEmpty()) {
+                        return@forEach
+                    }
+                    val profile = props["spring.config.activate.on-profile"]
+                    if (profile == null) {
+                        defaults.putAll(props)
+                    } else if (profile.split(',', ';').map { it.trim() }.any { it.equals(springProfile, ignoreCase = true) }) {
+                        profiles.putAll(props)
+                    }
+                }
+            return linkedMapOf<String, String>().apply {
+                putAll(defaults)
+                putAll(profiles)
+            }
+        }
+
+        private fun parseYamlDocument(document: String): Map<String, String> {
+            val props = linkedMapOf<String, String>()
+            val pathStack = mutableListOf<Pair<Int, String>>()
+            document.lineSequence().forEach { rawLine ->
+                val line = rawLine.substringBeforeComment().takeIf { it.isNotBlank() } ?: return@forEach
+                val indent = line.indexOfFirst { !it.isWhitespace() }.takeIf { it >= 0 } ?: 0
+                val trimmed = line.trim()
+                if (trimmed.startsWith("-") || !trimmed.contains(":")) {
+                    return@forEach
+                }
+                val key = trimmed.substringBefore(':').trim().normalizeConfigKey()
+                val rawValue = trimmed.substringAfter(':', missingDelimiterValue = "").trim()
+                while (pathStack.isNotEmpty() && pathStack.last().first >= indent) {
+                    pathStack.removeAt(pathStack.lastIndex)
+                }
+                pathStack += indent to key
+                if (rawValue.isNotBlank()) {
+                    val fullKey = pathStack.joinToString(".") { it.second }
+                    props[fullKey] = rawValue.unquoteConfigValue()
+                }
+            }
+            return props
+        }
+
+        private fun Map<String, String>.toJdbcSettings(): JimmerDdlJdbcSettings? {
+            val dynamicPrefix = "spring.datasource.dynamic"
+            val primary = this["$dynamicPrefix.primary"]?.takeIf { it.isNotBlank() } ?: "master"
+            val prefixes = listOf(
+                "$dynamicPrefix.datasource.$primary",
+                "$dynamicPrefix.datasource.master",
+                "spring.datasource",
+            )
+            val urlPrefix = prefixes.firstOrNull { prefix -> !this["$prefix.url"].isNullOrBlank() } ?: return null
+            val url = this["$urlPrefix.url"] ?: return null
+            val username = this["$urlPrefix.username"].orEmpty()
+            val password = this["$urlPrefix.password"].orEmpty()
+            val driver = this["$urlPrefix.driver-class-name"] ?: this["$urlPrefix.driverClassName"]
+            return JimmerDdlJdbcSettings(
+                url = url,
+                username = username,
+                password = password,
+                driverClassName = driver,
+            )
+        }
+
+        private fun File.isSpringConfigFile(): Boolean {
+            val name = name.lowercase()
+            return name.endsWith(".yml") || name.endsWith(".yaml") || name.endsWith(".properties")
+        }
+
+        private fun File.datasourceConfigPriority(): Int {
+            val normalizedName = nameWithoutExtension.lowercase()
+            return when {
+                "datasource" in normalizedName -> 0
+                "database" in normalizedName -> 1
+                normalizedName == "db" || normalizedName.endsWith("-db") || normalizedName.endsWith("_db") -> 2
+                normalizedName.startsWith("application") -> 3
+                else -> 4
+            }
+        }
+
+        private fun parseExplicitDatabaseType(rawValue: String): DatabaseType? {
+            val normalized = rawValue.trim().lowercase()
+            if (normalized.isBlank() || normalized == "auto" || normalized == "datasource") {
+                return null
+            }
+            if (normalized.startsWith("jdbc:")) {
+                return DatabaseType.fromUrl(rawValue)
+            }
+            val alias = when (normalized) {
+                "pg", "postgres" -> "postgresql"
+                "mssql" -> "sqlserver"
+                "dameng" -> "dm"
+                else -> normalized
+            }
+            return DatabaseType.fromCode(alias)
+                ?: DatabaseType.fromName(alias)
+        }
+
+        private fun String.toPackageFilters(): List<String> {
+            return toValueList()
+        }
+
+        private fun String.toValueList(): List<String> {
+            return split(',', ';')
+                .map { it.trim().trimEnd('.') }
+                .filter { it.isNotBlank() }
+                .distinct()
+        }
+
+        private fun Map<String, String>.option(
+            newKey: String,
+            defaultValue: String,
+        ): String {
+            val newValue = this[newKey]
+            if (!newValue.isNullOrBlank()) {
+                return newValue
+            }
+            return defaultValue
+        }
+
+        private fun Map<String, String>.profileOption(
+            profileName: String,
+            key: String,
+            defaultValue: String,
+        ): String {
+            val profileValue = this["jimmerDdl.profile.$profileName.$key"]
+            if (!profileValue.isNullOrBlank()) {
+                return profileValue
+            }
+            return option(
+                newKey = "jimmerDdl.$key",
+                defaultValue = defaultValue,
+            )
+        }
+
+        private fun String.normalizeYamlProfileKey(): String {
+            return replace(Regex("(?m)^spring\\.\\s+config\\.\\s+activate\\.\\s+on-profile\\s*:")) {
+                "spring.config.activate.on-profile:"
+            }
+        }
+
+        private fun String.substringBeforeComment(): String {
+            val trimmed = trimStart()
+            if (trimmed.startsWith("#")) {
+                return ""
+            }
+            val marker = indexOf(" #")
+            if (marker >= 0) {
+                return substring(0, marker).trimEnd()
+            }
+            return this
+        }
+
+        private fun String.normalizeConfigKey(): String {
+            return replace(Regex("\\s*\\.\\s*"), ".")
+        }
+
+        private fun String.unquoteConfigValue(): String {
+            return trim()
+                .removeSurrounding("\"")
+                .removeSurrounding("'")
+        }
+    }
+}
+
+private fun String.isInPackagePrefix(packagePrefix: String): Boolean {
+    return this == packagePrefix || startsWith("$packagePrefix.")
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSnapshot.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSnapshot.kt
@@ -1,0 +1,223 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.lsi.anno.LsiAnnotation
+import site.addzero.lsi.clazz.LsiClass
+import site.addzero.lsi.field.LsiField
+import site.addzero.lsi.method.LsiMethod
+import site.addzero.lsi.method.LsiParameter
+import site.addzero.lsi.type.LsiType
+
+/**
+ * KSP symbols cannot be safely resolved from `finish` after PSI changes.
+ * Freeze the LSI view during the valid processing round, then compile DDL from
+ * these immutable snapshots in `finish`.
+ */
+internal fun LsiClass.toStableJimmerDdlSnapshot(): LsiClass {
+    return snapshot(cache = linkedMapOf(), shallow = false)
+}
+
+private fun LsiClass.snapshot(
+    cache: MutableMap<String, LsiClass>,
+    shallow: Boolean,
+): LsiClass {
+    val key = "${qualifiedName ?: simpleName.orEmpty()}#$shallow"
+    cache[key]?.let { return it }
+
+    val snapshot = SnapshotLsiClass(
+        simpleName = simpleName,
+        qualifiedName = qualifiedName,
+        comment = comment,
+        fields = fields.map { field -> field.snapshot(cache, snapshotFieldTypeClass = !shallow) },
+        annotations = annotations.map { it.snapshot() },
+        isInterface = isInterface,
+        isEnum = isEnum,
+        isCollectionType = isCollectionType,
+        isPojo = isPojo,
+        superClasses = superClasses.map { it.snapshot(cache, shallow = shallow) },
+        interfaces = interfaces.map { it.snapshot(cache, shallow = shallow) },
+        methods = if (fields.isEmpty()) methods.map { it.snapshot(cache) } else emptyList(),
+        fileName = fileName,
+        isObject = isObject,
+        isCompanionObject = isCompanionObject,
+    )
+    cache[key] = snapshot
+    return snapshot
+}
+
+private fun LsiField.snapshot(
+    cache: MutableMap<String, LsiClass>,
+    snapshotFieldTypeClass: Boolean,
+): LsiField {
+    val annotationSnapshots = annotations.map { it.snapshot() }
+    val association = annotationSnapshots.any { annotation ->
+        annotation.simpleName in setOf("ManyToOne", "OneToOne", "OneToMany", "ManyToMany")
+    }
+    return SnapshotLsiField(
+        name = name,
+        type = type?.snapshot(cache, snapshotLsiClass = snapshotFieldTypeClass && association),
+        typeName = typeName,
+        comment = comment,
+        annotations = annotationSnapshots,
+        isStatic = isStatic,
+        isConstant = isConstant,
+        isEnum = isEnum,
+        isVar = isVar,
+        isLateInit = isLateInit,
+        isCollectionType = isCollectionType,
+        defaultValue = defaultValue,
+        columnName = columnName,
+        declaringClass = null,
+        fieldTypeClass = if (snapshotFieldTypeClass && association) fieldTypeClass?.snapshot(cache, shallow = true) else null,
+        isNestedObject = false,
+        children = emptyList(),
+        isNullable = isNullable,
+    )
+}
+
+private fun LsiMethod.snapshot(cache: MutableMap<String, LsiClass>): LsiMethod {
+    return SnapshotLsiMethod(
+        name = name,
+        returnType = returnType?.snapshot(cache),
+        returnTypeName = returnTypeName,
+        comment = comment,
+        annotations = annotations.map { it.snapshot() },
+        isStatic = isStatic,
+        isAbstract = isAbstract,
+        parameters = parameters.map { it.snapshot(cache) },
+        declaringClass = null,
+    )
+}
+
+private fun LsiParameter.snapshot(cache: MutableMap<String, LsiClass>): LsiParameter {
+    return SnapshotLsiParameter(
+        name = name,
+        type = type?.snapshot(cache),
+        typeName = typeName,
+        annotations = annotations.map { it.snapshot() },
+        hasDefault = hasDefault,
+    )
+}
+
+private fun LsiType.snapshot(
+    cache: MutableMap<String, LsiClass>,
+    snapshotLsiClass: Boolean = false,
+): LsiType {
+    return SnapshotLsiType(
+        simpleName = simpleName,
+        qualifiedName = qualifiedName,
+        presentableText = presentableText,
+        annotations = annotations.map { it.snapshot() },
+        isCollectionType = isCollectionType,
+        isNullable = isNullable,
+        typeParameters = typeParameters.map { it.snapshot(cache, snapshotLsiClass = snapshotLsiClass) },
+        isPrimitive = isPrimitive,
+        componentType = componentType?.snapshot(cache, snapshotLsiClass = snapshotLsiClass),
+        isArray = isArray,
+        lsiClass = if (snapshotLsiClass && !isCollectionType) {
+            lsiClass?.snapshot(cache, shallow = true)
+        } else {
+            null
+        },
+    )
+}
+
+private fun LsiAnnotation.snapshot(): LsiAnnotation {
+    return SnapshotLsiAnnotation(
+        qualifiedName = qualifiedName,
+        simpleName = simpleName,
+        attributes = attributes.mapValues { (_, value) -> value.freezeAnnotationAttribute() },
+    )
+}
+
+private fun Any?.freezeAnnotationAttribute(): Any? {
+    return when (this) {
+        null -> null
+        is String, is Number, is Boolean -> this
+        is Collection<*> -> map { it.freezeAnnotationAttribute() }
+        is Array<*> -> map { it.freezeAnnotationAttribute() }
+        else -> toString()
+    }
+}
+
+private data class SnapshotLsiAnnotation(
+    override val qualifiedName: String?,
+    override val simpleName: String?,
+    override val attributes: Map<String, Any?>,
+) : LsiAnnotation {
+    override fun getAttribute(name: String): Any? = attributes[name]
+
+    override fun hasAttribute(name: String): Boolean = attributes.containsKey(name)
+}
+
+private data class SnapshotLsiType(
+    override val simpleName: String?,
+    override val qualifiedName: String?,
+    override val presentableText: String?,
+    override val annotations: List<LsiAnnotation>,
+    override val isCollectionType: Boolean,
+    override val isNullable: Boolean,
+    override val typeParameters: List<LsiType>,
+    override val isPrimitive: Boolean,
+    override val componentType: LsiType?,
+    override val isArray: Boolean,
+    override val lsiClass: LsiClass?,
+) : LsiType
+
+private data class SnapshotLsiField(
+    override val name: String?,
+    override val type: LsiType?,
+    override val typeName: String?,
+    override val comment: String?,
+    override val annotations: List<LsiAnnotation>,
+    override val isStatic: Boolean,
+    override val isConstant: Boolean,
+    override val isEnum: Boolean,
+    override val isVar: Boolean,
+    override val isLateInit: Boolean,
+    override val isCollectionType: Boolean,
+    override val defaultValue: String?,
+    override val columnName: String?,
+    override val declaringClass: LsiClass?,
+    override val fieldTypeClass: LsiClass?,
+    override val isNestedObject: Boolean,
+    override val children: List<LsiField>,
+    override val isNullable: Boolean,
+) : LsiField
+
+private data class SnapshotLsiClass(
+    override val simpleName: String?,
+    override val qualifiedName: String?,
+    override val comment: String?,
+    override val fields: List<LsiField>,
+    override val annotations: List<LsiAnnotation>,
+    override val isInterface: Boolean,
+    override val isEnum: Boolean,
+    override val isCollectionType: Boolean,
+    override val isPojo: Boolean,
+    override val superClasses: List<LsiClass>,
+    override val interfaces: List<LsiClass>,
+    override val methods: List<LsiMethod>,
+    override val fileName: String?,
+    override val isObject: Boolean,
+    override val isCompanionObject: Boolean,
+) : LsiClass
+
+private data class SnapshotLsiMethod(
+    override val name: String?,
+    override val returnType: LsiType?,
+    override val returnTypeName: String?,
+    override val comment: String?,
+    override val annotations: List<LsiAnnotation>,
+    override val isStatic: Boolean,
+    override val isAbstract: Boolean,
+    override val parameters: List<LsiParameter>,
+    override val declaringClass: LsiClass?,
+) : LsiMethod
+
+private data class SnapshotLsiParameter(
+    override val name: String?,
+    override val type: LsiType?,
+    override val typeName: String?,
+    override val annotations: List<LsiAnnotation>,
+    override val hasDefault: Boolean,
+) : LsiParameter

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
@@ -1,0 +1,175 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.ddlgenerator.core.model.AutoDdlColumn
+import site.addzero.ddlgenerator.core.model.AutoDdlLogicalType
+import site.addzero.ddlgenerator.core.model.AutoDdlSchema
+import site.addzero.ddlgenerator.core.model.AutoDdlTable
+import site.addzero.util.db.DatabaseType
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.DriverManager
+import java.sql.ResultSet
+import java.sql.Types
+import java.util.Properties
+
+object JimmerDdlDatabaseSchemaReader {
+    fun read(
+        settings: JimmerDdlCompilerSettings,
+        desiredSchema: AutoDdlSchema,
+        renamedTables: Map<String, String> = emptyMap(),
+    ): AutoDdlSchema {
+        val jdbc = settings.jdbc
+        val driverClassName = jdbc.driverClassName ?: DatabaseType.getDriverClassName(jdbc.url)
+        if (!driverClassName.isNullOrBlank()) {
+            Class.forName(driverClassName)
+        }
+
+        val properties = Properties().apply {
+            if (jdbc.username.isNotBlank()) {
+                setProperty("user", jdbc.username)
+            }
+            if (jdbc.password.isNotBlank()) {
+                setProperty("password", jdbc.password)
+            }
+            setProperty("connectTimeout", "5")
+            setProperty("loginTimeout", "5")
+        }
+        DriverManager.getConnection(jdbc.url, properties).use { connection ->
+            val schemaName = jdbc.schema ?: runCatching { connection.schema }.getOrNull()
+            return readSchema(connection, schemaName, desiredSchema, renamedTables)
+        }
+    }
+
+    private fun readSchema(
+        connection: Connection,
+        schemaName: String?,
+        desiredSchema: AutoDdlSchema,
+        renamedTables: Map<String, String>,
+    ): AutoDdlSchema {
+        val actualTables = desiredSchema.tables.mapNotNull { desiredTable ->
+            readTable(connection, schemaName, desiredTable, renamedTables)
+        }
+        return AutoDdlSchema(actualTables, emptyList())
+    }
+
+    private fun readTable(
+        connection: Connection,
+        schemaName: String?,
+        desiredTable: AutoDdlTable,
+        renamedTables: Map<String, String>,
+    ): AutoDdlTable? {
+        val metaData = connection.metaData
+        val tableName = findExistingTableName(metaData, connection.catalog, schemaName, desiredTable.name)
+            ?: renamedTables[desiredTable.name.lowercase()]?.let { oldTableName ->
+                findExistingTableName(metaData, connection.catalog, schemaName, oldTableName)
+            }
+            ?: return null
+        val primaryKeys = readPrimaryKeys(metaData, connection.catalog, schemaName, tableName)
+        val desiredColumns = desiredTable.columns.associateBy { column -> column.name.lowercase() }
+        val columns = mutableListOf<AutoDdlColumn>()
+        metaData.findColumns(connection.catalog, schemaName, tableName).use { resultSet ->
+            while (resultSet.next()) {
+                val columnName = resultSet.getString("COLUMN_NAME") ?: continue
+                val desiredColumn = desiredColumns[columnName.lowercase()] ?: continue
+                val jdbcType = resultSet.getInt("DATA_TYPE")
+                val length = resultSet.getIntOrNull("COLUMN_SIZE")
+                val scale = resultSet.getIntOrNull("DECIMAL_DIGITS")
+                val nullable = resultSet.getInt("NULLABLE") == DatabaseMetaData.columnNullable
+                columns += desiredColumn.copy(
+                    columnName,
+                    jdbcType.toLogicalType(),
+                    nullable,
+                    length,
+                    desiredColumn.precision,
+                    scale,
+                    resultSet.getStringOrNull("COLUMN_DEF"),
+                    desiredColumn.comment,
+                    primaryKeys.any { key -> key.equals(columnName, ignoreCase = true) },
+                    desiredColumn.autoIncrement,
+                    desiredColumn.sequenceName,
+                    resultSet.getStringOrNull("TYPE_NAME"),
+                )
+            }
+        }
+        return AutoDdlTable(
+            desiredTable.name,
+            columns,
+            emptyList(),
+            emptyList(),
+            null,
+            null,
+        )
+    }
+
+    private fun findExistingTableName(
+        metaData: DatabaseMetaData,
+        catalog: String?,
+        schemaName: String?,
+        tableName: String,
+    ): String? {
+        val candidates = listOf(tableName, tableName.lowercase(), tableName.uppercase()).distinct()
+        candidates.forEach { candidate ->
+            metaData.getTables(catalog, schemaName, candidate, arrayOf("TABLE")).use { resultSet ->
+                if (resultSet.next()) {
+                    return resultSet.getString("TABLE_NAME") ?: candidate
+                }
+            }
+        }
+        return null
+    }
+
+    private fun DatabaseMetaData.findColumns(
+        catalog: String?,
+        schemaName: String?,
+        tableName: String,
+    ): ResultSet {
+        return getColumns(catalog, schemaName, tableName, "%")
+    }
+
+    private fun readPrimaryKeys(
+        metaData: DatabaseMetaData,
+        catalog: String?,
+        schemaName: String?,
+        tableName: String,
+    ): Set<String> {
+        val primaryKeys = linkedSetOf<String>()
+        metaData.getPrimaryKeys(catalog, schemaName, tableName).use { resultSet ->
+            while (resultSet.next()) {
+                resultSet.getString("COLUMN_NAME")?.let { columnName -> primaryKeys += columnName }
+            }
+        }
+        return primaryKeys
+    }
+
+    private fun ResultSet.getIntOrNull(columnName: String): Int? {
+        val value = getInt(columnName)
+        return if (wasNull()) null else value
+    }
+
+    private fun ResultSet.getStringOrNull(columnName: String): String? {
+        return runCatching { getString(columnName)?.takeIf { it.isNotBlank() } }.getOrNull()
+    }
+
+    private fun Int.toLogicalType(): AutoDdlLogicalType {
+        return when (this) {
+            Types.CHAR, Types.NCHAR -> AutoDdlLogicalType.CHAR
+            Types.VARCHAR, Types.NVARCHAR -> AutoDdlLogicalType.STRING
+            Types.LONGVARCHAR, Types.LONGNVARCHAR, Types.CLOB, Types.NCLOB -> AutoDdlLogicalType.TEXT
+            Types.BOOLEAN, Types.BIT -> AutoDdlLogicalType.BOOLEAN
+            Types.TINYINT -> AutoDdlLogicalType.INT8
+            Types.SMALLINT -> AutoDdlLogicalType.INT16
+            Types.INTEGER -> AutoDdlLogicalType.INT32
+            Types.BIGINT -> AutoDdlLogicalType.INT64
+            Types.NUMERIC, Types.DECIMAL -> AutoDdlLogicalType.DECIMAL
+            Types.REAL -> AutoDdlLogicalType.FLOAT32
+            Types.FLOAT, Types.DOUBLE -> AutoDdlLogicalType.FLOAT64
+            Types.DATE -> AutoDdlLogicalType.DATE
+            Types.TIME, Types.TIME_WITH_TIMEZONE -> AutoDdlLogicalType.TIME
+            Types.TIMESTAMP -> AutoDdlLogicalType.DATETIME
+            Types.TIMESTAMP_WITH_TIMEZONE -> AutoDdlLogicalType.DATETIME_TZ
+            Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY, Types.BLOB -> AutoDdlLogicalType.BINARY
+            Types.OTHER -> AutoDdlLogicalType.UNKNOWN
+            else -> AutoDdlLogicalType.UNKNOWN
+        }
+    }
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
@@ -1,0 +1,455 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.ddlgenerator.core.model.AutoDdlColumn
+import site.addzero.ddlgenerator.core.model.AutoDdlForeignKey
+import site.addzero.ddlgenerator.core.model.AutoDdlIndex
+import site.addzero.ddlgenerator.core.model.AutoDdlIndexType
+import site.addzero.ddlgenerator.core.model.AutoDdlJunction
+import site.addzero.ddlgenerator.core.model.AutoDdlLogicalType
+import site.addzero.ddlgenerator.core.model.AutoDdlSchema
+import site.addzero.ddlgenerator.core.model.AutoDdlTable
+import site.addzero.lsi.clazz.LsiClass
+import java.io.File
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.Properties
+
+private const val SOURCE_FINGERPRINT_KEY = "__sourceFingerprint"
+private const val TABLE_HASH_PREFIX = "__tableHash."
+private const val TABLE_SCHEMA_PREFIX = "__tableSchema."
+
+data class JimmerDdlSnapshot(
+    val sourceFingerprint: String? = null,
+    val entityTables: Map<String, String> = emptyMap(),
+    val tableHashes: Map<String, String> = emptyMap(),
+    val tableSchemas: Map<String, AutoDdlTable> = emptyMap(),
+) {
+    val isEmpty
+        get() = entityTables.isEmpty() && tableHashes.isEmpty()
+}
+
+data class JimmerDdlSchemaChangePlan(
+    val previous: JimmerDdlSnapshot,
+    val currentEntityTables: Map<String, String>,
+    val currentTableHashes: Map<String, String>,
+    val changedTableNames: Set<String>,
+    val renameOperations: List<RenameTable>,
+) {
+    val hasChanges
+        get() = changedTableNames.isNotEmpty() || renameOperations.isNotEmpty()
+}
+
+object JimmerDdlEntityTableSnapshot {
+    fun planSchemaChanges(
+        entities: List<LsiClass>,
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ): JimmerDdlSchemaChangePlan {
+        val previous = readSnapshot(settings)
+        val currentEntityTables = entities.toSnapshot()
+        val currentTableHashes = schema.toTableHashes()
+        val renameOperations = planRenameTables(
+            previous = previous,
+            current = currentEntityTables,
+            schema = schema,
+        )
+        val renamedNewTables = renameOperations.map { operation -> operation.newTableName.lowercase() }.toSet()
+        val changedTableNames = currentTableHashes
+            .filter { (tableName, currentHash) ->
+                previous.isEmpty ||
+                    previous.tableHashes.isEmpty() ||
+                    previous.tableHashes[tableName] != currentHash
+            }
+            .keys + renamedNewTables
+        return JimmerDdlSchemaChangePlan(
+            previous = previous,
+            currentEntityTables = currentEntityTables,
+            currentTableHashes = currentTableHashes,
+            changedTableNames = changedTableNames,
+            renameOperations = renameOperations,
+        )
+    }
+
+    fun planRenameTables(
+        entities: List<LsiClass>,
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ): List<RenameTable> {
+        val previous = readSnapshot(settings)
+        val current = entities.toSnapshot()
+        return planRenameTables(
+            previous = previous,
+            current = current,
+            schema = schema,
+        )
+    }
+
+    fun readSnapshot(settings: JimmerDdlCompilerSettings): JimmerDdlSnapshot {
+        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return JimmerDdlSnapshot()
+        return snapshotFile.readSnapshot()
+    }
+
+    private fun planRenameTables(
+        previous: JimmerDdlSnapshot,
+        current: Map<String, String>,
+        schema: AutoDdlSchema,
+    ): List<RenameTable> {
+        if (previous.entityTables.isEmpty()) {
+            return emptyList()
+        }
+
+        val existingDesiredTables = schema.tables.map { table -> table.name.lowercase() }.toSet()
+        return current.mapNotNull { entry ->
+            val oldTableName = previous.entityTables[entry.key]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val newTableName = entry.value.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            if (oldTableName.equals(newTableName, ignoreCase = true)) {
+                return@mapNotNull null
+            }
+            if (newTableName.lowercase() !in existingDesiredTables) {
+                return@mapNotNull null
+            }
+            RenameTable(
+                oldTableName = oldTableName,
+                newTableName = newTableName,
+            )
+        }.distinctBy { operation ->
+            "${operation.oldTableName.lowercase()}->${operation.newTableName.lowercase()}"
+        }
+    }
+
+    fun writeSnapshot(
+        entities: List<LsiClass>,
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ) {
+        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return
+        writeSnapshot(
+            snapshotFile = snapshotFile,
+            entities = entities,
+            schema = schema,
+            settings = settings,
+        )
+    }
+
+    fun writeGeneratedSnapshot(
+        entities: List<LsiClass>,
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ) {
+        val snapshotFile = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
+        writeSnapshot(
+            snapshotFile = snapshotFile,
+            entities = entities,
+            schema = schema,
+            settings = settings,
+        )
+    }
+
+    private fun writeSnapshot(
+        snapshotFile: File,
+        entities: List<LsiClass>,
+        schema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ) {
+        val previous = snapshotFile.readSnapshot()
+        val current = entities.toSnapshot()
+        val tableHashes = schema.toTableHashes()
+        snapshotFile.parentFile.mkdirs()
+        val sourceFingerprint = settings.sourceFingerprint ?: previous.sourceFingerprint
+        val content = buildString {
+            appendLine("# Jimmer DDL entity-to-table snapshot. Do not edit manually.")
+            sourceFingerprint?.takeIf { it.isNotBlank() }?.let {
+                appendLine("$SOURCE_FINGERPRINT_KEY=${sourceFingerprint.escapeProperty()}")
+            }
+            current.toSortedMap().forEach { (qualifiedName, tableName) ->
+                appendLine("${qualifiedName.escapeProperty()}=${tableName.escapeProperty()}")
+            }
+            tableHashes.toSortedMap().forEach { (tableName, hash) ->
+                appendLine("$TABLE_HASH_PREFIX${tableName.escapeProperty()}=${hash.escapeProperty()}")
+            }
+            schema.tables.sortedBy { table -> table.name.lowercase() }.forEach { table ->
+                appendLine("$TABLE_SCHEMA_PREFIX${table.name.lowercase().escapeProperty()}=${table.toCanonicalText().encodeBase64().escapeProperty()}")
+            }
+        }
+        snapshotFile.writeText(content)
+    }
+
+    private fun List<LsiClass>.toSnapshot(): Map<String, String> {
+        return mapNotNull { entity ->
+            val qualifiedName = entity.qualifiedName?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val tableName = entity.guessJimmerTableName().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            qualifiedName to tableName
+        }.toMap()
+    }
+
+    private fun File.readSnapshot(): JimmerDdlSnapshot {
+        if (!isFile) {
+            return JimmerDdlSnapshot()
+        }
+        val props = inputStream().use { input ->
+            Properties().apply { load(input) }
+        }
+        val entityTables = linkedMapOf<String, String>()
+        val tableHashes = linkedMapOf<String, String>()
+        val tableSchemas = linkedMapOf<String, AutoDdlTable>()
+        props.entries.forEach { (key, value) ->
+            val name = key.toString()
+            val text = value.toString()
+            when {
+                name == SOURCE_FINGERPRINT_KEY -> Unit
+                name.startsWith(TABLE_HASH_PREFIX) -> {
+                    val tableName = name.removePrefix(TABLE_HASH_PREFIX).lowercase()
+                    tableHashes[tableName] = text
+                }
+                name.startsWith(TABLE_SCHEMA_PREFIX) -> {
+                    val tableName = name.removePrefix(TABLE_SCHEMA_PREFIX).lowercase()
+                    text.decodeTableSchema(tableName)?.let { table ->
+                        tableSchemas[tableName] = table
+                    }
+                }
+                !name.startsWith("__") -> {
+                    entityTables[name] = text
+                }
+            }
+        }
+        return JimmerDdlSnapshot(
+            sourceFingerprint = props.getProperty(SOURCE_FINGERPRINT_KEY),
+            entityTables = entityTables,
+            tableHashes = tableHashes,
+            tableSchemas = tableSchemas,
+        )
+    }
+
+    private fun AutoDdlSchema.toTableHashes(): Map<String, String> {
+        return tables.associate { table ->
+            table.name.lowercase() to table.toCanonicalText().sha256()
+        }
+    }
+
+    private fun AutoDdlTable.toCanonicalText(): String {
+        return buildString {
+            appendEncodedLine("table", name, comment.orEmpty())
+            junction?.let { junction ->
+                appendEncodedLine(
+                    "junction",
+                    junction.leftTableName,
+                    junction.leftColumnName,
+                    junction.rightTableName,
+                    junction.rightColumnName,
+                )
+            }
+            columns.sortedBy { column -> column.name.lowercase() }.forEach { column ->
+                appendLine("column=${column.toCanonicalText()}")
+            }
+            indexes.sortedWith(compareBy<AutoDdlIndex> { index -> index.name.lowercase() }
+                .thenBy { index -> index.columnNames.joinToString(",") { it.lowercase() } })
+                .forEach { index ->
+                    appendLine("index=${index.toCanonicalText()}")
+                }
+            foreignKeys.sortedWith(compareBy<AutoDdlForeignKey> { foreignKey -> foreignKey.name.lowercase() }
+                .thenBy { foreignKey -> foreignKey.columnNames.joinToString(",") { it.lowercase() } })
+                .forEach { foreignKey ->
+                    appendLine("foreignKey=${foreignKey.toCanonicalText()}")
+                }
+        }
+    }
+
+    private fun AutoDdlColumn.toCanonicalText(): String {
+        return listOf(
+            name,
+            logicalType.name,
+            nullable.toString(),
+            length.orEmptyPart(),
+            precision.orEmptyPart(),
+            scale.orEmptyPart(),
+            defaultValue.orEmpty(),
+            comment.orEmpty(),
+            primaryKey.toString(),
+            autoIncrement.toString(),
+            sequenceName.orEmpty(),
+            nativeTypeHint.orEmpty(),
+        ).encodeParts()
+    }
+
+    private fun AutoDdlIndex.toCanonicalText(): String {
+        return listOf(
+            name,
+            type.name,
+            columnNames.joinToString(","),
+        ).encodeParts()
+    }
+
+    private fun AutoDdlForeignKey.toCanonicalText(): String {
+        return listOf(
+            name,
+            columnNames.joinToString(","),
+            referencedTableName,
+            referencedColumnNames.joinToString(","),
+            onDelete.orEmpty(),
+            onUpdate.orEmpty(),
+        ).encodeParts()
+    }
+
+    private fun StringBuilder.appendEncodedLine(
+        key: String,
+        vararg values: String,
+    ) {
+        appendLine("$key=${values.toList().encodeParts()}")
+    }
+
+    private fun String.decodeTableSchema(defaultTableName: String): AutoDdlTable? {
+        val text = runCatching { decodeBase64() }.getOrNull() ?: return null
+        var tableName = defaultTableName
+        var tableComment: String? = null
+        var junction: AutoDdlJunction? = null
+        val columns = mutableListOf<AutoDdlColumn>()
+        val indexes = mutableListOf<AutoDdlIndex>()
+        val foreignKeys = mutableListOf<AutoDdlForeignKey>()
+        text.lineSequence()
+            .filter { line -> line.isNotBlank() && "=" in line }
+            .forEach { line ->
+                val key = line.substringBefore("=")
+                val parts = line.substringAfter("=").decodeParts()
+                when (key) {
+                    "table" -> {
+                        tableName = parts.getOrNull(0)?.takeIf { it.isNotBlank() } ?: tableName
+                        tableComment = parts.getOrNull(1)?.takeIf { it.isNotBlank() }
+                    }
+                    "junction" -> {
+                        if (parts.size >= 4) {
+                            junction = AutoDdlJunction(
+                                parts[0],
+                                parts[2],
+                                parts[1],
+                                parts[3],
+                            )
+                        }
+                    }
+                    "column" -> parts.toColumn()?.let(columns::add)
+                    "index" -> parts.toIndex()?.let(indexes::add)
+                    "foreignKey" -> parts.toForeignKey()?.let(foreignKeys::add)
+                }
+            }
+        if (columns.isEmpty()) {
+            return null
+        }
+        return AutoDdlTable(
+            tableName,
+            columns,
+            foreignKeys,
+            indexes,
+            tableComment,
+            junction,
+        )
+    }
+
+    private fun List<String>.toColumn(): AutoDdlColumn? {
+        if (size < 12) {
+            return null
+        }
+        val logicalType = runCatching { AutoDdlLogicalType.valueOf(this[1]) }.getOrNull() ?: return null
+        return AutoDdlColumn(
+            this[0],
+            logicalType,
+            this[2].toBooleanStrictOrNull() ?: true,
+            this[3].toIntOrNull(),
+            this[4].toIntOrNull(),
+            this[5].toIntOrNull(),
+            this[6].takeIf { it.isNotBlank() },
+            this[7].takeIf { it.isNotBlank() },
+            this[8].toBooleanStrictOrNull() ?: false,
+            this[9].toBooleanStrictOrNull() ?: false,
+            this[10].takeIf { it.isNotBlank() },
+            this[11].takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun List<String>.toIndex(): AutoDdlIndex? {
+        if (size < 3) {
+            return null
+        }
+        val indexType = runCatching { AutoDdlIndexType.valueOf(this[1]) }.getOrNull() ?: return null
+        return AutoDdlIndex(
+            this[0],
+            this[2].split(',').filter { it.isNotBlank() },
+            indexType,
+        )
+    }
+
+    private fun List<String>.toForeignKey(): AutoDdlForeignKey? {
+        if (size < 6) {
+            return null
+        }
+        return AutoDdlForeignKey(
+            this[0],
+            this[1].split(',').filter { it.isNotBlank() },
+            this[2],
+            this[3].split(',').filter { it.isNotBlank() },
+            this[4].takeIf { it.isNotBlank() },
+            this[5].takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun List<String>.encodeParts(): String {
+        return joinToString("|") { value -> value.encodeBase64() }
+    }
+
+    private fun String.decodeParts(): List<String> {
+        return split('|').map { value -> value.decodeBase64() }
+    }
+
+    private fun String.encodeBase64(): String {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(toByteArray())
+    }
+
+    private fun String.decodeBase64(): String {
+        return String(Base64.getUrlDecoder().decode(this))
+    }
+
+    private fun Int?.orEmptyPart(): String {
+        return this?.toString().orEmpty()
+    }
+
+    private fun String.sha256(): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update(toByteArray())
+        return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    private fun String.escapeProperty(): String {
+        return replace("\\", "\\\\")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("=", "\\=")
+            .replace(":", "\\:")
+    }
+}
+
+private fun LsiClass.guessJimmerTableName(): String {
+    val tableName = annotations.firstNotNullOfOrNull { annotation ->
+        if (annotation.qualifiedName != "org.babyfish.jimmer.sql.Table" && annotation.simpleName != "Table") {
+            return@firstNotNullOfOrNull null
+        }
+        annotation.getAttribute("name")?.toString()?.takeIf { it.isNotBlank() }
+    }
+    return tableName ?: simpleName.orEmpty().toSnakeCase()
+}
+
+private fun String.toSnakeCase(): String {
+    if (isBlank()) {
+        return this
+    }
+    val builder = StringBuilder()
+    for (index in indices) {
+        val char = this[index]
+        if (char in 'A'..'Z') {
+            if (index > 0 && builder.lastOrNull() != '_') {
+                builder.append('_')
+            }
+            builder.append(char.lowercaseChar())
+        } else {
+            builder.append(char)
+        }
+    }
+    return builder.toString()
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/apt/JimmerDdlCompilerAptProcessor.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/apt/JimmerDdlCompilerAptProcessor.kt
@@ -1,0 +1,130 @@
+package org.babyfish.jimmer.ddl.compiler.apt
+
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompiler
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlEntityTableSnapshot
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompilerFiles
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompilerSettings
+import site.addzero.lsi.apt.clazz.toLsiClass
+import site.addzero.lsi.clazz.LsiClass
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.RoundEnvironment
+import javax.annotation.processing.SupportedAnnotationTypes
+import javax.annotation.processing.SupportedOptions
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+import javax.tools.Diagnostic
+
+private const val JIMMER_ENTITY = "org.babyfish.jimmer.sql.Entity"
+
+@SupportedAnnotationTypes(JIMMER_ENTITY)
+@SupportedOptions(
+    "jimmerDdl.enabled",
+    "jimmerDdl.profiles",
+    "jimmerDdl.databaseType",
+    "jimmerDdl.jdbcUrl",
+    "jimmerDdl.jdbcUsername",
+    "jimmerDdl.jdbcPassword",
+    "jimmerDdl.jdbcSchema",
+    "jimmerDdl.jdbcDriver",
+    "jimmerDdl.springResourcePath",
+    "jimmerDdl.springProfile",
+    "jimmerDdl.outputFormat",
+    "jimmerDdl.outputDir",
+    "jimmerDdl.version",
+    "jimmerDdl.description",
+    "jimmerDdl.includePackages",
+    "jimmerDdl.excludePackages",
+    "jimmerDdl.includeForeignKeys",
+    "jimmerDdl.includeIndexes",
+    "jimmerDdl.includeComments",
+    "jimmerDdl.includeSequences",
+    "jimmerDdl.includeManyToManyTables",
+    "jimmerDdl.compareDatabase",
+    "jimmerDdl.nullabilityRepairOnly",
+    "jimmerDdl.sourceFingerprint",
+)
+class JimmerDdlCompilerAptProcessor : AbstractProcessor() {
+    private val entities = linkedMapOf<String, LsiClass>()
+    private val supportedOptionNames = buildSet {
+        addAll(
+            listOf(
+                "jimmerDdl.enabled",
+                "jimmerDdl.profiles",
+                "jimmerDdl.databaseType",
+                "jimmerDdl.jdbcUrl",
+                "jimmerDdl.jdbcUsername",
+                "jimmerDdl.jdbcPassword",
+                "jimmerDdl.jdbcSchema",
+                "jimmerDdl.jdbcDriver",
+                "jimmerDdl.springResourcePath",
+                "jimmerDdl.springProfile",
+                "jimmerDdl.outputFormat",
+                "jimmerDdl.outputDir",
+                "jimmerDdl.version",
+                "jimmerDdl.description",
+                "jimmerDdl.includePackages",
+                "jimmerDdl.excludePackages",
+                "jimmerDdl.includeForeignKeys",
+                "jimmerDdl.includeIndexes",
+                "jimmerDdl.includeComments",
+                "jimmerDdl.includeSequences",
+                "jimmerDdl.includeManyToManyTables",
+                "jimmerDdl.compareDatabase",
+                "jimmerDdl.nullabilityRepairOnly",
+                "jimmerDdl.sourceFingerprint",
+            )
+        )
+    }
+
+    override fun getSupportedOptions(): MutableSet<String> {
+        return supportedOptionNames.toMutableSet()
+    }
+
+    override fun getSupportedSourceVersion(): SourceVersion {
+        return SourceVersion.latestSupported()
+    }
+
+    override fun process(
+        annotations: Set<TypeElement>,
+        roundEnv: RoundEnvironment,
+    ): Boolean {
+        val settingsList = JimmerDdlCompilerSettings.allFromOptions(processingEnv.options)
+        if (settingsList.none { it.enabled }) {
+            return false
+        }
+
+        if (!roundEnv.processingOver()) {
+            roundEnv.getElementsAnnotatedWithAny(annotations).forEach { entity ->
+                val key = entity.qualifiedName.toString()
+                entities[key] = entity.toLsiClass(processingEnv.elementUtils)
+            }
+            return false
+        }
+
+        if (entities.isEmpty()) {
+            return false
+        }
+        settingsList.forEach { settings ->
+            val result = JimmerDdlCompiler.compile(entities.values, settings)
+            result.warnings.forEach { warning ->
+                processingEnv.messager.printMessage(Diagnostic.Kind.WARNING, warning)
+            }
+            JimmerDdlEntityTableSnapshot.writeGeneratedSnapshot(
+                entities = result.entities,
+                schema = result.snapshotSchema,
+                settings = settings,
+            )
+            if (!result.isEmpty) {
+                val outputFile = JimmerDdlCompilerFiles.writeOutputFile(settings, result.sql)
+                processingEnv.messager.printMessage(Diagnostic.Kind.NOTE, "Jimmer DDL generated: ${outputFile.absolutePath}")
+            }
+        }
+        return false
+    }
+
+    private fun RoundEnvironment.getElementsAnnotatedWithAny(annotations: Set<TypeElement>): List<TypeElement> {
+        return annotations
+            .flatMap { getElementsAnnotatedWith(it) }
+            .filterIsInstance<TypeElement>()
+    }
+}

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/ksp/JimmerDdlCompilerProcessorProvider.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/ksp/JimmerDdlCompilerProcessorProvider.kt
@@ -1,0 +1,110 @@
+package org.babyfish.jimmer.ddl.compiler.ksp
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.validate
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompiler
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlEntityTableSnapshot
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompilerFiles
+import org.babyfish.jimmer.ddl.compiler.JimmerDdlCompilerSettings
+import org.babyfish.jimmer.ddl.compiler.toStableJimmerDdlSnapshot
+import site.addzero.lsi.clazz.LsiClass
+import site.addzero.lsi.ksp.clazz.toLsiClass
+import java.io.File
+
+private const val JIMMER_ENTITY = "org.babyfish.jimmer.sql.Entity"
+
+class JimmerDdlCompilerProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        val settingsList = JimmerDdlCompilerSettings.allFromOptions(environment.options)
+        val projectDirs = settingsList.mapNotNull { settings ->
+            settings.outputDir.toProjectDirFromOutputDir()
+        }.toSet()
+        return object : SymbolProcessor {
+            private val entities = linkedMapOf<String, LsiClass>()
+            private val relationTargetEntities = linkedMapOf<String, LsiClass>()
+            private var hasErrors = false
+
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                if (settingsList.none { it.enabled }) {
+                    return emptyList()
+                }
+                val deferred = mutableListOf<KSAnnotated>()
+                resolver.getSymbolsWithAnnotation(JIMMER_ENTITY).forEach { symbol ->
+                    if (!symbol.validate()) {
+                        deferred += symbol
+                        return@forEach
+                    }
+                    val declaration = symbol as? KSClassDeclaration
+                    if (declaration == null) {
+                        environment.logger.error("Jimmer DDL can only process class declarations: $symbol", symbol)
+                        hasErrors = true
+                        return@forEach
+                    }
+                    val key = declaration.qualifiedName?.asString() ?: declaration.simpleName.asString()
+                    val lsiClass = declaration.toLsiClass(resolver).toStableJimmerDdlSnapshot()
+                    relationTargetEntities[key] = lsiClass
+                    if (declaration.isCurrentProjectSource(projectDirs)) {
+                        entities[key] = lsiClass
+                    }
+                }
+                return deferred
+            }
+
+            override fun finish() {
+                if (hasErrors || entities.isEmpty()) {
+                    return
+                }
+                settingsList.forEach { settings ->
+                    val result = JimmerDdlCompiler.compile(
+                        classes = entities.values,
+                        settings = settings,
+                        relationTargetClasses = relationTargetEntities.values,
+                    )
+                    result.warnings.forEach { warning ->
+                        environment.logger.warn(warning)
+                    }
+                    JimmerDdlEntityTableSnapshot.writeGeneratedSnapshot(
+                        entities = result.entities,
+                        schema = result.snapshotSchema,
+                        settings = settings,
+                    )
+                    if (!result.isEmpty) {
+                        val outputFile = JimmerDdlCompilerFiles.writeOutputFile(settings, result.sql)
+                        environment.logger.warn("Jimmer DDL generated: ${outputFile.absolutePath}")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun KSClassDeclaration.isCurrentProjectSource(projectDirs: Set<String>): Boolean {
+    val path = containingFile?.filePath?.normalizedPath() ?: return false
+    if (path.contains("/build/generated/")) {
+        return false
+    }
+    if (projectDirs.isEmpty()) {
+        return true
+    }
+    return projectDirs.any { projectDir ->
+        path.startsWith("$projectDir/src/")
+    }
+}
+
+private fun String.toProjectDirFromOutputDir(): String? {
+    val outputPath = File(this).absolutePath.normalizedPath()
+    val index = outputPath.indexOf("/build/")
+    if (index < 0) {
+        return null
+    }
+    return outputPath.substring(0, index).trimEnd('/').takeIf { it.isNotBlank() }
+}
+
+private fun String.normalizedPath(): String {
+    return replace('\\', '/')
+}

--- a/project/jimmer-ddl-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/project/jimmer-ddl-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+org.babyfish.jimmer.ddl.compiler.ksp.JimmerDdlCompilerProcessorProvider

--- a/project/jimmer-ddl-compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/project/jimmer-ddl-compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.babyfish.jimmer.ddl.compiler.apt.JimmerDdlCompilerAptProcessor

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
@@ -1,0 +1,461 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import site.addzero.ddlgenerator.core.model.AutoDdlColumn
+import site.addzero.ddlgenerator.core.model.AutoDdlLogicalType
+import site.addzero.ddlgenerator.core.model.AutoDdlSchema
+import site.addzero.ddlgenerator.core.model.AutoDdlTable
+import site.addzero.lsi.anno.LsiAnnotation
+import site.addzero.lsi.clazz.LsiClass
+import site.addzero.lsi.field.LsiField
+import site.addzero.lsi.method.LsiMethod
+import site.addzero.lsi.type.LsiType
+import site.addzero.util.db.DatabaseType
+import kotlin.io.path.createTempDirectory
+
+class JimmerDdlCompilerTest {
+
+    @Test
+    fun `table annotation rename emits rename table operation from entity snapshot`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val originalEntity = bookEntity(tableName = "biz_user")
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = listOf(originalEntity),
+            schema = AutoDdlSchema(
+                listOf(
+                    AutoDdlTable(
+                        "biz_user",
+                        listOf(
+                            AutoDdlColumn("id", AutoDdlLogicalType.INT64, false, null, null, null, null, null, true, false, null, null),
+                        ),
+                        emptyList(),
+                        emptyList(),
+                        null,
+                        null,
+                    )
+                ),
+                emptyList(),
+            ),
+            settings = settings,
+        )
+
+        val renamedEntity = bookEntity(tableName = "biz_user_ext")
+        val renamedSchema = AutoDdlSchema(
+            listOf(
+                AutoDdlTable(
+                    "biz_user_ext",
+                    listOf(
+                        AutoDdlColumn("id", AutoDdlLogicalType.INT64, false, null, null, null, null, null, true, false, null, null),
+                    ),
+                    emptyList(),
+                    emptyList(),
+                    null,
+                    null,
+                )
+            ),
+            emptyList(),
+        )
+
+        val operations = JimmerDdlEntityTableSnapshot.planRenameTables(
+            entities = listOf(renamedEntity),
+            schema = renamedSchema,
+            settings = settings,
+        )
+
+        assertEquals(listOf(RenameTable("biz_user", "biz_user_ext")), operations)
+    }
+
+    @Test
+    fun `postgresql ddl contains idempotent table column and nullable repair statements`() {
+        val entity = bookEntity()
+        val result = JimmerDdlCompiler.compile(
+            classes = listOf(entity),
+            settings = JimmerDdlCompilerSettings(
+                databaseType = DatabaseType.POSTGRESQL,
+                outputFormat = JimmerDdlOutputFormat.PLAIN,
+            )
+        )
+
+        assertContains(result.sql, "CREATE TABLE \"book\"")
+        assertContains(result.sql, """"title" VARCHAR(255) NOT NULL""")
+        assertContains(result.sql, """ALTER TABLE "book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
+    }
+
+    @Test
+    fun `same schema snapshot does not emit ddl`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val entity = bookEntity()
+        val first = JimmerDdlCompiler.compile(
+            classes = listOf(entity),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = first.entities,
+            schema = first.schema,
+            settings = settings,
+        )
+
+        val second = JimmerDdlCompiler.compile(
+            classes = listOf(entity),
+            settings = settings,
+        )
+
+        assertEquals("", second.sql)
+    }
+
+    @Test
+    fun `changed schema snapshot only emits incremental ddl`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val entity = bookEntity()
+        val first = JimmerDdlCompiler.compile(
+            classes = listOf(entity),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = first.entities,
+            schema = first.schema,
+            settings = settings,
+        )
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true)),
+            settings = settings,
+        )
+
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN "summary" VARCHAR(255);""")
+        assertFalse("CREATE TABLE" in changed.sql)
+    }
+
+    @Test
+    fun `removed property emits drop column ddl`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val first = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true)),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = first.entities,
+            schema = first.schema,
+            settings = settings,
+        )
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = false)),
+            settings = settings,
+        )
+
+        assertContains(changed.sql, """ALTER TABLE "book" DROP COLUMN "summary";""")
+    }
+
+    @Test
+    fun `offline incremental ddl emits structural column changes`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+            nullabilityRepairOnly = true,
+        )
+        val first = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity()),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = first.entities,
+            schema = first.schema,
+            settings = settings,
+        )
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true, titleTypeName = "Int")),
+            settings = settings,
+        )
+
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN "summary" VARCHAR(255);""")
+        assertContains(changed.sql, """ALTER TABLE "book" ALTER COLUMN "title" TYPE INTEGER;""")
+        assertContains(changed.sql, """ALTER TABLE "book" ALTER COLUMN "title" SET NOT NULL;""")
+        assertTrue(changed.warnings.none { warning -> "skipped column structure changes" in warning })
+    }
+
+    @Test
+    fun `generated snapshot is staged under generated resources instead of source snapshot`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+        val outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val first = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity()),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = first.entities,
+            schema = first.schema,
+            settings = settings,
+        )
+        val sourceSnapshot = JimmerDdlCompilerFiles.resolveSnapshotFile(settings)
+        requireNotNull(sourceSnapshot)
+        val sourceContent = sourceSnapshot.readText()
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true)),
+            settings = settings,
+        )
+
+        JimmerDdlEntityTableSnapshot.writeGeneratedSnapshot(
+            entities = changed.entities,
+            schema = changed.schema,
+            settings = settings,
+        )
+
+        val generatedSnapshot = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
+        assertTrue(generatedSnapshot.isFile)
+        assertEquals(sourceContent, sourceSnapshot.readText())
+        assertFalse(sourceContent == generatedSnapshot.readText())
+    }
+
+    @Test
+    fun `cross module inherited many to many emits junction table without target table`() {
+        val user = TestClass(
+            simpleName = "User",
+            qualifiedName = "site.addzero.crud.model.system.user.User",
+            annotations = listOf(entity(), table("system_users")),
+            fields = listOf(
+                TestField(
+                    name = "id",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                    annotations = listOf(id()),
+                )
+            ),
+        )
+        val basePersonInCharge = TestClass(
+            simpleName = "BasePersonInCharge",
+            qualifiedName = "cn.iocoder.yudao.module.ai.power.equipment_information_archive.entity.BasePersonInCharge",
+            annotations = listOf(mappedSuperclass()),
+            fields = listOf(
+                TestField(
+                    name = "personInCharge",
+                    type = TestType(
+                        simpleName = "List",
+                        qualifiedName = "kotlin.collections.List",
+                        isCollectionType = true,
+                        typeParameters = listOf(
+                            TestType(
+                                simpleName = "User",
+                                qualifiedName = "site.addzero.crud.model.system.user.User",
+                                lsiClass = user,
+                            )
+                        ),
+                    ),
+                    typeName = "List",
+                    annotations = listOf(manyToMany()),
+                    isCollectionType = true,
+                )
+            ),
+        )
+        val device = TestClass(
+            simpleName = "EquipmentInformationArchive",
+            qualifiedName = "cn.iocoder.yudao.module.ai.power.equipment_information_archive.entity.EquipmentInformationArchive",
+            annotations = listOf(entity(), table("ai_power_device")),
+            fields = listOf(
+                TestField(
+                    name = "id",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                    annotations = listOf(id()),
+                )
+            ),
+            interfaces = listOf(basePersonInCharge),
+        )
+
+        val result = JimmerDdlCompiler.compile(
+            classes = listOf(device.toStableJimmerDdlSnapshot()),
+            settings = JimmerDdlCompilerSettings(
+                databaseType = DatabaseType.POSTGRESQL,
+                outputFormat = JimmerDdlOutputFormat.PLAIN,
+                compareDatabase = false,
+            ),
+        )
+
+        assertContains(result.sql, "CREATE TABLE \"ai_power_device\"")
+        assertContains(result.sql, "CREATE TABLE \"equipment_information_archive_person_in_charge_mapping\"")
+        assertContains(result.sql, "\"equipment_information_archive_id\" BIGINT NOT NULL")
+        assertContains(result.sql, "\"user_id\" BIGINT NOT NULL")
+        assertFalse("CREATE TABLE \"system_users\"" in result.sql)
+    }
+
+    private fun bookEntity(
+        tableName: String = "book",
+        extraField: Boolean = false,
+        titleTypeName: String = "String",
+    ): TestClass {
+        return TestClass(
+            simpleName = "Book",
+            qualifiedName = "demo.Book",
+            annotations = listOf(entity(), table(tableName)),
+            fields = listOf(
+                TestField(
+                    name = "id",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                    annotations = listOf(id()),
+                ),
+                TestField(
+                    name = "title",
+                    type = TestType(titleTypeName),
+                    typeName = titleTypeName,
+                    annotations = listOf(column("title")),
+                ),
+                TestField(
+                    name = "subtitle",
+                    type = TestType("String"),
+                    typeName = "String",
+                    annotations = listOf(column("subtitle")),
+                    isNullable = true,
+                ),
+            ) + if (extraField) {
+                listOf(
+                    TestField(
+                        name = "summary",
+                        type = TestType("String"),
+                        typeName = "String",
+                        annotations = listOf(column("summary")),
+                        isNullable = true,
+                    )
+                )
+            } else {
+                emptyList()
+            }
+        )
+    }
+
+    private fun entity(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Entity", "Entity")
+    }
+
+    private fun mappedSuperclass(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.MappedSuperclass", "MappedSuperclass")
+    }
+
+    private fun table(name: String): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Table", "Table", mapOf("name" to name))
+    }
+
+    private fun id(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Id", "Id")
+    }
+
+    private fun column(name: String): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Column", "Column", mapOf("name" to name))
+    }
+
+    private fun manyToMany(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.ManyToMany", "ManyToMany")
+    }
+
+    private data class TestAnnotation(
+        override val qualifiedName: String?,
+        override val simpleName: String?,
+        override val attributes: Map<String, Any?> = emptyMap(),
+    ) : LsiAnnotation {
+        override fun getAttribute(name: String): Any? = attributes[name]
+
+        override fun hasAttribute(name: String): Boolean = attributes.containsKey(name)
+    }
+
+    private data class TestType(
+        override val simpleName: String?,
+        override val qualifiedName: String? = simpleName,
+        override val presentableText: String? = simpleName,
+        override val annotations: List<LsiAnnotation> = emptyList(),
+        override val isCollectionType: Boolean = false,
+        override val isNullable: Boolean = false,
+        override val typeParameters: List<LsiType> = emptyList(),
+        override val isPrimitive: Boolean = false,
+        override val componentType: LsiType? = null,
+        override val isArray: Boolean = false,
+        override val lsiClass: LsiClass? = null,
+    ) : LsiType
+
+    private data class TestField(
+        override val name: String?,
+        override val type: LsiType? = null,
+        override val typeName: String? = type?.simpleName,
+        override val comment: String? = null,
+        override val annotations: List<LsiAnnotation> = emptyList(),
+        override val isStatic: Boolean = false,
+        override val isConstant: Boolean = false,
+        override val isEnum: Boolean = false,
+        override val isVar: Boolean = false,
+        override val isLateInit: Boolean = false,
+        override val isCollectionType: Boolean = false,
+        override val defaultValue: String? = null,
+        override val columnName: String? = null,
+        override val declaringClass: LsiClass? = null,
+        override val fieldTypeClass: LsiClass? = null,
+        override val isNestedObject: Boolean = false,
+        override val children: List<LsiField> = emptyList(),
+        override val isNullable: Boolean = false,
+    ) : LsiField
+
+    private data class TestClass(
+        override val simpleName: String?,
+        override val qualifiedName: String? = simpleName,
+        override val comment: String? = null,
+        override val fields: List<LsiField> = emptyList(),
+        override val annotations: List<LsiAnnotation> = emptyList(),
+        override val isInterface: Boolean = true,
+        override val isEnum: Boolean = false,
+        override val isCollectionType: Boolean = false,
+        override val isPojo: Boolean = true,
+        override val superClasses: List<LsiClass> = emptyList(),
+        override val interfaces: List<LsiClass> = emptyList(),
+        override val methods: List<LsiMethod> = emptyList(),
+        override val fileName: String? = null,
+        override val isObject: Boolean = false,
+        override val isCompanionObject: Boolean = false,
+    ) : LsiClass
+}

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
@@ -1,10 +1,17 @@
 package org.babyfish.jimmer.ddl.compiler
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.StandardLocation
+import javax.tools.ToolProvider
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.babyfish.jimmer.ddl.compiler.apt.JimmerDdlCompilerAptProcessor
 import site.addzero.ddlgenerator.core.model.AutoDdlColumn
 import site.addzero.ddlgenerator.core.model.AutoDdlLogicalType
 import site.addzero.ddlgenerator.core.model.AutoDdlSchema
@@ -18,6 +25,153 @@ import site.addzero.util.db.DatabaseType
 import kotlin.io.path.createTempDirectory
 
 class JimmerDdlCompilerTest {
+
+    @Test
+    fun `apt processor generates ddl file from java jimmer entity`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-apt-test")
+            .toFile()
+        val sourceDir = projectDir.resolve("src/main/java")
+        val classesDir = projectDir.resolve("build/classes")
+        val outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        writeJavaSource(
+            sourceDir = sourceDir,
+            path = "org/babyfish/jimmer/sql/Entity.java",
+            content = """
+                package org.babyfish.jimmer.sql;
+
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Target(ElementType.TYPE)
+                @Retention(RetentionPolicy.RUNTIME)
+                public @interface Entity {}
+            """.trimIndent(),
+        )
+        writeJavaSource(
+            sourceDir = sourceDir,
+            path = "org/babyfish/jimmer/sql/Table.java",
+            content = """
+                package org.babyfish.jimmer.sql;
+
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Target(ElementType.TYPE)
+                @Retention(RetentionPolicy.RUNTIME)
+                public @interface Table {
+                    String name() default "";
+                }
+            """.trimIndent(),
+        )
+        writeJavaSource(
+            sourceDir = sourceDir,
+            path = "org/babyfish/jimmer/sql/Id.java",
+            content = """
+                package org.babyfish.jimmer.sql;
+
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Target(ElementType.METHOD)
+                @Retention(RetentionPolicy.RUNTIME)
+                public @interface Id {}
+            """.trimIndent(),
+        )
+        writeJavaSource(
+            sourceDir = sourceDir,
+            path = "org/babyfish/jimmer/sql/Column.java",
+            content = """
+                package org.babyfish.jimmer.sql;
+
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Target(ElementType.METHOD)
+                @Retention(RetentionPolicy.RUNTIME)
+                public @interface Column {
+                    String name() default "";
+                }
+            """.trimIndent(),
+        )
+        writeJavaSource(
+            sourceDir = sourceDir,
+            path = "demo/AptBook.java",
+            content = """
+                package demo;
+
+                import org.babyfish.jimmer.sql.Column;
+                import org.babyfish.jimmer.sql.Entity;
+                import org.babyfish.jimmer.sql.Id;
+                import org.babyfish.jimmer.sql.Table;
+
+                @Entity
+                @Table(name = "apt_book")
+                public interface AptBook {
+                    @Id
+                    long id();
+
+                    @Column(name = "title")
+                    String title();
+
+                    @Column(name = "subtitle")
+                    String subtitle();
+                }
+            """.trimIndent(),
+        )
+
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val compiler = ToolProvider.getSystemJavaCompiler()
+            ?: error("JDK compiler is required to run APT integration tests")
+        val sourceFiles = sourceDir.walkTopDown()
+            .filter { file -> file.isFile && file.extension == "java" }
+            .toList()
+        classesDir.mkdirs()
+        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8).use { fileManager ->
+            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(classesDir))
+            val task = compiler.getTask(
+                null,
+                fileManager,
+                diagnostics,
+                listOf(
+                    "-classpath",
+                    System.getProperty("java.class.path"),
+                    "-AjimmerDdl.enabled=true",
+                    "-AjimmerDdl.databaseType=postgresql",
+                    "-AjimmerDdl.outputFormat=plain",
+                    "-AjimmerDdl.outputDir=${outputDir.absolutePath}",
+                    "-AjimmerDdl.description=apt_generated",
+                    "-AjimmerDdl.compareDatabase=false",
+                ),
+                null,
+                fileManager.getJavaFileObjectsFromFiles(sourceFiles),
+            )
+            task.setProcessors(listOf(JimmerDdlCompilerAptProcessor()))
+            val compiled = task.call()
+            assertTrue(compiled, diagnostics.toErrorMessage())
+        }
+
+        val sqlFile = outputDir.resolve("apt_generated.sql")
+        assertTrue(sqlFile.isFile, "APT should generate ddl file: ${sqlFile.absolutePath}")
+        val sql = sqlFile.readText()
+        assertContains(sql, """CREATE TABLE "apt_book"""")
+        assertContains(sql, """"id" BIGINT NOT NULL""")
+        assertContains(sql, """"title" VARCHAR(255)""")
+        assertContains(sql, """"subtitle" VARCHAR(255)""")
+        assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "title" DROP NOT NULL;""")
+        assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
+
+        val snapshotFile = projectDir.resolve("build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties")
+        assertTrue(snapshotFile.isFile, "APT should generate snapshot file: ${snapshotFile.absolutePath}")
+        assertContains(snapshotFile.readText(), "demo.AptBook=apt_book")
+    }
 
     @Test
     fun `table annotation rename emits rename table operation from entity snapshot`() {
@@ -394,6 +548,28 @@ class JimmerDdlCompilerTest {
 
     private fun manyToMany(): TestAnnotation {
         return TestAnnotation("org.babyfish.jimmer.sql.ManyToMany", "ManyToMany")
+    }
+
+    private fun writeJavaSource(
+        sourceDir: File,
+        path: String,
+        content: String,
+    ) {
+        val file = sourceDir.resolve(path)
+        file.parentFile.mkdirs()
+        file.writeText(content)
+    }
+
+    private fun DiagnosticCollector<JavaFileObject>.toErrorMessage(): String {
+        return diagnostics.joinToString(separator = "\n") { diagnostic ->
+            val source = diagnostic.source?.name.orEmpty()
+            val position = if (diagnostic.lineNumber > 0) {
+                "${diagnostic.lineNumber}:${diagnostic.columnNumber}"
+            } else {
+                "?:?"
+            }
+            "${diagnostic.kind} $source:$position ${diagnostic.getMessage(null)}"
+        }
     }
 
     private data class TestAnnotation(

--- a/project/settings.gradle.kts
+++ b/project/settings.gradle.kts
@@ -13,6 +13,7 @@ include(
     "jimmer-dto-compiler",
     "jimmer-client-swagger",
     "jimmer-client-scalar",
+    "jimmer-ddl-compiler",
 )
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Summary
- Add `jimmer-ddl-compiler` as a KSP/APT processor module for generating DDL from Jimmer entity metadata.
- Convert Jimmer entities to the LSI model, render dialect-specific SQL, and persist entity/table snapshots for incremental DDL and table rename detection.
- Add README usage/options docs and focused unit tests for snapshots, incremental DDL, PostgreSQL repairs, and inherited many-to-many junction tables.
- Depend on the published Addzero LSI and ddlgenerator artifacts from Maven Central (`site.addzero:*:2026.06.24`).

## Note
- The Addzero artifacts currently published to Maven Central carry newer Kotlin metadata than this project, so the module scopes `-Xskip-metadata-version-check` only to `jimmer-ddl-compiler`.

## Test
- `./gradlew :jimmer-ddl-compiler:test`
