### PR TITLE
Fix nested fetchers in transient resolvers

### DIFF
--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434Department.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434Department.kt
@@ -1,0 +1,15 @@
+package org.babyfish.jimmer.sql.kt.model.fetcher
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.Table
+
+@Entity
+@Table(name = "ISSUE_1434_DEPARTMENT")
+interface Issue1434Department {
+
+    @Id
+    val id: Long
+
+    val name: String
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434Message.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434Message.kt
@@ -1,0 +1,24 @@
+package org.babyfish.jimmer.sql.kt.model.fetcher
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.ForeignKeyType
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.JoinColumn
+import org.babyfish.jimmer.sql.ManyToOne
+import org.babyfish.jimmer.sql.Table
+import org.babyfish.jimmer.sql.Transient
+
+@Entity
+@Table(name = "ISSUE_1434_MESSAGE")
+interface Issue1434Message {
+
+    @Id
+    val id: Long
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", foreignKeyType = ForeignKeyType.FAKE)
+    val user: Issue1434User?
+
+    @Transient(Issue1434MessageUserDepartmentNamesResolver::class)
+    val userDepartmentNames: String
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434MessageUserDepartmentNamesResolver.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434MessageUserDepartmentNamesResolver.kt
@@ -1,0 +1,33 @@
+package org.babyfish.jimmer.sql.kt.model.fetcher
+
+import org.babyfish.jimmer.sql.kt.KSqlClient
+import org.babyfish.jimmer.sql.kt.KTransientResolver
+import org.babyfish.jimmer.sql.kt.ast.expression.valueIn
+
+class Issue1434MessageUserDepartmentNamesResolver(
+    private val sqlClient: KSqlClient
+) : KTransientResolver<Long, String> {
+
+    override fun resolve(ids: Collection<Long>): Map<Long, String> {
+        val messages = sqlClient.createQuery(Issue1434Message::class) {
+            where(table.id valueIn ids)
+            select(
+                table.fetchBy {
+                    user {
+                        departments {
+                            name()
+                        }
+                    }
+                }
+            )
+        }.execute(KTransientResolver.currentConnection)
+        return messages.associate { message ->
+            message.id to (
+                message.user
+                    ?.departments
+                    ?.joinToString(",") { it.name }
+                    ?: ""
+            )
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434User.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/model/fetcher/Issue1434User.kt
@@ -1,0 +1,25 @@
+package org.babyfish.jimmer.sql.kt.model.fetcher
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.JoinTable
+import org.babyfish.jimmer.sql.ManyToMany
+import org.babyfish.jimmer.sql.Table
+
+@Entity
+@Table(name = "ISSUE_1434_USER")
+interface Issue1434User {
+
+    @Id
+    val id: Long
+
+    val name: String
+
+    @ManyToMany
+    @JoinTable(
+        name = "ISSUE_1434_USER_DEPARTMENT_MAPPING",
+        joinColumnName = "USER_ID",
+        inverseJoinColumnName = "DEPARTMENT_ID"
+    )
+    val departments: List<Issue1434Department>
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/FetcherTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/FetcherTest.kt
@@ -14,11 +14,49 @@ import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
 import org.babyfish.jimmer.sql.kt.model.classic.store.fetchBy
 import org.babyfish.jimmer.sql.kt.model.embedded.Dependency
 import org.babyfish.jimmer.sql.kt.model.embedded.dto.DependencyView
+import org.babyfish.jimmer.sql.kt.model.fetcher.Issue1434Message
+import org.babyfish.jimmer.sql.kt.model.fetcher.fetchBy
 import org.babyfish.jimmer.sql.kt.model.fetchBy
 import org.babyfish.jimmer.sql.kt.model.`parent?`
 import org.junit.Test
 
 class FetcherTest : AbstractQueryTest() {
+
+    @Test
+    fun testNestedFetcherInTransientResolverWhenUserHasNoDepartments() {
+        executeAndExpect(
+            sqlClient.createQuery(Issue1434Message::class) {
+                select(
+                    table.fetchBy {
+                        userDepartmentNames()
+                    }
+                )
+            }
+        ) {
+            sql("select tb_1_.ID from ISSUE_1434_MESSAGE tb_1_")
+            statement(1).sql(
+                "select tb_1_.ID, tb_1_.USER_ID " +
+                    "from ISSUE_1434_MESSAGE tb_1_ " +
+                    "where tb_1_.ID = ?"
+            ).variables(1L)
+            statement(2).sql(
+                "select tb_1_.ID " +
+                    "from ISSUE_1434_USER tb_1_ " +
+                    "where tb_1_.ID = ?"
+            ).variables(1L)
+            statement(3).sql(
+                "select tb_1_.ID, tb_1_.NAME " +
+                    "from ISSUE_1434_DEPARTMENT tb_1_ " +
+                    "inner join ISSUE_1434_USER_DEPARTMENT_MAPPING tb_2_ on tb_1_.ID = tb_2_.DEPARTMENT_ID " +
+                    "where tb_2_.USER_ID = ?"
+            ).variables(1L)
+            rows(
+                "[" +
+                    "--->{\"id\":1,\"userDepartmentNames\":\"\"}" +
+                    "]"
+            )
+        }
+    }
 
     @Test
     fun testWithoutFilter() {

--- a/project/jimmer-sql-kotlin/src/test/resources/database.sql
+++ b/project/jimmer-sql-kotlin/src/test/resources/database.sql
@@ -1,6 +1,10 @@
 drop table eyepiece if exists;
 drop table objective if exists;
 drop table camera if exists;
+drop table issue_1434_message if exists;
+drop table issue_1434_user_department_mapping if exists;
+drop table issue_1434_department if exists;
+drop table issue_1434_user if exists;
 drop table topic if exists;
 drop table contact if exists;
 drop table customer if exists;
@@ -1185,6 +1189,42 @@ alter table objective
 insert into camera(id, name) values(1, 'camera-1');
 insert into eyepiece(id, name, eye_relief, camera_id) values(1, 'eyepiece-1', 10, 1);
 insert into objective(id, name, working_distance, camera_id) values(1, 'objective-1', 2500, 1);
+
+create table issue_1434_user(
+    id bigint not null,
+    name varchar(20) not null
+);
+alter table issue_1434_user
+    add constraint pk_issue_1434_user
+        primary key(id);
+
+create table issue_1434_department(
+    id bigint not null,
+    name varchar(20) not null
+);
+alter table issue_1434_department
+    add constraint pk_issue_1434_department
+        primary key(id);
+
+create table issue_1434_user_department_mapping(
+    user_id bigint not null,
+    department_id bigint not null
+);
+alter table issue_1434_user_department_mapping
+    add constraint pk_issue_1434_user_department_mapping
+        primary key(user_id, department_id);
+
+create table issue_1434_message(
+    id bigint not null,
+    user_id bigint
+);
+alter table issue_1434_message
+    add constraint pk_issue_1434_message
+        primary key(id);
+
+insert into issue_1434_user(id, name) values(1, 'user-1');
+insert into issue_1434_department(id, name) values(1, 'department-1');
+insert into issue_1434_message(id, user_id) values(1, 1);
 
 create table monster(
      id int not null PRIMARY KEY,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherContext.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 class FetcherContext {
 
@@ -42,6 +43,19 @@ class FetcherContext {
             } finally {
                 FETCHER_CONTEXT_LOCAL.remove();
             }
+        }
+    }
+
+    static <T> T withoutContext(Supplier<T> supplier) {
+        FetcherContext ctx = FETCHER_CONTEXT_LOCAL.get();
+        if (ctx == null) {
+            return supplier.get();
+        }
+        FETCHER_CONTEXT_LOCAL.remove();
+        try {
+            return supplier.get();
+        } finally {
+            FETCHER_CONTEXT_LOCAL.set(ctx);
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
@@ -17,10 +17,15 @@ import java.sql.Connection;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Supplier;
 
 public class FetcherUtil {
 
     private FetcherUtil() {}
+
+    public static <T> T withoutFetcherContext(Supplier<T> supplier) {
+        return FetcherContext.withoutContext(supplier);
+    }
 
     private static void visitFetchColumns(
             JSqlClientImplementor sqlClient,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/AbstractDataLoader.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/loader/AbstractDataLoader.java
@@ -904,13 +904,16 @@ public abstract class AbstractDataLoader {
             Collection<ImmutableSpi> sources,
             TransientResolverContext ctx
     ) {
-        Map<Object, Object> valueMap;
-        if (resolver instanceof TypedTransientResolver<?, ?, ?> && sources != null) {
-            TypedTransientResolver.Context<Object> context = new TypedTransientResolverContextImpl<>(sources);
-            valueMap = ((TypedTransientResolver<Object, Object, Object>) resolver).resolve(ids, context);
-        } else {
-            valueMap = resolver.resolve(ids, ctx);
-        }
+        // The resolver may execute queries with fetchers and use their results immediately.
+        // Those nested post-fetch tasks must be completed by their own fetcher context,
+        // not appended to the outer context that is still resolving this transient property.
+        Map<Object, Object> valueMap = FetcherUtil.withoutFetcherContext(() -> {
+            if (resolver instanceof TypedTransientResolver<?, ?, ?> && sources != null) {
+                TypedTransientResolver.Context<Object> context = new TypedTransientResolverContextImpl<>(sources);
+                return ((TypedTransientResolver<Object, Object, Object>) resolver).resolve(ids, context);
+            }
+            return resolver.resolve(ids, ctx);
+        });
 
         if (valueMap.keySet().containsAll(ids)) {
             return valueMap;

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/SimpleTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/SimpleTest.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import static org.babyfish.jimmer.sql.common.Constants.*;
 
 import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.model.fetcher.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,44 @@ public class SimpleTest extends AbstractQueryTest {
                                 "id", "name"
                         );
                     });
+                }
+        );
+    }
+
+    @Test
+    public void testNestedFetcherInTransientResolverWhenUserHasNoDepartments() {
+        Issue1434MessageTable table = Issue1434MessageTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .select(
+                                table.fetch(
+                                        Issue1434MessageFetcher.$.userDepartmentNames()
+                                )
+                        ),
+                ctx -> {
+                    ctx.sql("select tb_1_.ID from ISSUE_1434_MESSAGE tb_1_");
+                    ctx.statement(1).sql(
+                            "select tb_1_.ID, tb_1_.USER_ID " +
+                                    "from ISSUE_1434_MESSAGE tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    ).variables(1L);
+                    ctx.statement(2).sql(
+                            "select tb_1_.ID " +
+                                    "from ISSUE_1434_USER tb_1_ " +
+                                    "where tb_1_.ID = ?"
+                    ).variables(1L);
+                    ctx.statement(3).sql(
+                            "select tb_1_.ID, tb_1_.NAME " +
+                                    "from ISSUE_1434_DEPARTMENT tb_1_ " +
+                                    "inner join ISSUE_1434_USER_DEPARTMENT_MAPPING tb_2_ on tb_1_.ID = tb_2_.DEPARTMENT_ID " +
+                                    "where tb_2_.USER_ID = ?"
+                    ).variables(1L);
+                    ctx.rows(
+                            "[" +
+                                    "--->{\"id\":1,\"userDepartmentNames\":\"\"}" +
+                                    "]"
+                    );
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434Department.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434Department.java
@@ -1,0 +1,15 @@
+package org.babyfish.jimmer.sql.model.fetcher;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.Table;
+
+@Entity
+@Table(name = "ISSUE_1434_DEPARTMENT")
+public interface Issue1434Department {
+
+    @Id
+    long id();
+
+    String name();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434Message.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434Message.java
@@ -1,0 +1,26 @@
+package org.babyfish.jimmer.sql.model.fetcher;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.ForeignKeyType;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.JoinColumn;
+import org.babyfish.jimmer.sql.ManyToOne;
+import org.babyfish.jimmer.sql.Table;
+import org.babyfish.jimmer.sql.Transient;
+import org.jspecify.annotations.Nullable;
+
+@Entity
+@Table(name = "ISSUE_1434_MESSAGE")
+public interface Issue1434Message {
+
+    @Id
+    long id();
+
+    @Nullable
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", foreignKeyType = ForeignKeyType.FAKE)
+    Issue1434User user();
+
+    @Transient(Issue1434MessageUserDepartmentNamesResolver.class)
+    String userDepartmentNames();
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434MessageUserDepartmentNamesResolver.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434MessageUserDepartmentNamesResolver.java
@@ -1,0 +1,52 @@
+package org.babyfish.jimmer.sql.model.fetcher;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.TransientResolver;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Issue1434MessageUserDepartmentNamesResolver implements TransientResolver<Long, String> {
+
+    private final JSqlClient sqlClient;
+
+    public Issue1434MessageUserDepartmentNamesResolver(JSqlClient sqlClient) {
+        this.sqlClient = sqlClient;
+    }
+
+    @Override
+    public Map<Long, String> resolve(Collection<Long> ids) {
+        Issue1434MessageTable table = Issue1434MessageTable.$;
+        List<Issue1434Message> messages = sqlClient
+                .createQuery(table)
+                .where(table.id().in(ids))
+                .select(
+                        table.fetch(
+                                Issue1434MessageFetcher.$.user(
+                                        Issue1434UserFetcher.$.departments(
+                                                Issue1434DepartmentFetcher.$.name()
+                                        )
+                                )
+                        )
+                )
+                .execute(TransientResolver.currentConnection());
+        Map<Long, String> map = new LinkedHashMap<>((messages.size() * 4 + 2) / 3);
+        for (Issue1434Message message : messages) {
+            Issue1434User user = message.user();
+            map.put(
+                    message.id(),
+                    user != null ?
+                            user
+                                    .departments()
+                                    .stream()
+                                    .map(Issue1434Department::name)
+                                    .collect(Collectors.joining(",")) :
+                            ""
+            );
+        }
+        return map;
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434User.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/model/fetcher/Issue1434User.java
@@ -1,0 +1,27 @@
+package org.babyfish.jimmer.sql.model.fetcher;
+
+import org.babyfish.jimmer.sql.Entity;
+import org.babyfish.jimmer.sql.Id;
+import org.babyfish.jimmer.sql.JoinTable;
+import org.babyfish.jimmer.sql.ManyToMany;
+import org.babyfish.jimmer.sql.Table;
+
+import java.util.List;
+
+@Entity
+@Table(name = "ISSUE_1434_USER")
+public interface Issue1434User {
+
+    @Id
+    long id();
+
+    String name();
+
+    @ManyToMany
+    @JoinTable(
+            name = "ISSUE_1434_USER_DEPARTMENT_MAPPING",
+            joinColumnName = "USER_ID",
+            inverseJoinColumnName = "DEPARTMENT_ID"
+    )
+    List<Issue1434Department> departments();
+}

--- a/project/jimmer-sql/src/test/resources/database.sql
+++ b/project/jimmer-sql/src/test/resources/database.sql
@@ -63,6 +63,10 @@ drop table "group" if exists;
 drop table unit if exists;
 drop table medicine if exists;
 drop alias contains_id if exists;
+drop table issue_1434_message if exists;
+drop table issue_1434_user_department_mapping if exists;
+drop table issue_1434_department if exists;
+drop table issue_1434_user if exists;
 drop table customer_card_mapping if exists;
 drop table shop_customer_mapping if exists;
 drop table shop_vendor_mapping if exists;
@@ -1744,6 +1748,44 @@ insert into medicine(id, tags) values(
     1,
     '[{"name": "tag-1", "description": "tag-description-1"},{"name": "tag-2", "description": "tag-description-2"}]' format json
 );
+
+
+
+create table issue_1434_user(
+    id bigint not null,
+    name varchar(20) not null
+);
+alter table issue_1434_user
+    add constraint pk_issue_1434_user
+        primary key(id);
+
+create table issue_1434_department(
+    id bigint not null,
+    name varchar(20) not null
+);
+alter table issue_1434_department
+    add constraint pk_issue_1434_department
+        primary key(id);
+
+create table issue_1434_user_department_mapping(
+    user_id bigint not null,
+    department_id bigint not null
+);
+alter table issue_1434_user_department_mapping
+    add constraint pk_issue_1434_user_department_mapping
+        primary key(user_id, department_id);
+
+create table issue_1434_message(
+    id bigint not null,
+    user_id bigint
+);
+alter table issue_1434_message
+    add constraint pk_issue_1434_message
+        primary key(id);
+
+insert into issue_1434_user(id, name) values(1, 'user-1');
+insert into issue_1434_department(id, name) values(1, 'department-1');
+insert into issue_1434_message(id, user_id) values(1, 1);
 
 
 


### PR DESCRIPTION
## Summary
- Run nested fetcher queries inside transient resolvers with an isolated fetcher context so their post-fetch tasks complete before resolver code uses the results
- Add Java and Kotlin regression models/tests for the real reported shape: a transient resolver queries `message.user.departments { name }`, where the user exists but has no department rows; the resolver must see a loaded empty department collection instead of an id-only/unloaded shape

## Tests
- `./gradlew :jimmer-sql:test --tests 'org.babyfish.jimmer.sql.fetcher.SimpleTest.testNestedFetcherInTransientResolverWhenUserHasNoDepartments' --no-daemon`
- `./gradlew :jimmer-sql:test --tests 'org.babyfish.jimmer.sql.fetcher.SimpleTest' --no-daemon`
- `./gradlew :jimmer-sql-kotlin:test --tests 'org.babyfish.jimmer.sql.kt.query.FetcherTest.testNestedFetcherInTransientResolverWhenUserHasNoDepartments' --no-daemon`
