### PR TITLE
Fix object caching for polymorphic entities

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/ImmutableType.java
@@ -85,6 +85,10 @@ public interface ImmutableType {
 
     Set<ImmutableType> getAllDerivedTypes();
 
+    default boolean hasDerivedTypes() {
+        return !getDirectDerivedTypes().isEmpty();
+    }
+
     @Nullable
     String getDiscriminatorValue();
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/EntitiesImpl.java
@@ -293,7 +293,7 @@ public class EntitiesImpl implements Entities {
                     entities.add(entity);
                 }
             }
-            Shapes.reshape(sqlClient, con, entities, fetcher, null);
+            Shapes.reshape(sqlClient, con, entities, immutableType, fetcher, null);
             return entities;
         }
         ConfigurableRootQuery<?, E> query = Queries.createQuery(
@@ -365,7 +365,7 @@ public class EntitiesImpl implements Entities {
                     entities.add(entity);
                 }
             }
-            Shapes.reshape(sqlClient, con, entities, fetcher, converter);
+            Shapes.reshape(sqlClient, con, entities, immutableType, fetcher, converter);
             return entities;
         }
         ConfigurableRootQuery<?, E> query = Queries.<E>createQuery(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Deleter.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Deleter.java
@@ -238,7 +238,7 @@ public class Deleter {
             return false;
         }
         ImmutableType type = deletedTypes.iterator().next();
-        return type != inheritanceInfo.getRootType() && type.getAllDerivedTypes().isEmpty();
+        return type != inheritanceInfo.getRootType() && !type.hasDerivedTypes();
     }
 
     private int executeStagedJoinedExactDelete(Collection<Object> ids) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableDeleteImpl.java
@@ -159,7 +159,7 @@ public class MutableDeleteImpl
         }
         boolean manualPredicateRequired =
                 type == inheritanceInfo.getRootType() ||
