### PR TITLE
fix(base-query): render CTE body for expression-only base table

### DIFF
--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/base/CteBaseQueryTest.kt
@@ -1013,6 +1013,42 @@ class CteBaseQueryTest : AbstractQueryTest() {
     }
 
     @Test
+    fun testExpressionOnlyWeakJoinTarget() {
+        val baseAuthor = cteBaseTableSymbol {
+            sqlClient.createBaseQuery(Author::class) {
+                where(table.gender eq Gender.MALE)
+                groupBy(table.firstName)
+                selections
+                    .add(table.firstName)
+                    .add(count(table.id))
+            }
+        }
+        executeAndExpect(
+            sqlClient.createQuery(Book::class) {
+                where(
+                    table.asTableEx().weakJoin(baseAuthor) {
+                        source.name eq target._1
+                    }._2 gt 0
+                )
+                select(table)
+            }
+        ) {
+            sql(
+                "with tb_2_(c1, c2) as (" +
+                    "--->select tb_3_.FIRST_NAME, count(tb_3_.ID) " +
+                    "--->from AUTHOR tb_3_ " +
+                    "--->where tb_3_.GENDER = ? " +
+                    "--->group by tb_3_.FIRST_NAME" +
+                    ") " +
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID " +
+                    "from BOOK tb_1_ " +
+                    "inner join (tb_2_) on tb_1_.NAME = tb_2_.c1 " +
+                    "where tb_2_.c2 > ?"
+            )
+        }
+    }
+
+    @Test
     fun testIllegalTableWeakJoinBaseTable() {
         val baseAuthor = cteBaseTableSymbol {
             sqlClient.createBaseQuery(Author::class) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageCollector.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageCollector.java
@@ -99,6 +99,7 @@ public class TableUsageCollector extends TableUsageVisitor {
     @Override
     public void visitBaseTableExpression(BaseTableOwner baseTableOwner) {
         baseQueryExportUsagesBuilder.requireExpressionExport(canonicalTableOwner(baseTableOwner));
+        useResolvedBaseTable(baseTableOwner);
     }
 
     protected final TableUsedState getTableUsedState(RealTable table) {


### PR DESCRIPTION
# Render CTE body for expression-only base table

## Problem

When a base table is used as a weak-join target and is referenced **only**
through exported expressions (no entity table selection), its CTE declaration
renders an **empty body** — invalid SQL that the database rejects with a syntax
error:

```
with tb_2_(c1, c2) as  select ... where tb_2_.c2 > ?
                     ^^ empty body, no parentheses
```

## Root cause

`TableUsageCollector` marks the resolved base table as *used* on the
table-reference and fetcher-field paths (via `useResolvedBaseTable`), but not on
the expression path. A base table touched only by expression columns therefore
stays `TableUsedState.NONE`, and `RealTableImpl.renderTo` skips its body.

## Fix

Complete the `useResolvedBaseTable` pattern: mark the resolved base table used
when visiting a base-table expression, mirroring the reference and fetcher-field
paths.

```java
@Override
public void visitBaseTableExpression(BaseTableOwner baseTableOwner) {
    baseQueryExportUsagesBuilder.requireExpressionExport(canonicalTableOwner(baseTableOwner));
    useResolvedBaseTable(baseTableOwner); // <-- added
}
```

## Reproduction

```kotlin
val baseAuthor = cteBaseTableSymbol {
    sqlClient.createBaseQuery(Author::class) {
        where(table.gender eq Gender.MALE)
        groupBy(table.firstName)
        selections
            .add(table.firstName)   // expression-only base query
            .add(count(table.id))   // (no entity table selection)
    }
}

sqlClient.createQuery(Book::class) {
    where(
        table.asTableEx().weakJoin(baseAuthor) {
            source.name eq target._1
        }._2 gt 0
    )
    select(table)
}
```

Before the fix the CTE body was empty; after the fix it renders correctly:

```sql
with tb_2_(c1, c2) as (
    select tb_3_.FIRST_NAME, count(tb_3_.ID)
    from AUTHOR tb_3_
    where tb_3_.GENDER = ?
    group by tb_3_.FIRST_NAME
)
select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE, tb_1_.STORE_ID
from BOOK tb_1_
inner join (tb_2_) on tb_1_.NAME = tb_2_.c1
where tb_2_.c2 > ?
```

## Tests

Added `CteBaseQueryTest.testExpressionOnlyWeakJoinTarget` (Kotlin). Full
`jimmer-sql` and `jimmer-sql-kotlin` suites pass.
