### PR TITLE
fix(spring): skip validation for unloaded immutable properties

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ spring-boot-configurationProcessor = { group = "org.springframework.boot", name 
 spring-boot-starter-jdbc = { group = "org.springframework.boot", name = "spring-boot-starter-jdbc", version.ref = "springBoot" }
 spring-boot-starter-json = { group = "org.springframework.boot", name = "spring-boot-starter-json", version.ref = "springBoot" }
 spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web", version.ref = "springBoot" }
+spring-boot-starter-validation = { group = "org.springframework.boot", name = "spring-boot-starter-validation", version.ref = "springBoot" }
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "springBoot" }
 
 spring-data-commons = { group = "org.springframework.data", name = "spring-data-commons", version.ref = "springBoot" }

--- a/project/jimmer-spring-boot-starter/build.gradle.kts
+++ b/project/jimmer-spring-boot-starter/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     kspTest(projects.jimmerKsp)
 
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.validation)
     testImplementation(libs.spring.boot.starter.web)
     testImplementation(libs.h2)
     testRuntimeOnly(libs.bundles.jackson)

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerAutoConfiguration.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerAutoConfiguration.java
@@ -11,7 +11,8 @@ import org.springframework.context.annotation.Import;
         SqlClientConfig.class,
         JimmerRepositoriesConfig.class,
         ErrorTranslatorConfig.class,