-                        (resolvedMode == TypeMatchMode.EXACT && !type.getAllDerivedTypes().isEmpty());
+                        (resolvedMode == TypeMatchMode.EXACT && type.hasDerivedTypes());
         if (!manualPredicateRequired) {
             return;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/CacheLoader.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/CacheLoader.java
@@ -8,10 +8,10 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
 import org.babyfish.jimmer.sql.fetcher.IdOnlyFetchType;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherImpl;
+import org.babyfish.jimmer.sql.fetcher.impl.FetcherImplementor;
 
 import java.sql.Connection;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 @FunctionalInterface
 public interface CacheLoader<K, V> {
@@ -40,11 +40,17 @@ class ObjectCacheFetchers {
         return (Fetcher<V>) CACHE.get(type);
     }
 
-    @SuppressWarnings("unchecked")
     private static Fetcher<?> create(Class<?> type) {
-        ImmutableType immutableType = ImmutableType.get(type);
-        Fetcher<?> fetcher = new FetcherImpl<>((Class<Object>) type);
+        return create(ImmutableType.get(type), Collections.emptySet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Fetcher<?> create(ImmutableType immutableType, Set<String> inheritedPropNames) {
+        Fetcher<?> fetcher = new FetcherImpl<>((Class<Object>) immutableType.getJavaClass());
         for (ImmutableProp prop : immutableType.getObjectCacheProps().values()) {
+            if (inheritedPropNames.contains(prop.getName())) {
+                continue;
+            }
             ImmutableProp idViewProp = prop.getIdViewProp();
             ImmutableProp fetchedProp = idViewProp != null ? idViewProp : prop;
             if (prop.isReference(TargetLevel.PERSISTENT)) {
@@ -52,6 +58,15 @@ class ObjectCacheFetchers {
             } else {
                 fetcher = fetcher.add(fetchedProp.getName());
             }
+        }
+        Set<String> propNames = new HashSet<>(inheritedPropNames);
+        propNames.addAll(immutableType.getObjectCacheProps().keySet());
+        List<ImmutableType> derivedTypes = new ArrayList<>(immutableType.getDirectDerivedTypes());
+        derivedTypes.sort(Comparator.comparing(it -> it.getJavaClass().getName()));
+        for (ImmutableType derivedType : derivedTypes) {
+            fetcher = ((FetcherImplementor<?>) fetcher).__forType(
+                    create(derivedType, propNames)
+            );
         }
         return fetcher;
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
@@ -1,11 +1,9 @@
 package org.babyfish.jimmer.sql.cache;
 
-import org.babyfish.jimmer.jackson.codec.JsonCodec;
-import org.babyfish.jimmer.jackson.codec.JsonReader;
-import org.babyfish.jimmer.jackson.codec.JsonTypeFactory;
-import org.babyfish.jimmer.jackson.codec.JsonWriter;
+import org.babyfish.jimmer.jackson.codec.*;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.InheritanceInfo;
 import org.babyfish.jimmer.meta.TargetLevel;
 import org.babyfish.jimmer.sql.exception.SerializationException;
 import org.jetbrains.annotations.NotNull;
@@ -21,6 +19,10 @@ public class ValueSerializer<T> {
 
     private final JsonReader<T> jsonReader;
     private final JsonWriter jsonWriter;
+    private final ImmutableType polymorphicType;
+    private final InheritanceInfo inheritanceInfo;
+    private final JsonReader<Node> treeReader;
+    private final JsonConverter jsonConverter;
 
     public ValueSerializer(@NotNull ImmutableType type) {
         this(type, null, jsonCodec());
@@ -44,6 +46,18 @@ public class ValueSerializer<T> {
         }
         this.jsonReader = codec.readerFor(tf -> createValueType(tf, type, prop));
         this.jsonWriter = codec.writer();
+        InheritanceInfo inheritanceInfo = type != null ? type.getInheritanceInfo() : null;
+        if (inheritanceInfo != null && !type.getDirectDerivedTypes().isEmpty()) {
+            this.polymorphicType = type;
+            this.inheritanceInfo = inheritanceInfo;
+            this.treeReader = codec.treeReader();
+            this.jsonConverter = codec.converter();
+        } else {
+            this.polymorphicType = null;
+            this.inheritanceInfo = null;
+            this.treeReader = null;
+            this.jsonConverter = null;
+        }
     }
 
     private static <JT> JT createValueType(JsonTypeFactory<JT> typeFactory, ImmutableType type, ImmutableProp prop) {
@@ -91,11 +105,27 @@ public class ValueSerializer<T> {
         return serializedMap;
     }
 
+    @SuppressWarnings("unchecked")
     public T deserialize(byte[] value) {
         if (value == null || value.length == 0 || Arrays.equals(value, NULL_BYTES)) {
             return null;
         }
         try {
+            if (inheritanceInfo != null) {
+                Node node = treeReader.read(value);
+                ImmutableProp discriminatorProp = inheritanceInfo.getDiscriminatorProp();
+                Node discriminatorNode = node.get(discriminatorProp.getName());
+                if (discriminatorNode != null && !discriminatorNode.isNull()) {
+                    Object discriminator = discriminatorNode.convertTo(
+                            discriminatorProp.getReturnClass(),
+                            jsonConverter
+                    );
+                    ImmutableType actualType = inheritanceInfo.getDiscriminatorTypeMap().get(discriminator);
+                    if (actualType != null && polymorphicType.isAssignableFrom(actualType)) {
+                        return (T) node.convertTo(actualType.getJavaClass(), jsonConverter);
+                    }
+                }
+            }
             return jsonReader.read(value);
         } catch (Exception ex) {
             throw new SerializationException(ex);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
@@ -48,7 +48,7 @@ public class ValueSerializer<T> {
         this.jsonReader = codec.readerFor(tf -> createValueType(tf, type, prop));
         this.jsonWriter = codec.writer();
         InheritanceInfo inheritanceInfo = type != null ? type.getInheritanceInfo() : null;
-        if (inheritanceInfo != null && !type.getDirectDerivedTypes().isEmpty()) {
+        if (inheritanceInfo != null && type.hasDerivedTypes()) {
             ImmutableProp discriminatorProp = inheritanceInfo.getDiscriminatorProp();
             this.discriminatorPropName = discriminatorProp.getName();
             this.discriminatorType = discriminatorProp.getReturnClass();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/cache/ValueSerializer.java
@@ -19,8 +19,9 @@ public class ValueSerializer<T> {
 
     private final JsonReader<T> jsonReader;
     private final JsonWriter jsonWriter;
-    private final ImmutableType polymorphicType;
-    private final InheritanceInfo inheritanceInfo;
+    private final String discriminatorPropName;
+    private final Class<?> discriminatorType;
+    private final Map<Object, Class<?>> discriminatorTypeMap;
     private final JsonReader<Node> treeReader;
     private final JsonConverter jsonConverter;
 
@@ -48,13 +49,22 @@ public class ValueSerializer<T> {
         this.jsonWriter = codec.writer();
         InheritanceInfo inheritanceInfo = type != null ? type.getInheritanceInfo() : null;
         if (inheritanceInfo != null && !type.getDirectDerivedTypes().isEmpty()) {
-            this.polymorphicType = type;
-            this.inheritanceInfo = inheritanceInfo;
+            ImmutableProp discriminatorProp = inheritanceInfo.getDiscriminatorProp();
+            this.discriminatorPropName = discriminatorProp.getName();
+            this.discriminatorType = discriminatorProp.getReturnClass();
+            Map<Object, Class<?>> discriminatorTypeMap = new HashMap<>();
+            for (Map.Entry<Object, ImmutableType> e : inheritanceInfo.getDiscriminatorTypeMap().entrySet()) {
+                if (type.isAssignableFrom(e.getValue())) {
+                    discriminatorTypeMap.put(e.getKey(), e.getValue().getJavaClass());
+                }
+            }
+            this.discriminatorTypeMap = discriminatorTypeMap;
             this.treeReader = codec.treeReader();
             this.jsonConverter = codec.converter();
         } else {
-            this.polymorphicType = null;
-            this.inheritanceInfo = null;
+            this.discriminatorPropName = null;
+            this.discriminatorType = null;
+            this.discriminatorTypeMap = null;
             this.treeReader = null;
             this.jsonConverter = null;
         }
@@ -75,8 +85,7 @@ public class ValueSerializer<T> {
         }
     }
 
-    @NotNull
-    public byte[] serialize(T value) {
+    public byte @NotNull [] serialize(T value) {
         if (value == null) {
             return NULL_BYTES.clone();
         }
@@ -111,18 +120,16 @@ public class ValueSerializer<T> {
             return null;
         }
         try {
-            if (inheritanceInfo != null) {
+            if (discriminatorTypeMap != null) {
                 Node node = treeReader.read(value);
-                ImmutableProp discriminatorProp = inheritanceInfo.getDiscriminatorProp();
-                Node discriminatorNode = node.get(discriminatorProp.getName());
+                Node discriminatorNode = node.get(discriminatorPropName);
                 if (discriminatorNode != null && !discriminatorNode.isNull()) {
-                    Object discriminator = discriminatorNode.convertTo(
-                            discriminatorProp.getReturnClass(),
-                            jsonConverter
-                    );
-                    ImmutableType actualType = inheritanceInfo.getDiscriminatorTypeMap().get(discriminator);
-                    if (actualType != null && polymorphicType.isAssignableFrom(actualType)) {
-                        return (T) node.convertTo(actualType.getJavaClass(), jsonConverter);
+                    Object discriminator = discriminatorNode.canCastTo(discriminatorType) ?
+                            discriminatorNode.castTo(discriminatorType) :
+                            discriminatorNode.convertTo(discriminatorType, jsonConverter);
+                    Class<?> actualType = discriminatorTypeMap.get(discriminator);
+                    if (actualType != null) {
+                        return (T) node.convertTo(actualType, jsonConverter);
                     }
                 }
             }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
@@ -127,21 +127,17 @@ public class FetcherUtil {
 
         for (Map.Entry<Integer, List<Object>> e : columnMap.entrySet()) {
             int columnIndex = e.getKey();
-            List<Object> fetchedList = e.getValue();
             FetcherSelection<?> selection = (FetcherSelection<?>) selections.get(columnIndex);
-            Fetcher<?> fetcher = selection.getFetcher();
-            if (requiresPostFetch(sqlClient, fetcher)) {
-                fetchedList = produceList(sqlClient, con, selection, fetchedList);
-            }
-            Function<Object, Object> converter = (Function<Object, Object>) selection.getConverter();
-            if (converter != null) {
-                List<Object> list = new ArrayList<>(fetchedList.size());
-                for (Object fetched : fetchedList) {
-                    list.add(fetched != null ? converter.apply(fetched) : null);
-                }
-                fetchedList = list;
-            }
-            e.setValue(fetchedList);
+            e.setValue(
+                    fetchColumn(
+                            sqlClient,
+                            con,
+                            selection.getPath(),
+                            selection.getFetcher(),
+                            (Function<Object, Object>) selection.getConverter(),
+                            e.getValue()
+                    )
+            );
         }
 
         Map<Integer, Object> indexValueMap = new HashMap<>();
@@ -156,6 +152,48 @@ public class FetcherUtil {
             itr.set(ColumnAccessors.set(itr.next(), indexValueMap, tupleCreator));
             rowIndex++;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> void fetch(
+            JSqlClientImplementor sqlClient,
+            Connection con,
+            Fetcher<?> fetcher,
+            @Nullable Function<?, E> converter,
+            List<E> entities
+    ) {
+        List<Object> fetchedList = fetchColumn(
+                sqlClient,
+                con,
+                null,
+                fetcher,
+                (Function<Object, Object>) converter,
+                (List<Object>) entities
+        );
+        if (fetchedList != entities) {
+            Collections.copy(entities, (List<E>) fetchedList);
+        }
+    }
+
+    private static List<Object> fetchColumn(
+            JSqlClientImplementor sqlClient,
+            Connection con,
+            FetchPath path,
+            Fetcher<?> fetcher,
+            @Nullable Function<Object, Object> converter,
+            List<Object> fetchedList
+    ) {
+        if (requiresPostFetch(sqlClient, fetcher)) {
+            fetchedList = produceList(sqlClient, con, path, fetcher, fetchedList);
+        }
+        if (converter != null) {
+            List<Object> convertedList = new ArrayList<>(fetchedList.size());
+            for (Object fetched : fetchedList) {
+                convertedList.add(fetched != null ? converter.apply(fetched) : null);
+            }
+            return convertedList;
+        }
+        return fetchedList;
     }
 
     private static void fetch(
@@ -177,7 +215,8 @@ public class FetcherUtil {
     private static List<Object> produceList(
             JSqlClientImplementor sqlClient,
             Connection con,
-            FetcherSelection<?> selection,
+            FetchPath path,
+            Fetcher<?> fetcher,
             List<Object> fetchedList
     ) {
         return Internal.produceList(
@@ -186,8 +225,8 @@ public class FetcherUtil {
                 values -> fetch(
                         sqlClient,
                         con,
-                        selection.getPath(),
-                        selection.getFetcher(),
+                        path,
+                        fetcher,
                         (List<DraftSpi>) values
                 ),
                 null

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/FetcherUtil.java
@@ -206,6 +206,10 @@ public class FetcherUtil {
         if (hasReferenceFilter(fetcher.getImmutableType(), sqlClient)) {
             return true;
         }
+        if (fetcher instanceof FetcherImplementor<?> &&
+                ((FetcherImplementor<?>) fetcher).__isSimpleFetcher()) {
+            return false;
+        }
         for (Field field : fetcher.getFieldMap().values()) {
             if (field.isSimpleField()) {
                 continue;

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -2,7 +2,6 @@ package org.babyfish.jimmer.sql.fetcher.impl;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
-import org.babyfish.jimmer.meta.PropId;
 import org.babyfish.jimmer.runtime.DraftSpi;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.runtime.Internal;
@@ -18,32 +17,31 @@ import java.util.function.Function;
 
 public class Shapes {
 
-    private Shapes() {}
+    private Shapes() {
+    }
 
     @SuppressWarnings("unchecked")
     public static <E> void reshape(
             JSqlClientImplementor sqlClient,
             Connection con,
             List<E> entities,
+            ImmutableType immutableType,
             Fetcher<?> fetcher,
             Function<?, E> converter
     ) {
-        if (entities.isEmpty() || fetcher == null) {
+        if (entities.isEmpty()) {
             return;
         }
-        ImmutableType immutableType = fetcher.getImmutableType();
-        List<PropId> shownPropIds = new ArrayList<>();
-        for (Field field : fetcher.getFieldMap().values()) {
-            if (field.getProp().isView() || field.getProp().isFormula()) {
-                shownPropIds.add(field.getProp().getId());
-            }
-        }
+        Map<ImmutableType, Map<String, Field>> fieldMapCache = new HashMap<>();
         boolean needDrop = false;
         for (ImmutableSpi spi : (List<ImmutableSpi>) entities) {
-            for (ImmutableProp prop : immutableType.getProps().values()) {
+            ImmutableType actualType = spi.__type();
+            Map<String, Field> fieldMap = fetcher != null ?
+                    fieldMapCache.computeIfAbsent(actualType, it -> fieldMap(fetcher, it)) :
+                    null;
+            for (ImmutableProp prop : actualType.getProps().values()) {
                 if (spi.__isLoaded(prop.getId())) {
-                    Field field = fetcher.getFieldMap().get(prop.getName());
-                    if (field == null || field.isImplicit()) {
+                    if (!isIncluded(immutableType, fieldMap, prop) || isImplicit(fieldMap, prop)) {
                         needDrop = true;
                         break;
                     }
@@ -54,58 +52,110 @@ public class Shapes {
             ListIterator<ImmutableSpi> itr = (ListIterator<ImmutableSpi>) entities.listIterator();
             while (itr.hasNext()) {
                 ImmutableSpi spi = itr.next();
+                Map<String, Field> fieldMap = fetcher != null ? fieldMapCache.get(spi.__type()) : null;
                 itr.set(
                         (ImmutableSpi) Internal.produce(spi.__type(), spi, draft -> {
-                            for (ImmutableProp prop : immutableType.getProps().values()) {
+                            for (ImmutableProp prop : spi.__type().getProps().values()) {
                                 if (spi.__isLoaded(prop.getId())) {
-                                    Field field = fetcher.getFieldMap().get(prop.getName());
-                                    if (field == null) {
+                                    if (!isIncluded(immutableType, fieldMap, prop)) {
                                         if (!prop.isView()) {
                                             ((DraftSpi) draft).__unload(prop.getId());
                                         } else {
                                             ((DraftSpi) draft).__show(prop.getId(), false);
                                         }
-                                    } else if (field.isImplicit()) {
+                                    } else if (isImplicit(fieldMap, prop)) {
                                         ((DraftSpi) draft).__show(prop.getId(), false);
                                     }
                                 }
-                                for (PropId shownPropId : shownPropIds) {
-                                    ((DraftSpi) draft).__show(shownPropId, true);
+                            }
+                            if (fieldMap != null) {
+                                for (Field field : fieldMap.values()) {
+                                    ImmutableProp prop = field.getProp();
+                                    if (prop.isView() || prop.isFormula()) {
+                                        ((DraftSpi) draft).__show(prop.getId(), true);
+                                    }
                                 }
                             }
                         })
                 );
             }
         }
-        FetcherUtil.fetch(
-                sqlClient,
-                con,
-                Collections.singletonList(
-                        new FetcherSelection<E>() {
+        if (fetcher != null) {
+            FetcherUtil.fetch(
+                    sqlClient,
+                    con,
+                    Collections.singletonList(
+                            new FetcherSelection<E>() {
 
-                            @Override
-                            public FetchPath getPath() {
-                                return null;
-                            }
+                                @Override
+                                public FetchPath getPath() {
+                                    return null;
+                                }
 
-                            @Override
-                            public Fetcher<?> getFetcher() {
-                                return fetcher;
-                            }
+                                @Override
+                                public Fetcher<?> getFetcher() {
+                                    return fetcher;
+                                }
 
-                            @Override
-                            public PropExpression.Embedded<?> getEmbeddedPropExpression() {
-                                return null;
-                            }
+                                @Override
+                                public PropExpression.Embedded<?> getEmbeddedPropExpression() {
+                                    return null;
+                                }
 
-                            @Override
-                            public @Nullable Function<?, E> getConverter() {
-                                return converter;
+                                @Override
+                                public @Nullable Function<?, E> getConverter() {
+                                    return converter;
+                                }
                             }
-                        }
-                ),
-                null,
-                entities
-        );
+                    ),
+                    null,
+                    entities
+            );
+        }
+    }
+
+    private static boolean isIncluded(
+            ImmutableType immutableType,
+            Map<String, Field> fieldMap,
+            ImmutableProp prop
+    ) {
+        return fieldMap != null ?
+                fieldMap.containsKey(prop.getName()) :
+                immutableType.getObjectCacheProps().containsKey(prop.getName());
+    }
+
+    private static boolean isImplicit(Map<String, Field> fieldMap, ImmutableProp prop) {
+        if (fieldMap == null) {
+            return false;
+        }
+        Field field = fieldMap.get(prop.getName());
+        return field != null && field.isImplicit();
+    }
+
+    private static Map<String, Field> fieldMap(Fetcher<?> fetcher, ImmutableType actualType) {
+        Map<String, Field> fieldMap = new LinkedHashMap<>();
+        collectFields(fetcher, actualType, fieldMap);
+        return fieldMap;
+    }
+
+    private static void collectFields(
+            Fetcher<?> fetcher,
+            ImmutableType actualType,
+            Map<String, Field> fieldMap
+    ) {
+        for (Field field : fetcher.getFieldMap().values()) {
+            Field oldField = fieldMap.get(field.getProp().getName());
+            if (oldField == null || oldField.isImplicit() || !field.isImplicit()) {
+                fieldMap.put(field.getProp().getName(), field);
+            }
+        }
+        if (fetcher instanceof FetcherImplementor<?>) {
+            for (Map.Entry<ImmutableType, Fetcher<?>> e :
+                    ((FetcherImplementor<?>) fetcher).__getTypeBranchFetcherMap().entrySet()) {
+                if (e.getKey().isAssignableFrom(actualType)) {
+                    collectFields(e.getValue(), actualType, fieldMap);
+                }
+            }
+        }
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -29,7 +29,8 @@ public class Shapes {
             Fetcher<?> fetcher,
             Function<?, E> converter
     ) {
-        if (entities.isEmpty()) {
+        if (entities.isEmpty() ||
+                fetcher == null && immutableType.getDirectDerivedTypes().isEmpty()) {
             return;
         }
         Map<ImmutableType, Map<String, Field>> fieldMapCache = new HashMap<>();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -29,17 +29,14 @@ public class Shapes {
             Function<?, E> converter
     ) {
         if (entities.isEmpty() ||
-                fetcher == null && immutableType.getDirectDerivedTypes().isEmpty()) {
+                fetcher == null && !immutableType.hasDerivedTypes()) {
             return;
         }
         Map<ImmutableType, Shape> shapeMap = new HashMap<>();
         boolean needReshape = false;
         for (ImmutableSpi spi : (List<ImmutableSpi>) entities) {
             ImmutableType actualType = spi.__type();
-            Shape shape = shapeMap.computeIfAbsent(
-                    actualType,
-                    it -> createShape(immutableType, fetcher, it)
-            );
+            Shape shape = shapeMap.computeIfAbsent(actualType, it -> createShape(immutableType, fetcher, it));
             if (!needReshape) {
                 needReshape = shape.requiresReshape();
             }
@@ -48,11 +45,7 @@ public class Shapes {
             entities.replaceAll(entity -> {
                 ImmutableSpi spi = (ImmutableSpi) entity;
                 Shape shape = shapeMap.get(spi.__type());
-                return (E) Internal.produce(
-                        spi.__type(),
-                        spi,
-                        draft -> shape.apply((DraftSpi) draft)
-                );
+                return (E) Internal.produce(spi.__type(), spi, draft -> shape.apply((DraftSpi) draft));
             });
         }
         if (fetcher != null) {
@@ -66,9 +59,7 @@ public class Shapes {
             ImmutableType actualType
     ) {
         Map<String, Field> fieldMap = fetcher != null ? fieldMap(fetcher, actualType) : null;
-        Map<String, ImmutableProp> objectCachePropMap = fetcher == null ?
-                immutableType.getObjectCacheProps() :
-                null;
+        Map<String, ImmutableProp> objectCachePropMap = fetcher == null ? immutableType.getObjectCacheProps() : null;
         Map<String, ImmutableProp> actualObjectCachePropMap = actualType.getObjectCacheProps();
         List<PropId> unloadPropIds = new ArrayList<>();
         List<PropId> hidePropIds = new ArrayList<>();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -6,11 +6,9 @@ import org.babyfish.jimmer.meta.PropId;
 import org.babyfish.jimmer.runtime.DraftSpi;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.runtime.Internal;
-import org.babyfish.jimmer.sql.ast.PropExpression;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
 import org.babyfish.jimmer.sql.fetcher.Field;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
-import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
 import java.util.*;
@@ -39,55 +37,23 @@ public class Shapes {
         for (ImmutableSpi spi : (List<ImmutableSpi>) entities) {
             ImmutableType actualType = spi.__type();
             Shape shape = shapeMap.computeIfAbsent(actualType, it -> createShape(immutableType, fetcher, it));
-            if (shape.isRequired(spi)) {
-                needReshape = true;
+            if (!needReshape) {
+                needReshape = shape.isRequired(spi);
             }
         }
         if (needReshape) {
-            ListIterator<ImmutableSpi> itr = (ListIterator<ImmutableSpi>) entities.listIterator();
-            while (itr.hasNext()) {
-                ImmutableSpi spi = itr.next();
+            entities.replaceAll(entity -> {
+                ImmutableSpi spi = (ImmutableSpi) entity;
                 Shape shape = shapeMap.get(spi.__type());
-                itr.set(
-                        (ImmutableSpi) Internal.produce(
-                                spi.__type(),
-                                spi,
-                                draft -> shape.apply(spi, (DraftSpi) draft)
-                        )
+                return (E) Internal.produce(
+                        spi.__type(),
+                        spi,
+                        draft -> shape.apply(spi, (DraftSpi) draft)
                 );
-            }
+            });
         }
         if (fetcher != null) {
-            FetcherUtil.fetch(
-                    sqlClient,
-                    con,
-                    Collections.singletonList(
-                            new FetcherSelection<E>() {
-
-                                @Override
-                                public FetchPath getPath() {
-                                    return null;
-                                }
-
-                                @Override
-                                public Fetcher<?> getFetcher() {
-                                    return fetcher;
-                                }
-
-                                @Override
-                                public PropExpression.Embedded<?> getEmbeddedPropExpression() {
-                                    return null;
-                                }
-
-                                @Override
-                                public @Nullable Function<?, E> getConverter() {
-                                    return converter;
-                                }
-                            }
-                    ),
-                    null,
-                    entities
-            );
+            FetcherUtil.fetch(sqlClient, con, fetcher, converter, entities);
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.sql.fetcher.impl;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.PropId;
 import org.babyfish.jimmer.runtime.DraftSpi;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.runtime.Internal;
@@ -33,51 +34,26 @@ public class Shapes {
                 fetcher == null && immutableType.getDirectDerivedTypes().isEmpty()) {
             return;
         }
-        Map<ImmutableType, Map<String, Field>> fieldMapCache = new HashMap<>();
-        boolean needDrop = false;
+        Map<ImmutableType, Shape> shapeMap = new HashMap<>();
+        boolean needReshape = false;
         for (ImmutableSpi spi : (List<ImmutableSpi>) entities) {
             ImmutableType actualType = spi.__type();
-            Map<String, Field> fieldMap = fetcher != null ?
-                    fieldMapCache.computeIfAbsent(actualType, it -> fieldMap(fetcher, it)) :
-                    null;
-            for (ImmutableProp prop : actualType.getProps().values()) {
-                if (spi.__isLoaded(prop.getId())) {
-                    if (!isIncluded(immutableType, fieldMap, prop) || isImplicit(fieldMap, prop)) {
-                        needDrop = true;
-                        break;
-                    }
-                }
+            Shape shape = shapeMap.computeIfAbsent(actualType, it -> createShape(immutableType, fetcher, it));
+            if (shape.isRequired(spi)) {
+                needReshape = true;
             }
         }
-        if (needDrop) {
+        if (needReshape) {
             ListIterator<ImmutableSpi> itr = (ListIterator<ImmutableSpi>) entities.listIterator();
             while (itr.hasNext()) {
                 ImmutableSpi spi = itr.next();
-                Map<String, Field> fieldMap = fetcher != null ? fieldMapCache.get(spi.__type()) : null;
+                Shape shape = shapeMap.get(spi.__type());
                 itr.set(
-                        (ImmutableSpi) Internal.produce(spi.__type(), spi, draft -> {
-                            for (ImmutableProp prop : spi.__type().getProps().values()) {
-                                if (spi.__isLoaded(prop.getId())) {
-                                    if (!isIncluded(immutableType, fieldMap, prop)) {
-                                        if (!prop.isView()) {
-                                            ((DraftSpi) draft).__unload(prop.getId());
-                                        } else {
-                                            ((DraftSpi) draft).__show(prop.getId(), false);
-                                        }
-                                    } else if (isImplicit(fieldMap, prop)) {
-                                        ((DraftSpi) draft).__show(prop.getId(), false);
-                                    }
-                                }
-                            }
-                            if (fieldMap != null) {
-                                for (Field field : fieldMap.values()) {
-                                    ImmutableProp prop = field.getProp();
-                                    if (prop.isView() || prop.isFormula()) {
-                                        ((DraftSpi) draft).__show(prop.getId(), true);
-                                    }
-                                }
-                            }
-                        })
+                        (ImmutableSpi) Internal.produce(
+                                spi.__type(),
+                                spi,
+                                draft -> shape.apply(spi, (DraftSpi) draft)
+                        )
                 );
             }
         }
@@ -115,26 +91,46 @@ public class Shapes {
         }
     }
 
-    private static boolean isIncluded(
+    private static Shape createShape(
             ImmutableType immutableType,
-            Map<String, Field> fieldMap,
-            ImmutableProp prop
+            Fetcher<?> fetcher,
+            ImmutableType actualType
     ) {
-        return fieldMap != null ?
-                fieldMap.containsKey(prop.getName()) :
-                immutableType.getObjectCacheProps().containsKey(prop.getName());
-    }
-
-    private static boolean isImplicit(Map<String, Field> fieldMap, ImmutableProp prop) {
-        if (fieldMap == null) {
-            return false;
+        Map<String, Field> fieldMap = fetcher != null ? fieldMap(fetcher, actualType) : null;
+        Map<String, ImmutableProp> objectCachePropMap = fetcher == null ?
+                immutableType.getObjectCacheProps() :
+                null;
+        List<PropId> unloadPropIds = new ArrayList<>();
+        List<PropId> hidePropIds = new ArrayList<>();
+        List<PropId> showPropIds = new ArrayList<>();
+        for (ImmutableProp prop : actualType.getProps().values()) {
+            Field field = fieldMap != null ? fieldMap.get(prop.getName()) : null;
+            boolean included = fieldMap != null ?
+                    field != null :
+                    objectCachePropMap.containsKey(prop.getName());
+            if (!included) {
+                if (prop.isView()) {
+                    hidePropIds.add(prop.getId());
+                } else {
+                    unloadPropIds.add(prop.getId());
+                }
+            } else if (field != null && field.isImplicit()) {
+                hidePropIds.add(prop.getId());
+            }
         }
-        Field field = fieldMap.get(prop.getName());
-        return field != null && field.isImplicit();
+        if (fieldMap != null) {
+            for (Field field : fieldMap.values()) {
+                ImmutableProp prop = field.getProp();
+                if (prop.isView() || prop.isFormula()) {
+                    showPropIds.add(prop.getId());
+                }
+            }
+        }
+        return new Shape(unloadPropIds, hidePropIds, showPropIds);
     }
 
     private static Map<String, Field> fieldMap(Fetcher<?> fetcher, ImmutableType actualType) {
-        Map<String, Field> fieldMap = new LinkedHashMap<>();
+        Map<String, Field> fieldMap = new HashMap<>();
         collectFields(fetcher, actualType, fieldMap);
         return fieldMap;
     }
@@ -156,6 +152,55 @@ public class Shapes {
                 if (e.getKey().isAssignableFrom(actualType)) {
                     collectFields(e.getValue(), actualType, fieldMap);
                 }
+            }
+        }
+    }
+
+    private static class Shape {
+
+        private final List<PropId> unloadPropIds;
+
+        private final List<PropId> hidePropIds;
+
+        private final List<PropId> showPropIds;
+
+        private Shape(
+                List<PropId> unloadPropIds,
+                List<PropId> hidePropIds,
+                List<PropId> showPropIds
+        ) {
+            this.unloadPropIds = unloadPropIds;
+            this.hidePropIds = hidePropIds;
+            this.showPropIds = showPropIds;
+        }
+
+        private boolean isRequired(ImmutableSpi spi) {
+            for (PropId propId : unloadPropIds) {
+                if (spi.__isLoaded(propId)) {
+                    return true;
+                }
+            }
+            for (PropId propId : hidePropIds) {
+                if (spi.__isLoaded(propId)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void apply(ImmutableSpi spi, DraftSpi draft) {
+            for (PropId propId : unloadPropIds) {
+                if (spi.__isLoaded(propId)) {
+                    draft.__unload(propId);
+                }
+            }
+            for (PropId propId : hidePropIds) {
+                if (spi.__isLoaded(propId)) {
+                    draft.__show(propId, false);
+                }
+            }
+            for (PropId propId : showPropIds) {
+                draft.__show(propId, true);
             }
         }
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -36,9 +36,12 @@ public class Shapes {
         boolean needReshape = false;
         for (ImmutableSpi spi : (List<ImmutableSpi>) entities) {
             ImmutableType actualType = spi.__type();
-            Shape shape = shapeMap.computeIfAbsent(actualType, it -> createShape(immutableType, fetcher, it));
+            Shape shape = shapeMap.computeIfAbsent(
+                    actualType,
+                    it -> createShape(immutableType, fetcher, it)
+            );
             if (!needReshape) {
-                needReshape = shape.isRequired(spi);
+                needReshape = shape.requiresReshape();
             }
         }
         if (needReshape) {
@@ -48,7 +51,7 @@ public class Shapes {
                 return (E) Internal.produce(
                         spi.__type(),
                         spi,
-                        draft -> shape.apply(spi, (DraftSpi) draft)
+                        draft -> shape.apply((DraftSpi) draft)
                 );
             });
         }
@@ -66,14 +69,18 @@ public class Shapes {
         Map<String, ImmutableProp> objectCachePropMap = fetcher == null ?
                 immutableType.getObjectCacheProps() :
                 null;
+        Map<String, ImmutableProp> actualObjectCachePropMap = actualType.getObjectCacheProps();
         List<PropId> unloadPropIds = new ArrayList<>();
         List<PropId> hidePropIds = new ArrayList<>();
         List<PropId> showPropIds = new ArrayList<>();
         for (ImmutableProp prop : actualType.getProps().values()) {
+            if (!isAvailableInObjectCache(prop, actualObjectCachePropMap)) {
+                continue;
+            }
             Field field = fieldMap != null ? fieldMap.get(prop.getName()) : null;
             boolean included = fieldMap != null ?
                     field != null :
-                    objectCachePropMap.containsKey(prop.getName());
+                    !prop.isDiscriminator() && objectCachePropMap.containsKey(prop.getName());
             if (!included) {
                 if (prop.isView()) {
                     hidePropIds.add(prop.getId());
@@ -93,6 +100,17 @@ public class Shapes {
             }
         }
         return new Shape(unloadPropIds, hidePropIds, showPropIds);
+    }
+
+    private static boolean isAvailableInObjectCache(
+            ImmutableProp prop,
+            Map<String, ImmutableProp> objectCachePropMap
+    ) {
+        if (objectCachePropMap.containsKey(prop.getName())) {
+            return true;
+        }
+        ImmutableProp idViewBaseProp = prop.getIdViewBaseProp();
+        return idViewBaseProp != null && objectCachePropMap.containsKey(idViewBaseProp.getName());
     }
 
     private static Map<String, Field> fieldMap(Fetcher<?> fetcher, ImmutableType actualType) {
@@ -140,30 +158,18 @@ public class Shapes {
             this.showPropIds = showPropIds;
         }
 
-        private boolean isRequired(ImmutableSpi spi) {
-            for (PropId propId : unloadPropIds) {
-                if (spi.__isLoaded(propId)) {
-                    return true;
-                }
-            }
-            for (PropId propId : hidePropIds) {
-                if (spi.__isLoaded(propId)) {
-                    return true;
-                }
-            }
-            return false;
+        private boolean requiresReshape() {
+            return !unloadPropIds.isEmpty() || !hidePropIds.isEmpty();
         }
 
-        private void apply(ImmutableSpi spi, DraftSpi draft) {
+        private void apply(DraftSpi draft) {
+            // These operations are idempotent for unloaded properties, so the same
+            // target shape can be applied to cache hits and freshly loaded values.
             for (PropId propId : unloadPropIds) {
-                if (spi.__isLoaded(propId)) {
-                    draft.__unload(propId);
-                }
+                draft.__unload(propId);
             }
             for (PropId propId : hidePropIds) {
-                if (spi.__isLoaded(propId)) {
-                    draft.__show(propId, false);
-                }
+                draft.__show(propId, false);
             }
             for (PropId propId : showPropIds) {
                 draft.__show(propId, true);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/fetcher/impl/Shapes.java
@@ -55,7 +55,7 @@ public class Shapes {
             while (itr.hasNext()) {
                 ImmutableSpi spi = itr.next();
                 itr.set(
-                        (ImmutableSpi) Internal.produce(immutableType, spi, draft -> {
+                        (ImmutableSpi) Internal.produce(spi.__type(), spi, draft -> {
                             for (ImmutableProp prop : immutableType.getProps().values()) {
                                 if (spi.__isLoaded(prop.getId())) {
                                     Field field = fetcher.getFieldMap().get(prop.getName());

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -3,10 +3,13 @@ package org.babyfish.jimmer.sql.cache;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.runtime.DraftSpi;
+import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.model.inheritance.joinedtable.Client;
+import org.babyfish.jimmer.sql.model.inheritance.joinedtable.ClientFetcher;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.OrganizationFetcher;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2;
@@ -22,6 +25,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.babyfish.jimmer.sql.common.Constants.*;
 
 public class ObjectCacheTest extends AbstractQueryTest {
@@ -280,6 +284,28 @@ public class ObjectCacheTest extends AbstractQueryTest {
         } catch (SQLException ex) {
             Assertions.fail("SQL error", ex);
         }
+    }
+
+    @Test
+    public void testPolymorphicRootFetcher() {
+        connectAndExpect(con -> {
+            List<Client> clients = sqlClient
+                    .getEntities()
+                    .forConnection(con)
+                    .findByIds(ClientFetcher.$.name(), singletonList(200L));
+            Assertions.assertEquals(1, clients.size());
+            Client client = clients.get(0);
+            Assertions.assertEquals(Organization.class, ((ImmutableSpi) client).__type().getJavaClass());
+            Assertions.assertEquals("Globex", client.name());
+            Assertions.assertFalse(client instanceof DraftSpi);
+            return clients;
+        }, ctx -> {
+            ctx.sql(
+                    "select tb_1_.ID, tb_1_.CLIENT_TYPE, tb_1_.NAME, tb_1_.DESCRIPTION " +
+                            "from JOINED_CLIENT tb_1_ where tb_1_.ID = ?"
+            );
+            ctx.rows("[{\"id\":200,\"name\":\"Globex\"}]");
+        });
     }
 
     @Test

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -377,6 +377,57 @@ public class ObjectCacheTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testMixedPolymorphicObjectCacheHitAndMiss() {
+        connectAndExpect(con -> {
+            Client cachedClient = sqlClient
+                    .getEntities()
+                    .forConnection(con)
+                    .findById(Client.class, 200L);
+            Assertions.assertInstanceOf(Organization.class, cachedClient);
+            assertLoadState(cachedClient, "id", "name", "description");
+            List<Client> clients = sqlClient
+                    .getEntities()
+                    .forConnection(con)
+                    .findByIds(Client.class, Arrays.asList(200L, 202L));
+            Assertions.assertEquals(2, clients.size());
+            for (Client client : clients) {
+                Assertions.assertInstanceOf(Organization.class, client);
+            }
+            assertLoadState(clients, "id", "name", "description");
+            return clients;
+        }, ctx -> {
+            ctx.sql(
+                    "select tb_1_.ID, tb_1_.CLIENT_TYPE, tb_1_.NAME, tb_1_.DESCRIPTION, " +
+                            "tb_2_.TAX_CODE, tb_2_.STATUS, tb_3_.FIRST_NAME, tb_3_.LAST_NAME " +
+                            "from JOINED_CLIENT tb_1_ " +
+                            "left join JOINED_ORGANIZATION tb_2_ " +
+                            "on tb_1_.ID = tb_2_.ID and tb_1_.CLIENT_TYPE = ? " +
+                            "left join JOINED_PERSON tb_3_ " +
+                            "on tb_1_.ID = tb_3_.ID and tb_1_.CLIENT_TYPE = ? " +
+                            "where tb_1_.ID = ?"
+            );
+            ctx.variables("ORG", "Person", 200L);
+            ctx.statement(1).sql(
+                    "select tb_1_.ID, tb_1_.CLIENT_TYPE, tb_1_.NAME, tb_1_.DESCRIPTION, " +
+                            "tb_2_.TAX_CODE, tb_2_.STATUS, tb_3_.FIRST_NAME, tb_3_.LAST_NAME " +
+                            "from JOINED_CLIENT tb_1_ " +
+                            "left join JOINED_ORGANIZATION tb_2_ " +
+                            "on tb_1_.ID = tb_2_.ID and tb_1_.CLIENT_TYPE = ? " +
+                            "left join JOINED_PERSON tb_3_ " +
+                            "on tb_1_.ID = tb_3_.ID and tb_1_.CLIENT_TYPE = ? " +
+                            "where tb_1_.ID = ?"
+            );
+            ctx.statement(1).variables("ORG", "Person", 202L);
+            ctx.rows(
+                    "[" +
+                            "--->{\"id\":200,\"name\":\"Globex\",\"description\":\"DEFAULT_CLIENT_DESCRIPTION\"}," +
+                            "--->{\"id\":202,\"name\":\"Initech\",\"description\":\"DEFAULT_CLIENT_DESCRIPTION\"}" +
+                            "]"
+            );
+        });
+    }
+
+    @Test
     public void testIssue1154WithId() {
         for (int i = 0; i < 2; i++) {
             final boolean useSql = i == 0;

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.model.dto.ReusableBookStoreView;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.*;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2;
@@ -90,6 +91,34 @@ public class ObjectCacheTest extends AbstractQueryTest {
                                         "--->}" +
                                         "]"
                         );
+                    }
+            );
+        }
+    }
+
+    @Test
+    public void testDto() {
+        for (int i = 0; i < 2; i++) {
+            boolean useSql = i == 0;
+            connectAndExpect(
+                    con -> {
+                        ReusableBookStoreView view = sqlClient
+                                .getEntities()
+                                .forConnection(con)
+                                .findById(ReusableBookStoreView.class, oreillyId);
+                        Assertions.assertNotNull(view);
+                        Assertions.assertEquals(oreillyId, view.getId());
+                        Assertions.assertEquals("O'REILLY", view.getName());
+                        return view;
+                    }, ctx -> {
+                        if (useSql) {
+                            ctx.sql(
+                                    "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                                            "from BOOK_STORE tb_1_ " +
+                                            "where tb_1_.ID = ?"
+                            );
+                            ctx.variables(oreillyId);
+                        }
                     }
             );
         }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/cache/ObjectCacheTest.java
@@ -8,10 +8,8 @@ import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.common.CacheImpl;
 import org.babyfish.jimmer.sql.model.*;
-import org.babyfish.jimmer.sql.model.inheritance.joinedtable.Client;
-import org.babyfish.jimmer.sql.model.inheritance.joinedtable.ClientFetcher;
+import org.babyfish.jimmer.sql.model.inheritance.joinedtable.*;
 import org.babyfish.jimmer.sql.model.inheritance.joinedtable.Organization;
-import org.babyfish.jimmer.sql.model.inheritance.joinedtable.OrganizationFetcher;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2;
 import org.babyfish.jimmer.sql.model.issue1252.TreeNode2Fetcher;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +23,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.babyfish.jimmer.sql.common.Constants.*;
 
 public class ObjectCacheTest extends AbstractQueryTest {
@@ -288,24 +285,66 @@ public class ObjectCacheTest extends AbstractQueryTest {
 
     @Test
     public void testPolymorphicRootFetcher() {
+        for (int i = 0; i < 2; i++) {
+            final boolean useSql = i == 0;
+            connectAndExpect(con -> {
+                List<Client> clients = sqlClient
+                        .getEntities()
+                        .forConnection(con)
+                        .findByIds(
+                                ClientFetcher.$
+                                        .name()
+                                        .forType(OrganizationFetcher.$.taxCode())
+                                        .forType(PersonFetcher.$.firstName()),
+                                Arrays.asList(200L, 201L)
+                        );
+                Assertions.assertEquals(2, clients.size());
+                Organization organization = (Organization) clients.get(0);
+                Assertions.assertEquals("Globex", organization.name());
+                Assertions.assertEquals("GLOBEX-001", organization.taxCode());
+                Assertions.assertFalse(organization instanceof DraftSpi);
+                Person person = (Person) clients.get(1);
+                Assertions.assertEquals("Alice", person.name());
+                Assertions.assertEquals("Alice", person.firstName());
+                Assertions.assertFalse(person instanceof DraftSpi);
+                return clients;
+            }, ctx -> {
+                if (useSql) {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1_.CLIENT_TYPE, tb_1_.NAME, tb_1_.DESCRIPTION, " +
+                                    "tb_2_.TAX_CODE, tb_2_.STATUS, tb_3_.FIRST_NAME, tb_3_.LAST_NAME " +
+                                    "from JOINED_CLIENT tb_1_ " +
+                                    "left join JOINED_ORGANIZATION tb_2_ " +
+                                    "on tb_1_.ID = tb_2_.ID and tb_1_.CLIENT_TYPE = ? " +
+                                    "left join JOINED_PERSON tb_3_ " +
+                                    "on tb_1_.ID = tb_3_.ID and tb_1_.CLIENT_TYPE = ? " +
+                                    "where tb_1_.ID in (?, ?)"
+                    );
+                }
+                ctx.rows(
+                        "[" +
+                                "--->{\"id\":200,\"name\":\"Globex\",\"taxCode\":\"GLOBEX-001\"}," +
+                                "--->{\"id\":201,\"name\":\"Alice\",\"firstName\":\"Alice\"}" +
+                                "]"
+                );
+            });
+        }
         connectAndExpect(con -> {
             List<Client> clients = sqlClient
                     .getEntities()
                     .forConnection(con)
-                    .findByIds(ClientFetcher.$.name(), singletonList(200L));
-            Assertions.assertEquals(1, clients.size());
-            Client client = clients.get(0);
-            Assertions.assertEquals(Organization.class, ((ImmutableSpi) client).__type().getJavaClass());
-            Assertions.assertEquals("Globex", client.name());
-            Assertions.assertFalse(client instanceof DraftSpi);
+                    .findByIds(Client.class, Arrays.asList(200L, 201L));
+            Assertions.assertEquals(Organization.class, ((ImmutableSpi) clients.get(0)).__type().getJavaClass());
+            Assertions.assertEquals(Person.class, ((ImmutableSpi) clients.get(1)).__type().getJavaClass());
+            assertLoadState(clients.get(0), "id", "name", "description");
+            assertLoadState(clients.get(1), "id", "name", "description");
             return clients;
-        }, ctx -> {
-            ctx.sql(
-                    "select tb_1_.ID, tb_1_.CLIENT_TYPE, tb_1_.NAME, tb_1_.DESCRIPTION " +
-                            "from JOINED_CLIENT tb_1_ where tb_1_.ID = ?"
-            );
-            ctx.rows("[{\"id\":200,\"name\":\"Globex\"}]");
-        });
+        }, ctx -> ctx.rows(
+                "[" +
+                        "--->{\"id\":200,\"name\":\"Globex\",\"description\":\"DEFAULT_CLIENT_DESCRIPTION\"}," +
+                        "--->{\"id\":201,\"name\":\"Alice\",\"description\":\"DEFAULT_CLIENT_DESCRIPTION\"}" +
+                        "]"
+        ));
     }
 
     @Test


### PR DESCRIPTION
Fix https://github.com/babyfish-ct/jimmer/issues/1454

This PR fixes polymorphic object-cache reads:

- cached JSON is deserialized into the concrete entity type selected by the
  discriminator, avoiding `ClassCastException` and preserving subtype data;
- object-cache fetchers include scalar properties declared by derived types;
- cached entities are reshaped using their actual immutable type and the
  applicable polymorphic fetcher branches;
- a batch can safely combine cache hits and database-loaded misses of the same
  subtype, even though their initial loaded-property shapes differ;
- the discriminator remains an internal cache tag and is not exposed as a
  loaded property unless requested.

Previously, `Shapes.reshape` inspected all properties of every entity in the
batch. It now prepares one target shape per concrete entity type and reuses it
for all entities of that type. For `N` entities, `K` concrete types and `P`
properties, shape analysis is reduced from `O(N * P)` to `O(N + K * P)`;
applying a shape only visits the properties that must actually be changed.

Polymorphic deserialization also precomputes discriminator metadata and the
discriminator-to-class map once per serializer, and the object-cache post-fetch
path no longer creates the temporary wrappers and maps required by the general
multi-selection path.

Focused tests cover root and branch fetchers, derived scalar fields, DTO
conversion, cache-only reads, and mixed cache-hit/database-miss batches.