### PR TITLE
Add kotlinx serialization JSON codec

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ javaxValidation = "2.0.1.Final"
 jetbrainsAnnotations = "24.0.0"
 jspecify = "1.0.0"
 kafka = "0.10.0.0"
+kotlin = "2.1.20"
+kotlinxSerialization = "1.8.1"
 kotlinpoet = "2.2.0"
 ksp = "2.1.20-2.0.0"
 lombok = "1.18.38"
@@ -86,6 +88,8 @@ kafka-connect-api = { group = "org.apache.kafka", name = "connect-api", version.
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
+kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
@@ -138,3 +142,4 @@ jackson = ["jackson-annotations", "jackson3-databind", "jackson3-module-kotlin",
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/project/jimmer-bom/build.gradle.kts
+++ b/project/jimmer-bom/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
         api(projects.jimmerClientScalar)
         api(projects.jimmerCore)
         api(projects.jimmerCoreKotlin)
+        api(projects.jimmerKotlinxSerialization)
         api(projects.jimmerDtoCompiler)
         api(projects.jimmerDdlCompiler)
         api(projects.jimmerKsp)

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/codec/JacksonVersion.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/codec/JacksonVersion.java
@@ -1,5 +1,5 @@
 package org.babyfish.jimmer.jackson.codec;
 
 public enum JacksonVersion {
-    V2, V3
+    V2, V3, KOTLINX
 }

--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/codec/JsonCodec.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/jackson/codec/JsonCodec.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Facade to abstract jimmer from concrete jackson version.
- * Allows to support jimmer 2 and jimmer 3 simultaneously.
+ * Facade to abstract jimmer from concrete JSON implementation.
+ * Allows to support jackson 2, jackson 3 and other JSON codecs simultaneously.
  *
- * @param <JT> JavaType class from jackson
+ * @param <JT> implementation-specific type token
  */
 public interface JsonCodec<JT> {
     static JsonCodec<?> jsonCodec() {

--- a/project/jimmer-kotlinx-serialization/build.gradle.kts
+++ b/project/jimmer-kotlinx-serialization/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-convention`
+    `dokka-convention`
+    alias(libs.plugins.kotlinx.serialization)
+}
+
+dependencies {
+    api(projects.jimmerCore)
+    api(libs.kotlinx.serialization.core)
+    api(libs.kotlinx.serialization.json)
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+
+    testImplementation(libs.kotlin.test)
+}

--- a/project/jimmer-kotlinx-serialization/src/main/kotlin/org/babyfish/jimmer/serialization/kotlinx/KotlinxJsonCodec.kt
+++ b/project/jimmer-kotlinx-serialization/src/main/kotlin/org/babyfish/jimmer/serialization/kotlinx/KotlinxJsonCodec.kt
@@ -1,0 +1,438 @@
+package org.babyfish.jimmer.serialization.kotlinx
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import org.babyfish.jimmer.jackson.codec.JacksonVersion
+import org.babyfish.jimmer.jackson.codec.JsonCodec
+import org.babyfish.jimmer.jackson.codec.JsonCodecCustomization
+import org.babyfish.jimmer.jackson.codec.JsonConverter
+import org.babyfish.jimmer.jackson.codec.JsonReader
+import org.babyfish.jimmer.jackson.codec.JsonTypeFactory
+import org.babyfish.jimmer.jackson.codec.JsonWriter
+import org.babyfish.jimmer.jackson.codec.Node
+import org.babyfish.jimmer.jackson.codec.TypeCreator
+import org.babyfish.jimmer.meta.ImmutableType
+import org.babyfish.jimmer.runtime.DraftSpi
+import org.babyfish.jimmer.runtime.ImmutableSpi
+import org.babyfish.jimmer.runtime.Internal
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.Reader
+import java.io.Writer
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.TypeVariable
+import java.lang.reflect.WildcardType
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * JSON codec backed by kotlinx.serialization.
+ *
+ * This codec is intentionally explicit: applications can pass it to Jimmer APIs such as
+ * `JSqlClient.Builder#setJsonCodec` or `setDefaultSerializedTypeJsonCodec` when the
+ * serialized application model is kotlinx-serializable.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class KotlinxJsonCodec @JvmOverloads constructor(
+    private val json: Json = DEFAULT_JSON
+) : JsonCodec<KType> {
+
+    override fun withCustomizations(vararg customizations: JsonCodecCustomization): JsonCodec<KType> =
+        this
+
+    override fun converter(): JsonConverter =
+        KotlinxJsonConverter(json)
+
+    override fun <T : Any?> readerFor(clazz: Class<T>): JsonReader<T> =
+        readerFor(KotlinxJsonTypeFactory.constructType(clazz))
+
+    override fun <T : Any?> readerFor(typeCreator: TypeCreator<KType>): JsonReader<T> =
+        readerFor(typeCreator.createType(KotlinxJsonTypeFactory))
+
+    override fun <T : Any?> readerForArrayOf(componentType: Class<T>): JsonReader<Array<T>> =
+        readerFor(KotlinxJsonTypeFactory.constructArrayType(componentType))
+
+    override fun <T : Any?> readerForListOf(elementType: Class<T>): JsonReader<List<T>> =
+        readerFor(KotlinxJsonTypeFactory.constructListType(elementType))
+
+    override fun <V : Any?> readerForMapOf(valueType: Class<V>): JsonReader<Map<String, V>> =
+        readerFor(KotlinxJsonTypeFactory.constructMapType(String::class.java, valueType))
+
+    override fun treeReader(): JsonReader<Node> =
+        KotlinxTreeReader(json)
+
+    override fun writer(): JsonWriter =
+        KotlinxJsonWriter(json, null)
+
+    override fun writerFor(clazz: Class<*>): JsonWriter =
+        writerFor(KotlinxJsonTypeFactory.constructType(clazz))
+
+    override fun writerFor(typeCreator: TypeCreator<KType>): JsonWriter =
+        writerFor(typeCreator.createType(KotlinxJsonTypeFactory))
+
+    override fun version(): JacksonVersion =
+        JacksonVersion.KOTLINX
+
+    private fun <T> readerFor(type: KType): JsonReader<T> =
+        KotlinxJsonReader(json, type)
+
+    private fun writerFor(type: KType): JsonWriter =
+        KotlinxJsonWriter(json, type)
+
+    companion object {
+        @JvmField
+        val DEFAULT_JSON: Json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}
+
+class KotlinxJsonCodecProvider : org.babyfish.jimmer.jackson.codec.JsonCodecProvider {
+    override fun create(): JsonCodec<*> =
+        KotlinxJsonCodec()
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class KotlinxJsonReader<T>(
+    private val json: Json,
+    private val type: KType
+) : JsonReader<T> {
+
+    override fun read(json: String): T =
+        decode(this.json.parseToJsonElement(json))
+
+    override fun read(json: ByteArray): T =
+        read(String(json, StandardCharsets.UTF_8))
+
+    override fun read(reader: Reader): T =
+        read(reader.readText())
+
+    override fun read(inputStream: InputStream): T =
+        read(inputStream.readBytes())
+
+    @Suppress("UNCHECKED_CAST")
+    private fun decode(element: JsonElement): T =
+        KotlinxJsonSupport.decodeElement(json, element, type) as T
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class KotlinxTreeReader(
+    private val json: Json
+) : JsonReader<Node> {
+
+    override fun read(json: String): Node =
+        KotlinxJsonNode(this.json.parseToJsonElement(json))
+
+    override fun read(json: ByteArray): Node =
+        read(String(json, StandardCharsets.UTF_8))
+
+    override fun read(reader: Reader): Node =
+        read(reader.readText())
+
+    override fun read(inputStream: InputStream): Node =
+        read(inputStream.readBytes())
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class KotlinxJsonWriter(
+    private val json: Json,
+    private val type: KType?
+) : JsonWriter {
+
+    override fun withDefaultPrettyPrinter(): JsonWriter =
+        KotlinxJsonWriter(
+            Json(json) {
+                prettyPrint = true
+            },
+            type
+        )
+
+    override fun writeAsString(obj: Any?): String =
+        json.encodeToString(JsonElement.serializer(), encode(obj))
+
+    override fun writeAsBytes(obj: Any?): ByteArray =
+        writeAsString(obj).toByteArray(StandardCharsets.UTF_8)
+
+    override fun write(writer: Writer, obj: Any?) {
+        writer.write(writeAsString(obj))
+    }
+
+    override fun write(outputStream: OutputStream, obj: Any?) {
+        outputStream.write(writeAsBytes(obj))
+    }
+
+    private fun encode(value: Any?): JsonElement =
+        if (type !== null) {
+            KotlinxJsonSupport.encodeElement(json, value, type)
+        } else {
+            KotlinxJsonSupport.encodeUntyped(json, value)
+        }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class KotlinxJsonConverter(
+    private val json: Json
+) : JsonConverter {
+
+    override fun <T : Any?> convert(value: Any?, targetType: Class<T>): T =
+        convert(value, KotlinxJsonTypeFactory.constructType(targetType))
+
+    override fun <T : Any?> convert(value: Any?, typeCreator: TypeCreator<*>): T {
+        @Suppress("UNCHECKED_CAST")
+        val creator = typeCreator as TypeCreator<KType>
+        return convert(value, creator.createType(KotlinxJsonTypeFactory))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> convert(value: Any?, type: KType): T {
+        val element = when (value) {
+            is KotlinxJsonNode -> value.element
+            is JsonElement -> value
+            else -> KotlinxJsonSupport.encodeUntyped(json, value)
+        }
+        return KotlinxJsonSupport.decodeElement(json, element, type) as T
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private object KotlinxJsonSupport {
+
+    fun encodeUntyped(json: Json, value: Any?): JsonElement =
+        when (value) {
+            null -> JsonNull
+            is JsonElement -> value
+            is ImmutableSpi -> encodeImmutable(json, value)
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            is String -> JsonPrimitive(value)
+            is Char -> JsonPrimitive(value.toString())
+            is UUID -> JsonPrimitive(value.toString())
+            is Enum<*> -> JsonPrimitive(value.name)
+            is Iterable<*> -> JsonArray(value.map { encodeUntyped(json, it) })
+            is Array<*> -> JsonArray(value.map { encodeUntyped(json, it) })
+            is BooleanArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is ByteArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is ShortArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is IntArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is LongArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is FloatArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is DoubleArray -> JsonArray(value.map { JsonPrimitive(it) })
+            is CharArray -> JsonArray(value.map { JsonPrimitive(it.toString()) })
+            is Map<*, *> -> JsonObject(
+                value.entries.associate { (key, entryValue) ->
+                    key.toString() to encodeUntyped(json, entryValue)
+                }
+            )
+            else -> encodeElement(json, value, value::class.createType())
+        }
+
+    fun encodeElement(json: Json, value: Any?, type: KType): JsonElement {
+        if (value == null) {
+            return JsonNull
+        }
+        if (value is ImmutableSpi) {
+            return encodeImmutable(json, value)
+        }
+        val serializer = json.serializersModule.serializer(type) as KSerializer<Any?>
+        return json.encodeToJsonElement(serializer, value)
+    }
+
+    fun decodeElement(json: Json, element: JsonElement, type: KType): Any? {
+        if (element is JsonNull) {
+            return null
+        }
+        val immutableType = type.javaClassOrNull()?.let(ImmutableType::tryGet)
+        if (immutableType !== null && element is JsonObject) {
+            return decodeImmutable(json, element, immutableType)
+        }
+        val serializer = json.serializersModule.serializer(type) as KSerializer<Any?>
+        return json.decodeFromJsonElement(serializer, element)
+    }
+
+    private fun encodeImmutable(json: Json, value: ImmutableSpi): JsonObject {
+        val fields = linkedMapOf<String, JsonElement>()
+        for (prop in value.__type().props.values) {
+            val propId = prop.id
+            if (value.__isLoaded(propId) && value.__isVisible(propId)) {
+                fields[prop.name] = encodeUntyped(json, value.__get(propId))
+            }
+        }
+        return JsonObject(fields)
+    }
+
+    private fun decodeImmutable(json: Json, element: JsonObject, immutableType: ImmutableType): Any =
+        Internal.produce(immutableType, null) { draft ->
+            val spi = draft as DraftSpi
+            for (prop in immutableType.props.values) {
+                val propElement = element[prop.name] ?: continue
+                val value = decodeElement(json, propElement, KotlinxJsonTypeFactory.constructType(prop.genericType))
+                spi.__set(prop.id, value)
+            }
+        }
+
+    private fun KType.javaClassOrNull(): Class<*>? =
+        jvmErasure.java
+}
+
+private object KotlinxJsonTypeFactory : JsonTypeFactory<KType> {
+
+    override fun constructType(type: Type): KType =
+        type.toKType()
+
+    override fun constructParametricType(parametrized: Class<*>, vararg parameterClasses: Class<*>): KType =
+        parametrized.kotlin.createType(
+            parameterClasses.map { KTypeProjection.invariant(constructType(it)) }
+        )
+
+    override fun constructParametricType(parametrized: Class<*>, parameterClasses: Array<KType>): KType =
+        parametrized.kotlin.createType(
+            parameterClasses.map { KTypeProjection.invariant(it) }
+        )
+
+    override fun constructArrayType(componentType: Class<*>): KType =
+        constructArrayType(constructType(componentType))
+
+    override fun constructArrayType(componentType: KType): KType =
+        Array<Any?>::class.createType(listOf(KTypeProjection.invariant(componentType)))
+
+    override fun constructCollectionType(collectionType: Class<out Collection<*>>, elementType: Class<*>): KType =
+        constructCollectionType(collectionType, constructType(elementType))
+
+    override fun constructCollectionType(collectionType: Class<out Collection<*>>, elementType: KType): KType =
+        collectionType.kotlin.createType(listOf(KTypeProjection.invariant(elementType)))
+
+    override fun constructMapType(mapType: Class<out Map<*, *>>, keyType: Class<*>, valueType: Class<*>): KType =
+        constructMapType(mapType, constructType(keyType), constructType(valueType))
+
+    override fun constructMapType(mapType: Class<out Map<*, *>>, keyType: KType, valueType: KType): KType =
+        mapType.kotlin.createType(
+            listOf(
+                KTypeProjection.invariant(keyType),
+                KTypeProjection.invariant(valueType)
+            )
+        )
+
+    private fun Type.toKType(): KType =
+        when (this) {
+            is Class<*> -> toKType()
+            is ParameterizedType -> {
+                val rawClass = rawType as? Class<*>
+                    ?: throw IllegalArgumentException("Parameterized raw type \"$rawType\" is not a class")
+                rawClass.kotlin.createType(
+                    actualTypeArguments.map { argument ->
+                        KTypeProjection.invariant(argument.toKType())
+                    }
+                )
+            }
+            is GenericArrayType -> constructArrayType(genericComponentType.toKType())
+            is WildcardType -> upperBounds.firstOrNull()?.toKType() ?: Any::class.starProjectedType
+            is TypeVariable<*> -> bounds.firstOrNull()?.toKType() ?: Any::class.starProjectedType
+            else -> throw IllegalArgumentException("Unsupported type: $this")
+        }
+
+    private fun Class<*>.toKType(): KType =
+        kotlin.createType()
+}
+
+private class KotlinxJsonNode(
+    internal val element: JsonElement
+) : Node {
+
+    override fun get(index: Int): Node? =
+        (element as? JsonArray)?.getOrNull(index)?.let(::KotlinxJsonNode)
+
+    override fun get(fieldName: String): Node? =
+        (element as? JsonObject)?.get(fieldName)?.let(::KotlinxJsonNode)
+
+    override fun fieldsIterator(): Iterator<Map.Entry<String, Node>> {
+        val jsonObject = element as? JsonObject ?: return emptyMap<String, Node>().entries.iterator()
+        return jsonObject.entries
+            .map { (key, value) -> mapEntry(key, KotlinxJsonNode(value)) }
+            .iterator()
+    }
+
+    override fun isNull(): Boolean =
+        element is JsonNull
+
+    override fun canCastTo(type: Class<*>): Boolean =
+        CASTER_MAP.containsKey(type)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> castTo(type: Class<T>): T {
+        val caster = CASTER_MAP[type]
+            ?: throw IllegalArgumentException("Cannot cast node to type ${type.name}")
+        return caster(element) as T
+    }
+
+    override fun <T : Any?> convertTo(targetType: Class<T>, converter: JsonConverter): T =
+        converter.convert(element, targetType)
+
+    override fun equals(other: Any?): Boolean =
+        other is KotlinxJsonNode && element == other.element
+
+    override fun hashCode(): Int =
+        element.hashCode()
+
+    override fun toString(): String =
+        element.toString()
+
+    private fun mapEntry(key: String, value: Node): Map.Entry<String, Node> =
+        object : Map.Entry<String, Node> {
+            override val key: String = key
+            override val value: Node = value
+        }
+
+    companion object {
+        private val CASTER_MAP: Map<Class<*>, (JsonElement) -> Any?> = mapOf(
+            Boolean::class.javaPrimitiveType!! to { it.jsonPrimitive().booleanOrNull },
+            Boolean::class.java to { it.jsonPrimitive().booleanOrNull },
+            Char::class.javaPrimitiveType!! to { it.jsonPrimitive().contentOrNull?.firstOrNull() },
+            Char::class.java to { it.jsonPrimitive().contentOrNull?.firstOrNull() },
+            Byte::class.javaPrimitiveType!! to { it.jsonPrimitive().intOrNull?.toByte() },
+            Byte::class.java to { it.jsonPrimitive().intOrNull?.toByte() },
+            Short::class.javaPrimitiveType!! to { it.jsonPrimitive().intOrNull?.toShort() },
+            Short::class.java to { it.jsonPrimitive().intOrNull?.toShort() },
+            Int::class.javaPrimitiveType!! to { it.jsonPrimitive().intOrNull },
+            Int::class.java to { it.jsonPrimitive().intOrNull },
+            Long::class.javaPrimitiveType!! to { it.jsonPrimitive().longOrNull },
+            Long::class.java to { it.jsonPrimitive().longOrNull },
+            Float::class.javaPrimitiveType!! to { it.jsonPrimitive().floatOrNull },
+            Float::class.java to { it.jsonPrimitive().floatOrNull },
+            Double::class.javaPrimitiveType!! to { it.jsonPrimitive().doubleOrNull },
+            Double::class.java to { it.jsonPrimitive().doubleOrNull },
+            BigInteger::class.java to { it.jsonPrimitive().contentOrNull?.toBigInteger() },
+            BigDecimal::class.java to { it.jsonPrimitive().contentOrNull?.toBigDecimal() },
+            String::class.java to { it.jsonPrimitive().contentOrNull },
+            UUID::class.java to { it.jsonPrimitive().contentOrNull?.let(UUID::fromString) }
+        )
+
+        private fun JsonElement.jsonPrimitive(): JsonPrimitive =
+            this as? JsonPrimitive ?: throw SerializationException("JSON element is not a primitive: $this")
+    }
+}

--- a/project/jimmer-kotlinx-serialization/src/test/kotlin/org/babyfish/jimmer/serialization/kotlinx/KotlinxJsonCodecTest.kt
+++ b/project/jimmer-kotlinx-serialization/src/test/kotlin/org/babyfish/jimmer/serialization/kotlinx/KotlinxJsonCodecTest.kt
@@ -1,0 +1,73 @@
+package org.babyfish.jimmer.serialization.kotlinx
+
+import kotlinx.serialization.Serializable
+import org.babyfish.jimmer.jackson.codec.JacksonVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class KotlinxJsonCodecTest {
+
+    private val codec = KotlinxJsonCodec()
+
+    @Test
+    fun `reader and typed writer support serializable class`() {
+        val payload = Payload(
+            id = 1,
+            name = "jimmer",
+            tags = listOf("orm", "json")
+        )
+
+        val json = codec.writerFor(Payload::class.java).writeAsString(payload)
+
+        assertEquals("""{"id":1,"name":"jimmer","tags":["orm","json"]}""", json)
+        assertEquals(payload, codec.readerFor(Payload::class.java).read(json))
+        assertEquals(JacksonVersion.KOTLINX, codec.version())
+    }
+
+    @Test
+    fun `untyped writer supports serializable class`() {
+        val payload = Payload(
+            id = 3,
+            name = "cache",
+            tags = listOf("serialized")
+        )
+
+        val json = codec.writer().writeAsString(payload)
+
+        assertEquals("""{"id":3,"name":"cache","tags":["serialized"]}""", json)
+        assertEquals(payload, codec.readerFor(Payload::class.java).read(json))
+    }
+
+    @Test
+    fun `generic readers support list and map`() {
+        val payloads = codec
+            .readerForListOf(Payload::class.java)
+            .read("""[{"id":1,"name":"a","tags":[]},{"id":2,"name":"b","tags":["x"]}]""")
+        val map = codec
+            .readerForMapOf(Payload::class.java)
+            .read("""{"first":{"id":1,"name":"a","tags":[]}}""")
+
+        assertEquals(listOf("a", "b"), payloads.map { it.name })
+        assertEquals(Payload(1, "a", emptyList()), map["first"])
+    }
+
+    @Test
+    fun `tree reader exposes scalar casts and fields`() {
+        val id = UUID.fromString("00000000-0000-0000-0000-000000000123")
+        val node = codec.treeReader().read("""{"id":"$id","count":3,"enabled":true}""")
+        val fields = node.fieldsIterator().asSequence().map { it.key }.toList()
+
+        assertEquals(id, node["id"].castTo(UUID::class.java))
+        assertEquals(3, node["count"].castTo(Int::class.java))
+        assertEquals(true, node["enabled"].castTo(Boolean::class.java))
+        assertEquals(listOf("id", "count", "enabled"), fields)
+    }
+
+    @Serializable
+    data class Payload(
+        val id: Int,
+        val name: String,
+        val tags: List<String>
+    )
+}

--- a/project/settings.gradle.kts
+++ b/project/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "jimmer"
 include(
     "jimmer-bom",
     "jimmer-core",
+    "jimmer-kotlinx-serialization",
     "jimmer-mapstruct-apt",
     "jimmer-apt",
     "jimmer-sql",


### PR DESCRIPTION
## Summary
- add a new `jimmer-kotlinx-serialization` module
- provide `KotlinxJsonCodec` backed by `kotlinx.serialization.json.Json`
- replace the Jackson-specific codec version enum with neutral `JsonCodecFamily`
- register the kotlinx codec through `ServiceLoader`
- make Spring codec configuration return non-Jackson codecs without trying to wrap them with Jackson mappers
- support typed/untyped writer, class/list/map readers, tree node scalar casts, and basic Jimmer immutable object encoding/decoding through the existing JsonCodec SPI
- add the module to settings and BOM constraints

## Verified scope
- `JsonCodec.jsonCodec()` can resolve the kotlinx codec when the module is on the classpath
- `JSqlClient` serialized type scalar provider can use `KotlinxJsonCodec` for `@Serialized @Serializable` Kotlin types
- existing SQL and Spring compile paths still build against the neutral codec family API

## Not included in this PR
- generated DTO classes are not made `@Serializable`
- APT/KSP do not yet emit kotlinx serialization annotations/serializers
- the existing `org.babyfish.jimmer.jackson.*` package is not fully renamed in this PR

## Tests
- `./gradlew :jimmer-kotlinx-serialization:test :jimmer-spring-boot-starter:compileJava :jimmer-sql:compileJava --stacktrace`
- `./gradlew :jimmer-kotlinx-serialization:build :jimmer-bom:build --stacktrace`
