### PR TITLE
fix(transactional): return sqlClient actual entityManager instance

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/transaction/JTransactionalSqlClient.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/transaction/JTransactionalSqlClient.java
@@ -24,6 +24,10 @@ class JTransactionalSqlClient extends AbstractJSqlClientDelegate implements Tran
 
     @Override
     public EntityManager getEntityManager() {
-        return EMPTY_ENTITY_MANAGER;
+        JSqlClient sqlClient = JimmerTransactionManager.sqlClient();
+
+        return sqlClient != null
+                ? ((JSqlClientImplementor) sqlClient).getEntityManager()
+                : EMPTY_ENTITY_MANAGER;
     }
 }

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/TransactionalClientTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/TransactionalClientTest.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.spring.java;
 
+import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.spring.SqlClients;
 import org.babyfish.jimmer.spring.cfg.JimmerProperties;
 import org.babyfish.jimmer.spring.datasource.DataSources;
@@ -9,6 +10,7 @@ import org.babyfish.jimmer.spring.java.model.BookTable;
 import org.babyfish.jimmer.spring.transaction.JimmerTransactionManager;
 import org.babyfish.jimmer.spring.transaction.TransactionalSqlClients;
 import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +34,16 @@ public class TransactionalClientTest {
 
     @Autowired
     private JSqlClient sqlClient;
+
+    @Test
+    public void testEntityManagerOutsideTransaction() {
+        Assertions.assertFalse(
+                ((JSqlClientImplementor) sqlClient)
+                        .getEntityManager()
+                        .getAllTypes(null)
+                        .contains(ImmutableType.get(Book.class))
+        );
+    }
 
     @Transactional("tm")
     @Test


### PR DESCRIPTION
## Background

`TransactionalSqlClients.java()` uses a shared transactional proxy and resolves the
actual `JSqlClient` from `JimmerTransactionManager` at runtime.

In a multiple-data-source setup, each transaction manager can be associated with a
different `JSqlClient` and therefore a different `EntityManager`. However,
`JTransactionalSqlClient#getEntityManager()` always returned a static empty
`EntityManager`, even when a transaction was active.

As a result, code accessing entity metadata through the transactional client could
not obtain the metadata belonging to the `JSqlClient` selected by the current
transaction manager.

## Changes

- Resolve the current `JSqlClient` from `JimmerTransactionManager`.
- Return the active client's actual `EntityManager` when running inside a managed
  transaction.
- Keep returning the empty `EntityManager` when no transaction is active, preserving
  the existing behavior outside transactions.
- Add test coverage for the `EntityManager` fallback behavior outside a transaction.

## Behavior

Before:

```java
TransactionalSqlClient#getEntityManager()
    -> always returns EMPTY_ENTITY_MANAGER