-        JimmerJacksonConfig.class
+        JimmerJacksonConfig.class,
+        JimmerBeanValidationConfig.class
 })
 public class JimmerAutoConfiguration {
 }

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
@@ -1,0 +1,114 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.Consumer;
+
+@Configuration
+@ConditionalOnClass(name = "org.springframework.validation.beanvalidation.LocalValidatorFactoryBean")
+public class JimmerBeanValidationConfig {
+
+    @Bean
+    public BeanPostProcessor jimmerValidationBeanPostProcessor() {
+        return new JimmerValidationBeanPostProcessor();
+    }
+
+    private static class JimmerValidationBeanPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+            if (!isLocalValidatorFactoryBean(bean)) {
+                return bean;
+            }
+            configure(bean);
+            return bean;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static void configure(Object bean) {
+            Method setter = ReflectionUtils.findMethod(bean.getClass(), "setConfigurationInitializer", Consumer.class);
+            if (setter == null) {
+                return;
+            }
+            Field field = ReflectionUtils.findField(bean.getClass(), "configurationInitializer");
+            ReflectionUtils.makeAccessible(setter);
+            Consumer<Object> jimmerInitializer = JimmerValidationBeanPostProcessor::configureValidation;
+            if (field != null) {
+                ReflectionUtils.makeAccessible(field);
+                Consumer<Object> oldInitializer = (Consumer<Object>) ReflectionUtils.getField(field, bean);
+                if (oldInitializer != null) {
+                    jimmerInitializer = oldInitializer.andThen(jimmerInitializer);
+                }
+            }
+            ReflectionUtils.invokeMethod(setter, bean, jimmerInitializer);
+        }
+
+        private static void configureValidation(Object configuration) {
+            try {
+                Class<?> traversableResolverType = traversableResolverType(configuration.getClass().getClassLoader());
+                Method getDefaultTraversableResolver = configuration.getClass().getMethod("getDefaultTraversableResolver");
+                Object defaultTraversableResolver = getDefaultTraversableResolver.invoke(configuration);
+                Object jimmerTraversableResolver = Proxy.newProxyInstance(
+                        traversableResolverType.getClassLoader(),
+                        new Class<?>[] { traversableResolverType },
+                        (proxy, method, args) -> {
+                            String methodName = method.getName();
+                            if (("isReachable".equals(methodName) || "isCascadable".equals(methodName)) &&
+                                    args != null &&
+                                    args.length == 5 &&
+                                    !isLoaded(args[0], args[1])) {
+                                return false;
+                            }
+                            return method.invoke(defaultTraversableResolver, args);
+                        }
+                );
+                Method traversableResolver = configuration.getClass().getMethod(
+                        "traversableResolver",
+                        traversableResolverType
+                );
+                traversableResolver.invoke(configuration, jimmerTraversableResolver);
+            } catch (ClassNotFoundException ex) {
+                // Bean Validation is unavailable, nothing to customize.
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException("Cannot configure Bean Validation for Jimmer immutable objects", ex);
+            }
+        }
+
+        private static Class<?> traversableResolverType(ClassLoader classLoader) throws ClassNotFoundException {
+            try {
+                return Class.forName("javax.validation.TraversableResolver", false, classLoader);
+            } catch (ClassNotFoundException ex) {
+                return Class.forName("jakarta.validation.TraversableResolver", false, classLoader);
+            }
+        }
+
+        private static boolean isLoaded(Object traversableObject, Object traversableProperty) throws ReflectiveOperationException {
+            if (!(traversableObject instanceof ImmutableSpi) || traversableProperty == null) {
+                return true;
+            }
+            Method getName = traversableProperty.getClass().getMethod("getName");
+            String propName = (String) getName.invoke(traversableProperty);
+            return propName == null || ((ImmutableSpi) traversableObject).__isLoaded(propName);
+        }
+
+        private static boolean isLocalValidatorFactoryBean(Object bean) {
+            Class<?> type = bean.getClass();
+            while (type != null) {
+                if ("org.springframework.validation.beanvalidation.LocalValidatorFactoryBean".equals(type.getName())) {
+                    return true;
+                }
+                type = type.getSuperclass();
+            }
+            return false;
+        }
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfigTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfigTest.java
@@ -1,0 +1,79 @@
+package org.babyfish.jimmer.spring.cfg;
+
+import org.babyfish.jimmer.DraftObjects;
+import org.babyfish.jimmer.UnloadedException;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutable;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableDraft;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableProps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class JimmerBeanValidationConfigTest {
+
+    @Test
+    public void testAutoConfigurationImportsBeanValidationConfig() {
+        Import importAnnotation = JimmerAutoConfiguration.class.getAnnotation(Import.class);
+
+        Assertions.assertNotNull(importAnnotation);
+        Assertions.assertTrue(
+                Arrays
+                        .asList(importAnnotation.value())
+                        .contains(JimmerBeanValidationConfig.class)
+        );
+    }
+
+    @Test
+    public void testSkipUnloadedImmutableProperty() {
+        ValidatedImmutable immutable = unloadedImmutable();
+
+        Assertions.assertThrows(UnloadedException.class, immutable::getName);
+
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            AtomicBoolean initializerCalled = new AtomicBoolean();
+
+            ctx.register(JimmerBeanValidationConfig.class);
+            ctx.registerBean(LocalValidatorFactoryBean.class, () -> {
+                LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+                validatorFactoryBean.setConfigurationInitializer(configuration -> initializerCalled.set(true));
+                return validatorFactoryBean;
+            });
+            ctx.refresh();
+
+            Validator validator = ctx.getBean(Validator.class);
+            Set<ConstraintViolation<ValidatedImmutable>> violations = validator.validate(immutable);
+
+            Assertions.assertTrue(initializerCalled.get());
+            Assertions.assertTrue(violations.isEmpty());
+        }
+    }
+
+    @Test
+    public void testPlainValidatorTouchesUnloadedImmutableProperty() {
+        ValidatedImmutable immutable = unloadedImmutable();
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        try {
+            Assertions.assertThrows(ValidationException.class, () -> validator.validate(immutable));
+        } finally {
+            validator.destroy();
+        }
+    }
+
+    private static ValidatedImmutable unloadedImmutable() {
+        return ValidatedImmutableDraft.$.produce(draft -> {
+            draft.setName("Jimmer");
+            DraftObjects.unload(draft, ValidatedImmutableProps.NAME);
+        });
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/validation/ValidatedImmutable.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/java/validation/ValidatedImmutable.java
@@ -1,0 +1,12 @@
+package org.babyfish.jimmer.spring.java.validation;
+
+import org.babyfish.jimmer.Immutable;
+
+import javax.validation.constraints.NotBlank;
+
+@Immutable
+public interface ValidatedImmutable {
+
+    @NotBlank
+    String getName();
+}


### PR DESCRIPTION
## What this fixes

When Spring Bean Validation validates a partially-loaded Jimmer immutable object, it can traverse getters for properties that are not loaded. This commonly happens when a request body is deserialized into an immutable entity and only the submitted JSON fields are loaded. Accessing an unloaded getter can throw before validation reaches the actual submitted fields.

## Changes

- Add a Spring Boot starter Bean Validation customization for Jimmer immutable objects
- Treat unloaded `ImmutableSpi` properties as unreachable for Bean Validation traversal
- Continue validating loaded properties normally
- Preserve existing `LocalValidatorFactoryBean` configuration initializers
- Support both `javax.validation` and `jakarta.validation` runtimes via reflection

## Verification

- `./gradlew :jimmer-spring-boot-starter:compileJava --no-daemon`


