### PR TITLE
Support both Bean Validation APIs with typed adapters

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -9,8 +9,7 @@ intellijAnnotations = "12.0"
 jackson2 = "2.15.2"
 jackson3 = "3.0.3"
 jacksonAnnotations = "2.21"
-jakartaValidation = "2.0.2"
-jakartaee = "9.0.0"
+jakartaValidation = "3.0.2"
 javapoet = "1.13.0"
 javaxValidation = "2.0.1.Final"
 jetbrainsAnnotations = "24.0.0"
@@ -72,7 +71,6 @@ jackson3-databind = { group = "tools.jackson.core", name = "jackson-databind", v
 jackson3-module-kotlin = { group = "tools.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson3" }
 
 jakarta-validation-api = { group = "jakarta.validation", name = "jakarta.validation-api", version.ref = "jakartaValidation" }
-jakartaee-api = { group = "jakarta.platform", name = "jakarta.jakartaee-api", version.ref = "jakartaee" }
 
 javapoet = { group = "com.squareup", name = "javapoet", version.ref = "javapoet" }
 

--- a/project/jimmer-spring-boot-starter/build.gradle.kts
+++ b/project/jimmer-spring-boot-starter/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
     compileOnly(libs.spring.data.redis)
     compileOnly(libs.caffeine)
     compileOnly(libs.spring.graphql)
-    compileOnly(libs.jakartaee.api)
+    compileOnly(libs.javax.validation.api)
+    compileOnly(libs.jakarta.validation.api)
     compileOnly(libs.springdoc.openapi.common)
 
     annotationProcessor(libs.spring.boot.configurationProcessor)
@@ -30,6 +31,8 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.starter.validation)
     testImplementation(libs.spring.boot.starter.web)
+    testImplementation(libs.javax.validation.api)
+    testImplementation(libs.jakarta.validation.api)
     testImplementation(libs.h2)
     testRuntimeOnly(libs.bundles.jackson)
     testRuntimeOnly(projects.jimmerClientSwagger)

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
@@ -1,114 +1,17 @@
 package org.babyfish.jimmer.spring.cfg;
 
