### PR TITLE
Reapply database initialization and coalesce fixes

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerDependsOnDatabaseInitializationDetector.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerDependsOnDatabaseInitializationDetector.java
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.kt.KSqlClient;
+import org.springframework.boot.sql.init.dependency.AbstractBeansOfTypeDependsOnDatabaseInitializationDetector;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+class JimmerDependsOnDatabaseInitializationDetector extends AbstractBeansOfTypeDependsOnDatabaseInitializationDetector {
+
+    @Override
+    protected Set<Class<?>> getDependsOnDatabaseInitializationBeanTypes() {
+        return new HashSet<>(Arrays.asList(JSqlClient.class, KSqlClient.class));
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/project/jimmer-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -2,3 +2,6 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.babyfish.jimmer.spring.cfg.JimmerAutoConfiguration,\
 org.babyfish.jimmer.spring.cfg.JimmerSpringGraphQLAutoConfiguration,\
 org.babyfish.jimmer.spring.cfg.ServletControllerConfiguration
+
+org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializationDetector=\
+org.babyfish.jimmer.spring.cfg.JimmerDependsOnDatabaseInitializationDetector

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerDependsOnDatabaseInitializationDetectorTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerDependsOnDatabaseInitializationDetectorTest.java
@@ -1,0 +1,44 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.kt.KSqlClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializationDetector;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class JimmerDependsOnDatabaseInitializationDetectorTest {
+
+    @Test
+    public void testDetectSqlClientBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("javaSqlClient", new RootBeanDefinition(JSqlClient.class));
+        beanFactory.registerBeanDefinition("kotlinSqlClient", new RootBeanDefinition(KSqlClient.class));
+        beanFactory.registerBeanDefinition("otherBean", new RootBeanDefinition(String.class));
+
+        Set<String> names = new JimmerDependsOnDatabaseInitializationDetector().detect(beanFactory);
+
+        Assertions.assertEquals(
+                new HashSet<>(Arrays.asList("javaSqlClient", "kotlinSqlClient")),
+                names
+        );
+    }
+
+    @Test
+    public void testSpringFactoriesRegistration() {
+        Assertions.assertTrue(
+                SpringFactoriesLoader
+                        .loadFactoryNames(
+                                DependsOnDatabaseInitializationDetector.class,
+                                getClass().getClassLoader()
+                        )
+                        .contains(JimmerDependsOnDatabaseInitializationDetector.class.getName())
+        );
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/CoalesceBuilder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/CoalesceBuilder.java
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.ast.impl;
 
+import org.babyfish.jimmer.impl.util.Classes;
 import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.runtime.SqlBuilder;
@@ -20,8 +21,10 @@ public class CoalesceBuilder<T> {
     }
 
     public CoalesceBuilder<T> or(Expression<T> expr) {
-        if (((ExpressionImplementor<?>) expressions.get(0)).getType() !=
-                ((ExpressionImplementor<?>)expr).getType()) {
+        if (!Classes.matches(
+                ((ExpressionImplementor<?>) expressions.get(0)).getType(),
+                ((ExpressionImplementor<?>)expr).getType()
+        )) {
             throw new IllegalArgumentException("The branches of coalesce must belong to same type");
         }
         expressions.add(expr);
@@ -249,4 +252,3 @@ public class CoalesceBuilder<T> {
         }
     }
 }
-

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/ComplexExprTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/ComplexExprTest.java
@@ -109,6 +109,21 @@ public class ComplexExprTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testCoalescePrimitiveAndBoxType() {
+        executeAndExpect(
+                getLambdaClient().createQuery(BookTable.class, (q, book) -> {
+                    return q.select(book.edition().coalesce(0));
+                }),
+                ctx -> {
+                    ctx.sql(
+                            "select coalesce(tb_1_.EDITION, ?) from BOOK tb_1_"
+                    );
+                    ctx.variables(0);
+                }
+        );
+    }
+
+    @Test
     public void testSimpleCase() {
         executeAndExpect(
                 getLambdaClient().createQuery(BookStoreTable.class, (q, store) -> {


### PR DESCRIPTION
PR 1405 1406 
The original fixes were merged successfully, but were accidentally reverted later, so the same regressions can reappear on current `main`.
