### PR TITLE
feat(ddl): store schema snapshots per table

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
-addzero = "2026.07.15.2"
+addzero-ddlgenerator = "2026.07.30"
+addzero-ddlgenerator-archived = "2026.07.15.2"
+addzero-lsi = "2026.07.30"
 antlr = "4.13.0"
 buildconfig = "5.3.5"
 caffeine = "2.9.1"
@@ -36,21 +38,21 @@ scalar = "0.5.47"
 
 [libraries]
 
-addzero-lsi-core = { group = "site.addzero", name = "lsi-core", version.ref = "addzero" }
-addzero-lsi-ksp = { group = "site.addzero", name = "lsi-ksp", version.ref = "addzero" }
-addzero-lsi-apt = { group = "site.addzero", name = "lsi-apt", version.ref = "addzero" }
-addzero-ddlgenerator-core = { group = "site.addzero", name = "ddlgenerator-core", version.ref = "addzero" }
-addzero-ddlgenerator-lsi-adaptor = { group = "site.addzero", name = "ddlgenerator-lsi-adaptor", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-mysql = { group = "site.addzero", name = "ddlgenerator-dialect-mysql", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-postgresql = { group = "site.addzero", name = "ddlgenerator-dialect-postgresql", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-h2 = { group = "site.addzero", name = "ddlgenerator-dialect-h2", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-sqlite = { group = "site.addzero", name = "ddlgenerator-dialect-sqlite", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-sqlserver = { group = "site.addzero", name = "ddlgenerator-dialect-sqlserver", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-oracle = { group = "site.addzero", name = "ddlgenerator-dialect-oracle", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-dm = { group = "site.addzero", name = "ddlgenerator-dialect-dm", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-kingbase = { group = "site.addzero", name = "ddlgenerator-dialect-kingbase", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-taos = { group = "site.addzero", name = "ddlgenerator-dialect-taos", version.ref = "addzero" }
-addzero-tool-database-model = { group = "site.addzero", name = "tool-database-model", version.ref = "addzero" }
+addzero-lsi-core = { group = "site.addzero", name = "lsi-core", version.ref = "addzero-lsi" }
+addzero-lsi-ksp = { group = "site.addzero", name = "lsi-ksp", version.ref = "addzero-lsi" }
+addzero-lsi-apt = { group = "site.addzero", name = "lsi-apt", version.ref = "addzero-lsi" }
+addzero-ddlgenerator-core = { group = "site.addzero", name = "ddlgenerator-core", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-lsi-adaptor = { group = "site.addzero", name = "ddlgenerator-lsi-adaptor", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-mysql = { group = "site.addzero", name = "ddlgenerator-dialect-mysql", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-postgresql = { group = "site.addzero", name = "ddlgenerator-dialect-postgresql", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-h2 = { group = "site.addzero", name = "ddlgenerator-dialect-h2", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-sqlite = { group = "site.addzero", name = "ddlgenerator-dialect-sqlite", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-sqlserver = { group = "site.addzero", name = "ddlgenerator-dialect-sqlserver", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-oracle = { group = "site.addzero", name = "ddlgenerator-dialect-oracle", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-dm = { group = "site.addzero", name = "ddlgenerator-dialect-dm", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-kingbase = { group = "site.addzero", name = "ddlgenerator-dialect-kingbase", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-taos = { group = "site.addzero", name = "ddlgenerator-dialect-taos", version.ref = "addzero-ddlgenerator-archived" }
+addzero-tool-database-model = { group = "site.addzero", name = "tool-database-model", version.ref = "addzero-ddlgenerator" }
 antlr = { group = "org.antlr", name = "antlr4", version.ref = "antlr" }
 
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }

--- a/project/jimmer-ddl-compiler/README.md
+++ b/project/jimmer-ddl-compiler/README.md
@@ -58,14 +58,18 @@ tasks.withType<JavaCompile>().configureEach {
 | `jimmerDdl.includeManyToManyTables` | `true` | Generates Jimmer many-to-many junction tables. |
 | `jimmerDdl.compareDatabase` | `true` | Reads the configured database and emits diff SQL. If the database cannot be read, it falls back to offline DDL. |
 | `jimmerDdl.nullabilityRepairOnly` | `false` | Limits risky offline alteration planning to nullability repair. |
-| `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored in the snapshot. |
+| `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored as build-local state outside the structural snapshot. |
 | `jimmerDdl.jdbcUrl` / `jdbcUsername` / `jdbcPassword` / `jdbcSchema` / `jdbcDriver` | empty | Explicit JDBC settings used by database comparison. |
 | `jimmerDdl.springResourcePath` | empty | Optional Spring resource path used to discover datasource settings. |
 | `jimmerDdl.springProfile` | `local` | Spring profile used when reading YAML datasource settings. |
 
 ## Snapshot model
 
-The compiler writes a generated snapshot to `build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties`. The snapshot records entity-to-table mappings and table hashes so subsequent builds can emit incremental SQL, including table renames caused by `@Table(name = ...)` changes.
+The durable schema baseline is a directory of per-table lockfiles under `.jimmer-ddl/entity-table-snapshot/`. Each lockfile records one table schema hash, its encoded structural model, and the Jimmer entities mapped to that table. Keeping tables in independent files prevents unrelated entity changes on separate branches from rewriting the same Git-tracked snapshot.
+
+The compiler stages the next baseline under `build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot/`. After accepting the generated migration, the consumer build must mirror that whole directory to the durable `.jimmer-ddl/entity-table-snapshot/` directory, including deletion of lockfiles for removed tables. The former aggregate `entity-table-snapshot.properties` file is not read.
+
+When `jimmerDdl.sourceFingerprint` is supplied, it is written to `build/jimmer-ddl/source-fingerprint.properties`. It is disposable build state and must not be committed or copied into the structural snapshot.
 
 ## Tests
 

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
@@ -4,21 +4,27 @@ import java.io.File
 
 object JimmerDdlCompilerFiles {
     private const val SNAPSHOT_DIR_NAME = ".jimmer-ddl"
-    private const val SNAPSHOT_FILE_NAME = "entity-table-snapshot.properties"
+    private const val SNAPSHOT_DIRECTORY_NAME = "entity-table-snapshot"
+    private const val SOURCE_FINGERPRINT_FILE_NAME = "source-fingerprint.properties"
 
     fun resolveOutputFile(settings: JimmerDdlCompilerSettings): File {
         val outputDir = File(settings.outputDir)
         return File(outputDir, settings.outputFileName)
     }
 
-    fun resolveSnapshotFile(settings: JimmerDdlCompilerSettings): File? {
+    fun resolveSnapshotDirectory(settings: JimmerDdlCompilerSettings): File? {
         val projectDir = settings.outputDir.toProjectDir() ?: return null
-        return projectDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+        return projectDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_DIRECTORY_NAME)
     }
 
-    fun resolveGeneratedSnapshotFile(settings: JimmerDdlCompilerSettings): File {
+    fun resolveGeneratedSnapshotDirectory(settings: JimmerDdlCompilerSettings): File {
         val resourcesDir = settings.outputDir.toGeneratedResourcesDir()
-        return resourcesDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+        return resourcesDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_DIRECTORY_NAME)
+    }
+
+    fun resolveBuildSourceFingerprintFile(settings: JimmerDdlCompilerSettings): File? {
+        val projectDir = settings.outputDir.toProjectDir() ?: return null
+        return projectDir.resolve("build/jimmer-ddl").resolve(SOURCE_FINGERPRINT_FILE_NAME)
     }
 
     fun writeOutputFile(

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
@@ -15,11 +15,13 @@ import java.util.Base64
 import java.util.Properties
 
 private const val SOURCE_FINGERPRINT_KEY = "__sourceFingerprint"
-private const val TABLE_HASH_PREFIX = "__tableHash."
-private const val TABLE_SCHEMA_PREFIX = "__tableSchema."
+private const val TABLE_NAME_KEY = "tableName"
+private const val TABLE_HASH_KEY = "tableHash"
+private const val TABLE_SCHEMA_KEY = "tableSchema"
+private const val ENTITY_TABLE_PREFIX = "entity."
+private val SAFE_SNAPSHOT_FILE_NAME = Regex("[a-z0-9][a-z0-9._-]*")
 
 data class JimmerDdlSnapshot(
-    val sourceFingerprint: String? = null,
     val entityTables: Map<String, String> = emptyMap(),
     val tableHashes: Map<String, String> = emptyMap(),
     val tableSchemas: Map<String, AutoDdlTable> = emptyMap(),
@@ -85,8 +87,8 @@ object JimmerDdlEntityTableSnapshot {
     }
 
     fun readSnapshot(settings: JimmerDdlCompilerSettings): JimmerDdlSnapshot {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return JimmerDdlSnapshot()
-        return snapshotFile.readSnapshot()
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings) ?: return JimmerDdlSnapshot()
+        return snapshotDirectory.readSnapshot()
     }
 
     private fun planRenameTables(
@@ -122,12 +124,11 @@ object JimmerDdlEntityTableSnapshot {
         schema: AutoDdlSchema,
         settings: JimmerDdlCompilerSettings,
     ) {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings) ?: return
         writeSnapshot(
-            snapshotFile = snapshotFile,
+            snapshotDirectory = snapshotDirectory,
             entities = entities,
             schema = schema,
-            settings = settings,
         )
     }
 
@@ -136,42 +137,72 @@ object JimmerDdlEntityTableSnapshot {
         schema: AutoDdlSchema,
         settings: JimmerDdlCompilerSettings,
     ) {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveGeneratedSnapshotDirectory(settings)
         writeSnapshot(
-            snapshotFile = snapshotFile,
+            snapshotDirectory = snapshotDirectory,
             entities = entities,
             schema = schema,
-            settings = settings,
         )
+        writeGeneratedSourceFingerprint(settings)
     }
 
     private fun writeSnapshot(
-        snapshotFile: File,
+        snapshotDirectory: File,
         entities: List<LsiClass>,
         schema: AutoDdlSchema,
-        settings: JimmerDdlCompilerSettings,
     ) {
-        val previous = snapshotFile.readSnapshot()
-        val current = entities.toSnapshot()
-        val tableHashes = schema.toTableHashes()
-        snapshotFile.parentFile.mkdirs()
-        val sourceFingerprint = settings.sourceFingerprint ?: previous.sourceFingerprint
-        val content = buildString {
-            appendLine("# Jimmer DDL entity-to-table snapshot. Do not edit manually.")
-            sourceFingerprint?.takeIf { it.isNotBlank() }?.let {
-                appendLine("$SOURCE_FINGERPRINT_KEY=${sourceFingerprint.escapeProperty()}")
-            }
-            current.toSortedMap().forEach { (qualifiedName, tableName) ->
-                appendLine("${qualifiedName.escapeProperty()}=${tableName.escapeProperty()}")
-            }
-            tableHashes.toSortedMap().forEach { (tableName, hash) ->
-                appendLine("$TABLE_HASH_PREFIX${tableName.escapeProperty()}=${hash.escapeProperty()}")
-            }
-            schema.tables.sortedBy { table -> table.name.lowercase() }.forEach { table ->
-                appendLine("$TABLE_SCHEMA_PREFIX${table.name.lowercase().escapeProperty()}=${table.toCanonicalText().encodeBase64().escapeProperty()}")
-            }
+        val entityNamesByTable = entities.toSnapshot()
+            .entries
+            .groupBy(
+                keySelector = { entry -> entry.value.lowercase() },
+                valueTransform = { entry -> entry.key },
+            )
+        snapshotDirectory.mkdirs()
+        val snapshotFiles = schema.tables.associateWith { table ->
+            snapshotDirectory.resolve(table.name.toSnapshotFileName())
         }
-        snapshotFile.writeText(content)
+        val expectedFileNames = snapshotFiles.values.mapTo(mutableSetOf()) { file -> file.name }
+        snapshotDirectory.listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .filterNot { file -> file.name in expectedFileNames }
+            .forEach { file ->
+                check(file.delete()) { "Cannot delete stale Jimmer DDL snapshot lockfile: ${file.absolutePath}" }
+            }
+        snapshotFiles.entries
+            .sortedBy { (table) -> table.name.lowercase() }
+            .forEach { (table, snapshotFile) ->
+                val tableName = table.name.lowercase()
+                val canonicalSchema = table.toCanonicalText()
+                val content = buildString {
+                    appendLine("# Jimmer DDL structural snapshot. Do not edit manually.")
+                    appendLine("$TABLE_NAME_KEY=${table.name.escapeProperty()}")
+                    appendLine("$TABLE_HASH_KEY=${canonicalSchema.sha256()}")
+                    appendLine("$TABLE_SCHEMA_KEY=${canonicalSchema.encodeBase64().escapeProperty()}")
+                    entityNamesByTable[tableName]
+                        .orEmpty()
+                        .sorted()
+                        .forEach { qualifiedName ->
+                            appendLine("$ENTITY_TABLE_PREFIX${qualifiedName.escapeProperty()}=${table.name.escapeProperty()}")
+                        }
+                }
+                snapshotFile.writeTextIfChanged(content)
+            }
+    }
+
+    private fun writeGeneratedSourceFingerprint(settings: JimmerDdlCompilerSettings) {
+        val fingerprintFile = JimmerDdlCompilerFiles.resolveBuildSourceFingerprintFile(settings) ?: return
+        val sourceFingerprint = settings.sourceFingerprint?.takeIf { it.isNotBlank() }
+        if (sourceFingerprint == null) {
+            if (fingerprintFile.exists()) {
+                check(fingerprintFile.delete()) { "Cannot delete stale Jimmer DDL source fingerprint: ${fingerprintFile.absolutePath}" }
+            }
+            return
+        }
+        val content = buildString {
+            appendLine("# Build-local Jimmer DDL source fingerprint. Do not commit this file.")
+            appendLine("$SOURCE_FINGERPRINT_KEY=${sourceFingerprint.escapeProperty()}")
+        }
+        fingerprintFile.writeTextIfChanged(content)
     }
 
     private fun List<LsiClass>.toSnapshot(): Map<String, String> {
@@ -183,41 +214,62 @@ object JimmerDdlEntityTableSnapshot {
     }
 
     private fun File.readSnapshot(): JimmerDdlSnapshot {
-        if (!isFile) {
+        if (!isDirectory) {
             return JimmerDdlSnapshot()
-        }
-        val props = inputStream().use { input ->
-            Properties().apply { load(input) }
         }
         val entityTables = linkedMapOf<String, String>()
         val tableHashes = linkedMapOf<String, String>()
         val tableSchemas = linkedMapOf<String, AutoDdlTable>()
-        props.entries.forEach { (key, value) ->
-            val name = key.toString()
-            val text = value.toString()
-            when {
-                name == SOURCE_FINGERPRINT_KEY -> Unit
-                name.startsWith(TABLE_HASH_PREFIX) -> {
-                    val tableName = name.removePrefix(TABLE_HASH_PREFIX).lowercase()
-                    tableHashes[tableName] = text
+        listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .sortedBy { file -> file.name }
+            .forEach { snapshotFile ->
+                val props = snapshotFile.reader(Charsets.UTF_8).use { input ->
+                    Properties().apply { load(input) }
                 }
-                name.startsWith(TABLE_SCHEMA_PREFIX) -> {
-                    val tableName = name.removePrefix(TABLE_SCHEMA_PREFIX).lowercase()
-                    text.decodeTableSchema(tableName)?.let { table ->
-                        tableSchemas[tableName] = table
+                val tableName = props.getProperty(TABLE_NAME_KEY)
+                    ?.takeIf { it.isNotBlank() }
+                    ?.lowercase()
+                    ?: return@forEach
+                props.getProperty(TABLE_HASH_KEY)
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { hash -> tableHashes[tableName] = hash }
+                props.getProperty(TABLE_SCHEMA_KEY)
+                    ?.decodeTableSchema(tableName)
+                    ?.let { table -> tableSchemas[tableName] = table }
+                props.entries.forEach { (key, value) ->
+                    val name = key.toString()
+                    if (name.startsWith(ENTITY_TABLE_PREFIX)) {
+                        val qualifiedName = name.removePrefix(ENTITY_TABLE_PREFIX)
+                        value.toString().takeIf { it.isNotBlank() }?.let { mappedTableName ->
+                            entityTables[qualifiedName] = mappedTableName
+                        }
                     }
                 }
-                !name.startsWith("__") -> {
-                    entityTables[name] = text
-                }
             }
-        }
         return JimmerDdlSnapshot(
-            sourceFingerprint = props.getProperty(SOURCE_FINGERPRINT_KEY),
             entityTables = entityTables,
             tableHashes = tableHashes,
             tableSchemas = tableSchemas,
         )
+    }
+
+    private fun String.toSnapshotFileName(): String {
+        val normalized = lowercase()
+        val baseName = if (normalized.length <= 180 && SAFE_SNAPSHOT_FILE_NAME.matches(normalized)) {
+            normalized
+        } else {
+            normalized.sha256()
+        }
+        return "$baseName.properties"
+    }
+
+    private fun File.writeTextIfChanged(content: String) {
+        if (isFile && readText() == content) {
+            return
+        }
+        parentFile.mkdirs()
+        writeText(content)
     }
 
     private fun AutoDdlSchema.toTableHashes(): Map<String, String> {

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
@@ -163,14 +163,16 @@ class JimmerDdlCompilerTest {
         val sql = sqlFile.readText()
         assertContains(sql, """CREATE TABLE IF NOT EXISTS "apt_book"""")
         assertContains(sql, """"id" BIGINT NOT NULL""")
-        assertContains(sql, """"title" VARCHAR(255)""")
-        assertContains(sql, """"subtitle" VARCHAR(255)""")
+        assertContains(sql, """"title" TEXT""")
+        assertContains(sql, """"subtitle" TEXT""")
         assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "title" DROP NOT NULL;""")
         assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
 
-        val snapshotFile = projectDir.resolve("build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties")
-        assertTrue(snapshotFile.isFile, "APT should generate snapshot file: ${snapshotFile.absolutePath}")
-        assertContains(snapshotFile.readText(), "demo.AptBook=apt_book")
+        val snapshotDirectory = projectDir.resolve("build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot")
+        val snapshotFile = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.singleOrNull()
+        assertTrue(snapshotFile?.isFile == true, "APT should generate one table snapshot under: ${snapshotDirectory.absolutePath}")
+        assertContains(snapshotFile.readText(), "entity.demo.AptBook=apt_book")
     }
 
     @Test
@@ -232,6 +234,121 @@ class JimmerDdlCompilerTest {
     }
 
     @Test
+    fun `snapshot stores each table in an independent structural lockfile`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-test").toFile()
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration").absolutePath,
+            compareDatabase = false,
+            sourceFingerprint = "first-source-fingerprint",
+        )
+        val entities = listOf(
+            bookEntity(),
+            bookEntity(
+                simpleName = "Author",
+                qualifiedName = "demo.Author",
+                tableName = "author",
+            ),
+        )
+        val result = JimmerDdlCompiler.compile(
+            classes = entities,
+            settings = settings,
+        )
+
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = result.entities,
+            schema = result.snapshotSchema,
+            settings = settings,
+        )
+
+        val snapshotDirectory = projectDir.resolve(".jimmer-ddl/entity-table-snapshot")
+        val initialFiles = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.sortedBy { file -> file.name }
+            .orEmpty()
+        assertEquals(2, initialFiles.size)
+        assertTrue(initialFiles.all { file -> "__sourceFingerprint" !in file.readText() })
+        val initialContents = initialFiles.associate { file -> file.name to file.readBytes() }
+
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = result.entities,
+            schema = result.snapshotSchema,
+            settings = settings.copy(sourceFingerprint = "second-source-fingerprint"),
+        )
+
+        val rewrittenFiles = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.associate { file -> file.name to file.readBytes() }
+            .orEmpty()
+        assertEquals(initialContents.keys, rewrittenFiles.keys)
+        initialContents.forEach { (name, content) ->
+            assertTrue(content.contentEquals(rewrittenFiles.getValue(name)))
+        }
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(
+                bookEntity(extraField = true),
+                entities.last(),
+            ),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = changed.entities,
+            schema = changed.snapshotSchema,
+            settings = settings,
+        )
+
+        val finalContents = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            .orEmpty()
+            .associate { file -> file.name to file.readBytes() }
+        val authorFileName = initialFiles.single { file -> "tableName=author" in file.readText() }.name
+        val bookFileName = initialFiles.single { file -> "tableName=book" in file.readText() }.name
+        assertTrue(initialContents.getValue(authorFileName).contentEquals(finalContents.getValue(authorFileName)))
+        assertFalse(initialContents.getValue(bookFileName).contentEquals(finalContents.getValue(bookFileName)))
+    }
+
+    @Test
+    fun `rewriting snapshot removes lockfiles for deleted tables`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-test").toFile()
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration").absolutePath,
+            compareDatabase = false,
+        )
+        val book = bookEntity()
+        val author = bookEntity(
+            simpleName = "Author",
+            qualifiedName = "demo.Author",
+            tableName = "author",
+        )
+        val initial = JimmerDdlCompiler.compile(
+            classes = listOf(book, author),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = initial.entities,
+            schema = initial.snapshotSchema,
+            settings = settings,
+        )
+
+        val remaining = JimmerDdlCompiler.compile(
+            classes = listOf(book),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = remaining.entities,
+            schema = remaining.snapshotSchema,
+            settings = settings,
+        )
+
+        val snapshot = JimmerDdlEntityTableSnapshot.readSnapshot(settings)
+        assertEquals(setOf("book"), snapshot.tableHashes.keys)
+        assertEquals(mapOf("demo.Book" to "book"), snapshot.entityTables)
+        val snapshotDirectory = projectDir.resolve(".jimmer-ddl/entity-table-snapshot")
+        assertEquals(1, snapshotDirectory.listFiles { file -> file.extension == "properties" }.orEmpty().size)
+    }
+
+    @Test
     fun `postgresql ddl contains idempotent table column and nullable repair statements`() {
         val entity = bookEntity()
         val result = JimmerDdlCompiler.compile(
@@ -243,8 +360,83 @@ class JimmerDdlCompilerTest {
         )
 
         assertContains(result.sql, "CREATE TABLE IF NOT EXISTS \"book\"")
-        assertContains(result.sql, """"title" VARCHAR(255) NOT NULL""")
+        assertContains(result.sql, """"title" TEXT NOT NULL""")
         assertContains(result.sql, """ALTER TABLE "book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
+    }
+
+    @Test
+    fun `nested jimmer embeddable properties are expanded into leaf columns`() {
+        val coordinates = TestClass(
+            simpleName = "Coordinates",
+            qualifiedName = "demo.Coordinates",
+            annotations = listOf(embeddable()),
+            fields = listOf(
+                TestField(
+                    name = "latitude",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                )
+            ),
+        )
+        val address = TestClass(
+            simpleName = "Address",
+            qualifiedName = "demo.Address",
+            annotations = listOf(embeddable()),
+            fields = listOf(
+                TestField(
+                    name = "street",
+                    type = TestType("String"),
+                    typeName = "String",
+                ),
+                TestField(
+                    name = "coordinates",
+                    type = TestType(
+                        simpleName = "Coordinates",
+                        qualifiedName = "demo.Coordinates",
+                        lsiClass = coordinates,
+                    ),
+                    typeName = "demo.Coordinates",
+                    fieldTypeClass = coordinates,
+                ),
+            ),
+        )
+        val warehouse = TestClass(
+            simpleName = "Warehouse",
+            qualifiedName = "demo.Warehouse",
+            annotations = listOf(entity(), table("warehouse")),
+            fields = listOf(
+                TestField(
+                    name = "id",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                    annotations = listOf(id()),
+                ),
+                TestField(
+                    name = "address",
+                    type = TestType(
+                        simpleName = "Address",
+                        qualifiedName = "demo.Address",
+                        lsiClass = address,
+                    ),
+                    typeName = "demo.Address",
+                    fieldTypeClass = address,
+                ),
+            ),
+        )
+
+        val result = JimmerDdlCompiler.compile(
+            classes = listOf(warehouse),
+            settings = JimmerDdlCompilerSettings(
+                databaseType = DatabaseType.POSTGRESQL,
+                outputFormat = JimmerDdlOutputFormat.PLAIN,
+                compareDatabase = false,
+            ),
+        )
+
+        assertContains(result.sql, """"street" TEXT NOT NULL""")
+        assertContains(result.sql, """"latitude" BIGINT NOT NULL""")
+        assertFalse("\"address\"" in result.sql)
+        assertFalse("\"coordinates\"" in result.sql)
     }
 
     @Test
@@ -304,7 +496,7 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" VARCHAR(255);""")
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" TEXT;""")
         assertFalse("CREATE TABLE" in changed.sql)
     }
 
@@ -364,7 +556,7 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" VARCHAR(255);""")
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" TEXT;""")
         assertContains(changed.sql, """ALTER COLUMN "title" TYPE INTEGER""")
         assertContains(changed.sql, """USING CASE""")
         assertTrue(changed.warnings.none { warning -> "skipped column structure changes" in warning })
@@ -380,6 +572,7 @@ class JimmerDdlCompilerTest {
             outputFormat = JimmerDdlOutputFormat.PLAIN,
             outputDir = outputDir.absolutePath,
             compareDatabase = false,
+            sourceFingerprint = "generated-source-fingerprint",
         )
         val first = JimmerDdlCompiler.compile(
             classes = listOf(bookEntity()),
@@ -390,9 +583,9 @@ class JimmerDdlCompilerTest {
             schema = first.schema,
             settings = settings,
         )
-        val sourceSnapshot = JimmerDdlCompilerFiles.resolveSnapshotFile(settings)
+        val sourceSnapshot = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings)
         requireNotNull(sourceSnapshot)
-        val sourceContent = sourceSnapshot.readText()
+        val sourceContent = sourceSnapshot.readSnapshotContents()
         val changed = JimmerDdlCompiler.compile(
             classes = listOf(bookEntity(extraField = true)),
             settings = settings,
@@ -404,10 +597,14 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        val generatedSnapshot = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
-        assertTrue(generatedSnapshot.isFile)
-        assertEquals(sourceContent, sourceSnapshot.readText())
-        assertFalse(sourceContent == generatedSnapshot.readText())
+        val generatedSnapshot = JimmerDdlCompilerFiles.resolveGeneratedSnapshotDirectory(settings)
+        assertTrue(generatedSnapshot.isDirectory)
+        assertEquals(sourceContent, sourceSnapshot.readSnapshotContents())
+        assertFalse(sourceContent == generatedSnapshot.readSnapshotContents())
+        val sourceFingerprint = JimmerDdlCompilerFiles.resolveBuildSourceFingerprintFile(settings)
+        requireNotNull(sourceFingerprint)
+        assertTrue(sourceFingerprint.isFile)
+        assertContains(sourceFingerprint.readText(), "__sourceFingerprint=generated-source-fingerprint")
     }
 
     @Test
@@ -482,13 +679,15 @@ class JimmerDdlCompilerTest {
     }
 
     private fun bookEntity(
+        simpleName: String = "Book",
+        qualifiedName: String = "demo.Book",
         tableName: String = "book",
         extraField: Boolean = false,
         titleTypeName: String = "String",
     ): TestClass {
         return TestClass(
-            simpleName = "Book",
-            qualifiedName = "demo.Book",
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
             annotations = listOf(entity(), table(tableName)),
             fields = listOf(
                 TestField(
@@ -534,6 +733,10 @@ class JimmerDdlCompilerTest {
         return TestAnnotation("org.babyfish.jimmer.sql.MappedSuperclass", "MappedSuperclass")
     }
 
+    private fun embeddable(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Embeddable", "Embeddable")
+    }
+
     private fun table(name: String): TestAnnotation {
         return TestAnnotation("org.babyfish.jimmer.sql.Table", "Table", mapOf("name" to name))
     }
@@ -558,6 +761,12 @@ class JimmerDdlCompilerTest {
         val file = sourceDir.resolve(path)
         file.parentFile.mkdirs()
         file.writeText(content)
+    }
+
+    private fun File.readSnapshotContents(): Map<String, String> {
+        return listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .associate { file -> file.name to file.readText() }
     }
 
     private fun DiagnosticCollector<JavaFileObject>.toErrorMessage(): String {


### PR DESCRIPTION
## Problem

The DDL compiler stores every entity mapping, table schema, and source fingerprint in one Git-tracked properties file. Unrelated entity changes therefore rewrite the same snapshot and frequently conflict across branches.

## Changes

- Store the durable schema baseline as independent `.jimmer-ddl/entity-table-snapshot/<table>.properties` lockfiles.
- Keep the optional source fingerprint in disposable `build/jimmer-ddl` state instead of structural lockfiles.
- Skip unchanged lockfile writes and remove lockfiles for deleted tables.
- Stage generated lockfiles as a directory under generated resources and document the required directory mirror workflow.
- Upgrade active LSI and DDL generator artifacts to `2026.07.30`, including recursive Jimmer `@Embeddable` expansion; keep archived dialect artifacts on `2026.07.15.2`.
- Treat the former aggregate `entity-table-snapshot.properties` format as replaced rather than adding a compatibility reader.

## Verification

- `./gradlew :jimmer-ddl-compiler:check`
- `./gradlew :jimmer-ddl-compiler:publishToMavenLocal`
- APT snapshot generation, incremental DDL, table rename, deleted-table cleanup, unrelated-table lockfile isolation, build-only source fingerprint, and nested embeddable regression tests all pass.
- `site.addzero` version `2026.07.30` was published and resolved from Maven Central.