-import org.babyfish.jimmer.runtime.ImmutableSpi;
-import org.springframework.beans.BeansException;
+import org.babyfish.jimmer.spring.validation.JimmerValidationBeanPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.ReflectionUtils;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.function.Consumer;
-
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.springframework.validation.beanvalidation.LocalValidatorFactoryBean")
 public class JimmerBeanValidationConfig {
 
     @Bean
-    public BeanPostProcessor jimmerValidationBeanPostProcessor() {
+    public static BeanPostProcessor jimmerValidationBeanPostProcessor() {
         return new JimmerValidationBeanPostProcessor();
-    }
-
-    private static class JimmerValidationBeanPostProcessor implements BeanPostProcessor {
-
-        @Override
-        public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-            if (!isLocalValidatorFactoryBean(bean)) {
-                return bean;
-            }
-            configure(bean);
-            return bean;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static void configure(Object bean) {
-            Method setter = ReflectionUtils.findMethod(bean.getClass(), "setConfigurationInitializer", Consumer.class);
-            if (setter == null) {
-                return;
-            }
-            Field field = ReflectionUtils.findField(bean.getClass(), "configurationInitializer");
-            ReflectionUtils.makeAccessible(setter);
-            Consumer<Object> jimmerInitializer = JimmerValidationBeanPostProcessor::configureValidation;
-            if (field != null) {
-                ReflectionUtils.makeAccessible(field);
-                Consumer<Object> oldInitializer = (Consumer<Object>) ReflectionUtils.getField(field, bean);
-                if (oldInitializer != null) {
-                    jimmerInitializer = oldInitializer.andThen(jimmerInitializer);
-                }
-            }
-            ReflectionUtils.invokeMethod(setter, bean, jimmerInitializer);
-        }
-
-        private static void configureValidation(Object configuration) {
-            try {
-                Class<?> traversableResolverType = traversableResolverType(configuration.getClass().getClassLoader());
-                Method getDefaultTraversableResolver = configuration.getClass().getMethod("getDefaultTraversableResolver");
-                Object defaultTraversableResolver = getDefaultTraversableResolver.invoke(configuration);
-                Object jimmerTraversableResolver = Proxy.newProxyInstance(
-                        traversableResolverType.getClassLoader(),
-                        new Class<?>[] { traversableResolverType },
-                        (proxy, method, args) -> {
-                            String methodName = method.getName();
-                            if (("isReachable".equals(methodName) || "isCascadable".equals(methodName)) &&
-                                    args != null &&
-                                    args.length == 5 &&
-                                    !isLoaded(args[0], args[1])) {
-                                return false;
-                            }
-                            return method.invoke(defaultTraversableResolver, args);
-                        }
-                );
-                Method traversableResolver = configuration.getClass().getMethod(
-                        "traversableResolver",
-                        traversableResolverType
-                );
-                traversableResolver.invoke(configuration, jimmerTraversableResolver);
-            } catch (ClassNotFoundException ex) {
-                // Bean Validation is unavailable, nothing to customize.
-            } catch (ReflectiveOperationException ex) {
-                throw new IllegalStateException("Cannot configure Bean Validation for Jimmer immutable objects", ex);
-            }
-        }
-
-        private static Class<?> traversableResolverType(ClassLoader classLoader) throws ClassNotFoundException {
-            try {
-                return Class.forName("javax.validation.TraversableResolver", false, classLoader);
-            } catch (ClassNotFoundException ex) {
-                return Class.forName("jakarta.validation.TraversableResolver", false, classLoader);
-            }
-        }
-
-        private static boolean isLoaded(Object traversableObject, Object traversableProperty) throws ReflectiveOperationException {
-            if (!(traversableObject instanceof ImmutableSpi) || traversableProperty == null) {
-                return true;
-            }
-            Method getName = traversableProperty.getClass().getMethod("getName");
-            String propName = (String) getName.invoke(traversableProperty);
-            return propName == null || ((ImmutableSpi) traversableObject).__isLoaded(propName);
-        }
-
-        private static boolean isLocalValidatorFactoryBean(Object bean) {
-            Class<?> type = bean.getClass();
-            while (type != null) {
-                if ("org.springframework.validation.beanvalidation.LocalValidatorFactoryBean".equals(type.getName())) {
-                    return true;
-                }
-                type = type.getSuperclass();
-            }
-            return false;
-        }
     }
 }

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JakartaCompositeTraversableResolver.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JakartaCompositeTraversableResolver.java
@@ -1,0 +1,64 @@
+package org.babyfish.jimmer.spring.validation;
+
+import jakarta.validation.Path;
+import jakarta.validation.TraversableResolver;
+
+import java.lang.annotation.ElementType;
+
+final class JakartaCompositeTraversableResolver implements TraversableResolver {
+
+    private final TraversableResolver first;
+
+    private final TraversableResolver second;
+
+    JakartaCompositeTraversableResolver(TraversableResolver first, TraversableResolver second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public boolean isReachable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return first.isReachable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        ) && second.isReachable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        );
+    }
+
+    @Override
+    public boolean isCascadable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return first.isCascadable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        ) && second.isCascadable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        );
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JavaxCompositeTraversableResolver.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JavaxCompositeTraversableResolver.java
@@ -1,0 +1,63 @@
+package org.babyfish.jimmer.spring.validation;
+
+import javax.validation.Path;
+import javax.validation.TraversableResolver;
+import java.lang.annotation.ElementType;
+
+final class JavaxCompositeTraversableResolver implements TraversableResolver {
+
+    private final TraversableResolver first;
+
+    private final TraversableResolver second;
+
+    JavaxCompositeTraversableResolver(TraversableResolver first, TraversableResolver second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public boolean isReachable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return first.isReachable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        ) && second.isReachable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        );
+    }
+
+    @Override
+    public boolean isCascadable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return first.isCascadable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        ) && second.isCascadable(
+                traversableObject,
+                traversableProperty,
+                rootBeanType,
+                pathToTraversableObject,
+                elementType
+        );
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerJakartaTraversableResolver.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerJakartaTraversableResolver.java
@@ -1,0 +1,39 @@
+package org.babyfish.jimmer.spring.validation;
+
+import jakarta.validation.Path;
+import jakarta.validation.TraversableResolver;
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+
+import java.lang.annotation.ElementType;
+
+/**
+ * Prevents Bean Validation from traversing unloaded Jimmer immutable properties.
+ * This resolver does not delegate; combine it with other resolvers when necessary.
+ */
+public final class JimmerJakartaTraversableResolver implements TraversableResolver {
+
+    @Override
+    public boolean isReachable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return !(traversableObject instanceof ImmutableSpi) ||
+                traversableProperty == null ||
+                traversableProperty.getName() == null ||
+                ((ImmutableSpi) traversableObject).__isLoaded(traversableProperty.getName());
+    }
+
+    @Override
+    public boolean isCascadable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return true;
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerJavaxTraversableResolver.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerJavaxTraversableResolver.java
@@ -1,0 +1,39 @@
+package org.babyfish.jimmer.spring.validation;
+
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+
+import javax.validation.Path;
+import javax.validation.TraversableResolver;
+import java.lang.annotation.ElementType;
+
+/**
+ * Prevents Bean Validation from traversing unloaded Jimmer immutable properties.
+ * This resolver does not delegate; combine it with other resolvers when necessary.
+ */
+public final class JimmerJavaxTraversableResolver implements TraversableResolver {
+
+    @Override
+    public boolean isReachable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return !(traversableObject instanceof ImmutableSpi) ||
+                traversableProperty == null ||
+                traversableProperty.getName() == null ||
+                ((ImmutableSpi) traversableObject).__isLoaded(traversableProperty.getName());
+    }
+
+    @Override
+    public boolean isCascadable(
+            Object traversableObject,
+            Path.Node traversableProperty,
+            Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType
+    ) {
+        return true;
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerValidation.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerValidation.java
@@ -1,0 +1,69 @@
+package org.babyfish.jimmer.spring.validation;
+
+final class JimmerValidation {
+
+    private static final String JAVAX_CONFIGURATION_CLASS_NAME = "javax.validation.Configuration";
+
+    private static final String JAKARTA_CONFIGURATION_CLASS_NAME = "jakarta.validation.Configuration";
+
+    private JimmerValidation() {
+    }
+
+    static void initialize(Object configuration) {
+        Class<?> configurationInterface = findConfigurationInterface(configuration.getClass());
+        if (configurationInterface == null) {
+            throw new IllegalArgumentException(
+                    "The configuration object does not implement javax.validation.Configuration " +
+                            "or jakarta.validation.Configuration"
+            );
+        }
+        switch (configurationInterface.getName()) {
+            case JAVAX_CONFIGURATION_CLASS_NAME:
+                JavaxValidation.initialize(configuration);
+                break;
+            case JAKARTA_CONFIGURATION_CLASS_NAME:
+                JakartaValidation.initialize(configuration);
+                break;
+        }
+    }
+
+    private static Class<?> findConfigurationInterface(Class<?> type) {
+        for (Class<?> interfaceType : type.getInterfaces()) {
+            String interfaceName = interfaceType.getName();
+            if (JAVAX_CONFIGURATION_CLASS_NAME.equals(interfaceName) ||
+                    JAKARTA_CONFIGURATION_CLASS_NAME.equals(interfaceName)) {
+                return interfaceType;
+            }
+            Class<?> configurationInterface = findConfigurationInterface(interfaceType);
+            if (configurationInterface != null) {
+                return configurationInterface;
+            }
+        }
+        Class<?> superType = type.getSuperclass();
+        return superType != null ? findConfigurationInterface(superType) : null;
+    }
+
+    private static final class JavaxValidation {
+        static void initialize(Object configuration) {
+            javax.validation.Configuration<?> typedConfig = (javax.validation.Configuration<?>) configuration;
+            typedConfig.traversableResolver(
+                    new JavaxCompositeTraversableResolver(
+                            new JimmerJavaxTraversableResolver(),
+                            typedConfig.getDefaultTraversableResolver()
+                    )
+            );
+        }
+    }
+
+    private static final class JakartaValidation {
+        static void initialize(Object configuration) {
+            jakarta.validation.Configuration<?> typedConfig = (jakarta.validation.Configuration<?>) configuration;
+            typedConfig.traversableResolver(
+                    new JakartaCompositeTraversableResolver(
+                            new JimmerJakartaTraversableResolver(),
+                            typedConfig.getDefaultTraversableResolver()
+                    )
+            );
+        }
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerValidationBeanPostProcessor.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/validation/JimmerValidationBeanPostProcessor.java
@@ -1,0 +1,46 @@
+package org.babyfish.jimmer.spring.validation;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+public class JimmerValidationBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(@NotNull Object bean, @NotNull String beanName) throws BeansException {
+        if (bean instanceof LocalValidatorFactoryBean) {
+            configure((LocalValidatorFactoryBean) bean);
+        }
+        return bean;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void configure(LocalValidatorFactoryBean bean) {
+        if (fieldValue(bean, "traversableResolver") != null) {
+            return;
+        }
+        Consumer<Object> jimmerInitializer = JimmerValidation::initialize;
+        Consumer<Object> userInitializer = (Consumer<Object>) fieldValue(bean, "configurationInitializer");
+        if (userInitializer != null) {
+            jimmerInitializer = jimmerInitializer.andThen(userInitializer);
+        }
+        // The erased setter is identical in Spring 5 and 6, but its generic
+        // Configuration type is javax.validation or jakarta.validation.
+        bean.setConfigurationInitializer((Consumer) jimmerInitializer);
+    }
+
+    private static Object fieldValue(LocalValidatorFactoryBean bean, String name) {
+        try {
+            Field field = LocalValidatorFactoryBean.class.getDeclaredField(name);
+            ReflectionUtils.makeAccessible(field);
+            return ReflectionUtils.getField(field, bean);
+        } catch (NoSuchFieldException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfigTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfigTest.java
@@ -7,11 +7,13 @@ import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableDraft;
 import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableProps;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.TraversableResolver;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 import java.util.Arrays;
@@ -68,6 +70,53 @@ public class JimmerBeanValidationConfigTest {
         } finally {
             validator.destroy();
         }
+    }
+
+    @Test
+    public void testUserInitializerCanReplaceJimmerTraversableResolver() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            ctx.register(JimmerBeanValidationConfig.class);
+            ctx.registerBean(LocalValidatorFactoryBean.class, () -> {
+                LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+                validatorFactoryBean.setConfigurationInitializer(
+                        configuration -> configuration.traversableResolver(alwaysTraversableResolver())
+                );
+                return validatorFactoryBean;
+            });
+            ctx.refresh();
+
+            Validator validator = ctx.getBean(Validator.class);
+            Assertions.assertThrows(ValidationException.class, () -> validator.validate(unloadedImmutable()));
+        }
+    }
+
+    @Test
+    public void testExplicitTraversableResolverDisablesJimmerInitializer() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            AtomicBoolean initializerCalled = new AtomicBoolean();
+
+            ctx.register(JimmerBeanValidationConfig.class);
+            ctx.registerBean(LocalValidatorFactoryBean.class, () -> {
+                LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+                validatorFactoryBean.setTraversableResolver(alwaysTraversableResolver());
+                validatorFactoryBean.setConfigurationInitializer(configuration -> initializerCalled.set(true));
+                return validatorFactoryBean;
+            });
+            ctx.refresh();
+
+            Validator validator = ctx.getBean(Validator.class);
+            Assertions.assertTrue(initializerCalled.get());
+            Assertions.assertThrows(ValidationException.class, () -> validator.validate(unloadedImmutable()));
+        }
+    }
+
+    private static TraversableResolver alwaysTraversableResolver() {
+        TraversableResolver resolver = Mockito.mock(TraversableResolver.class);
+        Mockito.when(resolver.isReachable(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+        Mockito.when(resolver.isCascadable(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+        return resolver;
     }
 
     private static ValidatedImmutable unloadedImmutable() {

--- a/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/validation/JimmerValidationTest.java
+++ b/project/jimmer-spring-boot-starter/src/test/java/org/babyfish/jimmer/spring/validation/JimmerValidationTest.java
@@ -1,0 +1,86 @@
+package org.babyfish.jimmer.spring.validation;
+
+import org.babyfish.jimmer.DraftObjects;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutable;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableDraft;
+import org.babyfish.jimmer.spring.java.validation.ValidatedImmutableProps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class JimmerValidationTest {
+
+    @Test
+    public void testJavaxValidation() {
+        javax.validation.Configuration<?> configuration = Mockito.mock(javax.validation.Configuration.class);
+        javax.validation.TraversableResolver delegate = Mockito.mock(javax.validation.TraversableResolver.class);
+        javax.validation.Path.Node property = Mockito.mock(javax.validation.Path.Node.class);
+        Mockito.when(configuration.getDefaultTraversableResolver()).thenReturn(delegate);
+        Mockito.when(property.getName()).thenReturn("name");
+
+        JimmerJavaxTraversableResolver jimmerResolver = new JimmerJavaxTraversableResolver();
+        Assertions.assertFalse(jimmerResolver.isReachable(unloadedImmutable(), property, null, null, null));
+        Assertions.assertTrue(jimmerResolver.isReachable(loadedImmutable(), property, null, null, null));
+
+        JimmerValidation.initialize(configuration);
+
+        ArgumentCaptor<javax.validation.TraversableResolver> captor =
+                ArgumentCaptor.forClass(javax.validation.TraversableResolver.class);
+        Mockito.verify(configuration).traversableResolver(captor.capture());
+        javax.validation.TraversableResolver resolver = captor.getValue();
+
+        Assertions.assertFalse(resolver.isReachable(unloadedImmutable(), property, null, null, null));
+        Mockito.verifyNoInteractions(delegate);
+
+        Mockito.when(delegate.isReachable(Mockito.any(), Mockito.eq(property), Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+                .thenReturn(true);
+        Mockito.when(delegate.isCascadable(Mockito.any(), Mockito.eq(property), Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+                .thenReturn(true);
+        ValidatedImmutable immutable = loadedImmutable();
+        Assertions.assertTrue(resolver.isReachable(immutable, property, null, null, null));
+        Assertions.assertTrue(resolver.isCascadable(immutable, property, null, null, null));
+    }
+
+    @Test
+    public void testJakartaValidation() {
+        jakarta.validation.Configuration<?> configuration = Mockito.mock(jakarta.validation.Configuration.class);
+        jakarta.validation.TraversableResolver delegate = Mockito.mock(jakarta.validation.TraversableResolver.class);
+        jakarta.validation.Path.Node property = Mockito.mock(jakarta.validation.Path.Node.class);
+        Mockito.when(configuration.getDefaultTraversableResolver()).thenReturn(delegate);
+        Mockito.when(property.getName()).thenReturn("name");
+
+        JimmerJakartaTraversableResolver jimmerResolver = new JimmerJakartaTraversableResolver();
+        Assertions.assertFalse(jimmerResolver.isReachable(unloadedImmutable(), property, null, null, null));
+        Assertions.assertTrue(jimmerResolver.isReachable(loadedImmutable(), property, null, null, null));
+
+        JimmerValidation.initialize(configuration);
+
+        ArgumentCaptor<jakarta.validation.TraversableResolver> captor =
+                ArgumentCaptor.forClass(jakarta.validation.TraversableResolver.class);
+        Mockito.verify(configuration).traversableResolver(captor.capture());
+        jakarta.validation.TraversableResolver resolver = captor.getValue();
+
+        Assertions.assertFalse(resolver.isReachable(unloadedImmutable(), property, null, null, null));
+        Mockito.verifyNoInteractions(delegate);
+
+        Mockito.when(delegate.isReachable(Mockito.any(), Mockito.eq(property), Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+                .thenReturn(true);
+        Mockito.when(delegate.isCascadable(Mockito.any(), Mockito.eq(property), Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+                .thenReturn(true);
+        ValidatedImmutable immutable = loadedImmutable();
+        Assertions.assertTrue(resolver.isReachable(immutable, property, null, null, null));
+        Assertions.assertTrue(resolver.isCascadable(immutable, property, null, null, null));
+    }
+
+    private static ValidatedImmutable loadedImmutable() {
+        return ValidatedImmutableDraft.$.produce(draft -> draft.setName("Jimmer"));
+    }
+
+    private static ValidatedImmutable unloadedImmutable() {
+        return ValidatedImmutableDraft.$.produce(draft -> {
+            draft.setName("Jimmer");
+            DraftObjects.unload(draft, ValidatedImmutableProps.NAME);
+        });
+    }
+}


### PR DESCRIPTION
This PR replaces and fixes the Bean Validation integration introduced by
[#1446](https://github.com/babyfish-ct/jimmer/pull/1446).

The previous implementation handled both Validation namespaces through a
reflection proxy and treated `isReachable` and `isCascadable` identically. It
also installed the Jimmer resolver after user configuration, so it could
silently override an explicitly configured `TraversableResolver`.

The new implementation:

- provides statically typed adapters for both `javax.validation` and
  `jakarta.validation`;
- prevents validation of unloaded immutable properties through
  `isReachable`, while correctly allowing cascading through `isCascadable`;
- composes Jimmer's check with the provider's default resolver;
- backs off when the user explicitly configures a resolver, and gives an
  existing configuration initializer the final say;
- exposes stateless Jimmer resolvers for explicit user composition;
- limits reflection to the Spring 5/6 compatibility boundary;
- replaces the broad Jakarta EE dependency with the two Bean Validation API
  dependencies actually required;
- adds focused coverage for both Validation APIs and Spring configuration
  precedence.
