### PR TITLE
fix: fix Bean Validation compatibility with Spring Boot 3 / Hibernate…

### DIFF
--- a/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
+++ b/project/jimmer-spring-boot-starter/src/main/java/org/babyfish/jimmer/spring/cfg/JimmerBeanValidationConfig.java
@@ -85,9 +85,9 @@ public class JimmerBeanValidationConfig {
 
         private static Class<?> traversableResolverType(ClassLoader classLoader) throws ClassNotFoundException {
             try {
-                return Class.forName("javax.validation.TraversableResolver", false, classLoader);
-            } catch (ClassNotFoundException ex) {
                 return Class.forName("jakarta.validation.TraversableResolver", false, classLoader);
+            } catch (ClassNotFoundException ex) {
+                return Class.forName("javax.validation.TraversableResolver", false, classLoader);
             }
         }
 


### PR DESCRIPTION
  Title:
  fix: fix Bean Validation compatibility with Spring Boot 3 / Hibernate Validator 8

  Body:
  In `JimmerBeanValidationConfig.traversableResolverType()`, the method tries
  `javax.validation.TraversableResolver` first, falling back to
  `jakarta.validation.TraversableResolver`.

  On Spring Boot 3, both APIs are on the classpath:
  - `jakarta.validation:jakarta-validation-api` (from Spring Boot)
  - `javax.validation:validation-api` (from jimmer-core)

  So `Class.forName("javax.validation...")` succeeds, returning the javax type.
  The code then reflectively calls:

  ```java
  configuration.getClass().getMethod("traversableResolver", javaxType)
  ```
  
  But Hibernate Validator 8.x's `ConfigurationImpl` only has:
  
  ```java
  traversableResolver(jakarta.validation.TraversableResolver)
  ```
  
  The parameter types don't match, causing `NoSuchMethodException`.
  
  **Fix:** reverse the priority — try `jakarta.validation.TraversableResolver`
  first, fallback to `javax.validation.TraversableResolver`.

  - Spring Boot 3 + Hibernate Validator 8.x: jakarta loads first → matches
  - Spring Boot 2 + Hibernate Validator 6.x: jakarta not found → falls back to javax → matches