### PR TITLE
feat(ddl): store schema snapshots per table safely

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
-addzero = "2026.07.15.2"
+addzero-ddlgenerator = "2026.07.30"
+addzero-ddlgenerator-archived = "2026.07.15.2"
+addzero-lsi = "2026.07.30"
 antlr = "4.13.0"
 buildconfig = "5.3.5"
 caffeine = "2.9.1"
@@ -36,21 +38,21 @@ scalar = "0.5.47"
 
 [libraries]
 
-addzero-lsi-core = { group = "site.addzero", name = "lsi-core", version.ref = "addzero" }
-addzero-lsi-ksp = { group = "site.addzero", name = "lsi-ksp", version.ref = "addzero" }
-addzero-lsi-apt = { group = "site.addzero", name = "lsi-apt", version.ref = "addzero" }
-addzero-ddlgenerator-core = { group = "site.addzero", name = "ddlgenerator-core", version.ref = "addzero" }
-addzero-ddlgenerator-lsi-adaptor = { group = "site.addzero", name = "ddlgenerator-lsi-adaptor", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-mysql = { group = "site.addzero", name = "ddlgenerator-dialect-mysql", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-postgresql = { group = "site.addzero", name = "ddlgenerator-dialect-postgresql", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-h2 = { group = "site.addzero", name = "ddlgenerator-dialect-h2", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-sqlite = { group = "site.addzero", name = "ddlgenerator-dialect-sqlite", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-sqlserver = { group = "site.addzero", name = "ddlgenerator-dialect-sqlserver", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-oracle = { group = "site.addzero", name = "ddlgenerator-dialect-oracle", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-dm = { group = "site.addzero", name = "ddlgenerator-dialect-dm", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-kingbase = { group = "site.addzero", name = "ddlgenerator-dialect-kingbase", version.ref = "addzero" }
-addzero-ddlgenerator-dialect-taos = { group = "site.addzero", name = "ddlgenerator-dialect-taos", version.ref = "addzero" }
-addzero-tool-database-model = { group = "site.addzero", name = "tool-database-model", version.ref = "addzero" }
+addzero-lsi-core = { group = "site.addzero", name = "lsi-core", version.ref = "addzero-lsi" }
+addzero-lsi-ksp = { group = "site.addzero", name = "lsi-ksp", version.ref = "addzero-lsi" }
+addzero-lsi-apt = { group = "site.addzero", name = "lsi-apt", version.ref = "addzero-lsi" }
+addzero-ddlgenerator-core = { group = "site.addzero", name = "ddlgenerator-core", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-lsi-adaptor = { group = "site.addzero", name = "ddlgenerator-lsi-adaptor", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-mysql = { group = "site.addzero", name = "ddlgenerator-dialect-mysql", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-postgresql = { group = "site.addzero", name = "ddlgenerator-dialect-postgresql", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-h2 = { group = "site.addzero", name = "ddlgenerator-dialect-h2", version.ref = "addzero-ddlgenerator" }
+addzero-ddlgenerator-dialect-sqlite = { group = "site.addzero", name = "ddlgenerator-dialect-sqlite", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-sqlserver = { group = "site.addzero", name = "ddlgenerator-dialect-sqlserver", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-oracle = { group = "site.addzero", name = "ddlgenerator-dialect-oracle", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-dm = { group = "site.addzero", name = "ddlgenerator-dialect-dm", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-kingbase = { group = "site.addzero", name = "ddlgenerator-dialect-kingbase", version.ref = "addzero-ddlgenerator-archived" }
+addzero-ddlgenerator-dialect-taos = { group = "site.addzero", name = "ddlgenerator-dialect-taos", version.ref = "addzero-ddlgenerator-archived" }
+addzero-tool-database-model = { group = "site.addzero", name = "tool-database-model", version.ref = "addzero-ddlgenerator" }
 antlr = { group = "org.antlr", name = "antlr4", version.ref = "antlr" }
 
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }

--- a/project/jimmer-ddl-compiler/README.md
+++ b/project/jimmer-ddl-compiler/README.md
@@ -58,14 +58,18 @@ tasks.withType<JavaCompile>().configureEach {
 | `jimmerDdl.includeManyToManyTables` | `true` | Generates Jimmer many-to-many junction tables. |
 | `jimmerDdl.compareDatabase` | `true` | Reads the configured database and emits diff SQL. If the database cannot be read, it falls back to offline DDL. |
 | `jimmerDdl.nullabilityRepairOnly` | `false` | Limits risky offline alteration planning to nullability repair. |
-| `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored in the snapshot. |
+| `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored as build-local state outside the structural snapshot. |
 | `jimmerDdl.jdbcUrl` / `jdbcUsername` / `jdbcPassword` / `jdbcSchema` / `jdbcDriver` | empty | Explicit JDBC settings used by database comparison. |
 | `jimmerDdl.springResourcePath` | empty | Optional Spring resource path used to discover datasource settings. |
 | `jimmerDdl.springProfile` | `local` | Spring profile used when reading YAML datasource settings. |
 
 ## Snapshot model
 
-The compiler writes a generated snapshot to `build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties`. The snapshot records entity-to-table mappings and table hashes so subsequent builds can emit incremental SQL, including table renames caused by `@Table(name = ...)` changes.
+The durable schema baseline is a directory of per-table lockfiles under `.jimmer-ddl/entity-table-snapshot/`. Each lockfile records one table schema hash, its encoded structural model, and the Jimmer entities mapped to that table. Keeping tables in independent files prevents unrelated entity changes on separate branches from rewriting the same Git-tracked snapshot.
+
+The compiler stages the next baseline under `build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot/`. After accepting the generated migration, the consumer build must mirror that whole directory to the durable `.jimmer-ddl/entity-table-snapshot/` directory, including deletion of lockfiles for removed tables. The former aggregate `entity-table-snapshot.properties` file is not read.
+
+When `jimmerDdl.sourceFingerprint` is supplied, it is written to `build/jimmer-ddl/source-fingerprint.properties`. It is disposable build state and must not be committed or copied into the structural snapshot.
 
 ## Tests
 

--- a/project/jimmer-ddl-compiler/README.md
+++ b/project/jimmer-ddl-compiler/README.md
@@ -57,11 +57,17 @@ tasks.withType<JavaCompile>().configureEach {
 | `jimmerDdl.includeSequences` | `true` | Generates sequences. |
 | `jimmerDdl.includeManyToManyTables` | `true` | Generates Jimmer many-to-many junction tables. |
 | `jimmerDdl.compareDatabase` | `true` | Reads the configured database and emits diff SQL. If the database cannot be read, it falls back to offline DDL. |
+| `jimmerDdl.allowDestructiveChanges` | `false` | Allows destructive diff operations and inferred table renames. A column rename is emitted as an added new column plus a dropped old column. |
 | `jimmerDdl.nullabilityRepairOnly` | `false` | Limits risky offline alteration planning to nullability repair. |
 | `jimmerDdl.sourceFingerprint` | empty | Optional source fingerprint stored as build-local state outside the structural snapshot. |
 | `jimmerDdl.jdbcUrl` / `jdbcUsername` / `jdbcPassword` / `jdbcSchema` / `jdbcDriver` | empty | Explicit JDBC settings used by database comparison. |
 | `jimmerDdl.springResourcePath` | empty | Optional Spring resource path used to discover datasource settings. |
 | `jimmerDdl.springProfile` | `local` | Spring profile used when reading YAML datasource settings. |
+
+> [!WARNING]
+> Setting `jimmerDdl.allowDestructiveChanges=true` permits generated migrations to drop schema objects and rename tables, which can cause irreversible data loss. Review the generated SQL and back up the database before applying it. Once enabled, the consuming project is responsible for these migrations; Jimmer does not guarantee data preservation for destructive statements.
+
+With the default `false`, removed columns remain in the staged structural snapshot so they can still be dropped by a later explicitly enabled run. An inferred table rename instead creates the desired table, preserves the old database table, and emits a warning.
 
 ## Snapshot model
 

--- a/project/jimmer-ddl-compiler/build.gradle.kts
+++ b/project/jimmer-ddl-compiler/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.ksp.symbolProcessing.api)
 
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.h2)
 }
 
 tasks.test {

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompiler.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompiler.kt
@@ -93,6 +93,9 @@ object JimmerDdlCompiler {
         settings: JimmerDdlCompilerSettings,
     ): JimmerDdlCompilePlan {
         val renameOperations = changePlan.renameOperations
+            .takeIf { settings.allowDestructiveChanges }
+            .orEmpty()
+        val effectiveChangePlan = changePlan.copy(renameOperations = renameOperations)
         val operationPlan = if (settings.compareDatabase && settings.jdbc.url.isNotBlank()) {
             generateComparedOperations(
                 schema = schema,
@@ -104,7 +107,7 @@ object JimmerDdlCompiler {
         } else {
             buildOfflineIncrementalOperationPlan(
                 schema = schema,
-                changePlan = changePlan,
+                changePlan = effectiveChangePlan,
                 settings = settings,
             )
         }
@@ -118,7 +121,7 @@ object JimmerDdlCompiler {
         return JimmerDdlCompilePlan(
             statements = statements,
             snapshotSchema = operationPlan.snapshotSchema ?: schema,
-            warnings = operationPlan.warnings,
+            warnings = operationPlan.warnings + buildSkippedRenameWarnings(changePlan, settings),
         )
     }
 
@@ -135,7 +138,15 @@ object JimmerDdlCompiler {
         )
         return JimmerDdlOperationPlan(
             operations = operations,
-            snapshotSchema = schema,
+            snapshotSchema = if (settings.allowDestructiveChanges) {
+                schema
+            } else {
+                val previousSchema = changePlan.previous.toSchemaFor(
+                    schema = schema,
+                    renameOperations = changePlan.renameOperations,
+                )
+                schema.preserveSkippedDestructiveChanges(previousSchema, settings)
+            },
         )
     }
 
@@ -153,7 +164,7 @@ object JimmerDdlCompiler {
             val operations = SchemaDiffPlanner.plan(
                 schema,
                 actualSchema,
-                AutoDdlDiffOptions(settings.options, true, emptyList(), emptyList())
+                settings.toDiffOptions(),
             )
             JimmerDdlOperationPlan(operations = operations)
         }.getOrElse { cause ->
@@ -343,7 +354,27 @@ object JimmerDdlCompiler {
         return SchemaDiffPlanner.plan(
             schema,
             previousSchema,
-            AutoDdlDiffOptions(settings.options, true, emptyList(), emptyList())
+            settings.toDiffOptions(),
+        )
+    }
+
+    private fun JimmerDdlCompilerSettings.toDiffOptions(): AutoDdlDiffOptions {
+        return AutoDdlDiffOptions(
+            ddlOptions = options,
+            allowDestructiveChanges = allowDestructiveChanges,
+        )
+    }
+
+    private fun buildSkippedRenameWarnings(
+        changePlan: JimmerDdlSchemaChangePlan,
+        settings: JimmerDdlCompilerSettings,
+    ): List<String> {
+        if (settings.allowDestructiveChanges || changePlan.renameOperations.isEmpty()) {
+            return emptyList()
+        }
+        return listOf(
+            "Jimmer DDL skipped ${changePlan.renameOperations.size} table rename operation(s) because " +
+                "jimmerDdl.allowDestructiveChanges is false; new tables are created and old tables are preserved."
         )
     }
 
@@ -396,6 +427,76 @@ object JimmerDdlCompiler {
             tables.filter { table -> table.name.lowercase() in normalizedTableNames },
             sequences,
         )
+    }
+
+    private fun AutoDdlSchema.preserveSkippedDestructiveChanges(
+        previousSchema: AutoDdlSchema,
+        settings: JimmerDdlCompilerSettings,
+    ): AutoDdlSchema {
+        val previousTables = previousSchema.tables.associateBy { table -> table.name.lowercase() }
+        return copy(
+            tables = tables.map { desiredTable ->
+                val previousTable = previousTables[desiredTable.name.lowercase()]
+                    ?: return@map desiredTable
+                val desiredColumnNames = desiredTable.columns.map { column -> column.name.lowercase() }.toSet()
+                val previousPrimaryKey = previousTable.primaryKeyColumnNames.map { name -> name.lowercase() }.toSet()
+                val desiredPrimaryKey = desiredTable.primaryKeyColumnNames.map { name -> name.lowercase() }.toSet()
+                val effectivePrimaryKey = if (previousPrimaryKey.isNotEmpty() && previousPrimaryKey != desiredPrimaryKey) {
+                    previousPrimaryKey
+                } else {
+                    desiredPrimaryKey
+                }
+                val retainedColumns = desiredTable.columns + previousTable.columns.filter { column ->
+                    column.name.lowercase() !in desiredColumnNames
+                }
+                desiredTable.copy(
+                    columns = retainedColumns.map { column ->
+                        val previousColumn = previousTable.column(column.name)
+                        column.copy(
+                            comment = when {
+                                !settings.options.includeComments -> previousColumn?.comment
+                                !column.comment.isNullOrBlank() -> column.comment
+                                else -> previousColumn?.comment
+                            },
+                            primaryKey = column.name.lowercase() in effectivePrimaryKey,
+                        )
+                    },
+                    foreignKeys = if (settings.options.includeForeignKeys) {
+                        previousTable.foreignKeys + desiredTable.foreignKeys.filter { desiredForeignKey ->
+                            previousTable.foreignKeys.none { previousForeignKey ->
+                                previousForeignKey.columnNames.normalizedNames() == desiredForeignKey.columnNames.normalizedNames() &&
+                                    previousForeignKey.referencedTableName.equals(desiredForeignKey.referencedTableName, ignoreCase = true) &&
+                                    previousForeignKey.referencedColumnNames.normalizedNames() == desiredForeignKey.referencedColumnNames.normalizedNames() &&
+                                    previousForeignKey.onDelete.orEmpty().equals(desiredForeignKey.onDelete.orEmpty(), ignoreCase = true) &&
+                                    previousForeignKey.onUpdate.orEmpty().equals(desiredForeignKey.onUpdate.orEmpty(), ignoreCase = true)
+                            }
+                        }
+                    } else {
+                        previousTable.foreignKeys
+                    },
+                    indexes = if (settings.options.includeIndexes) {
+                        previousTable.indexes + desiredTable.indexes.filter { desiredIndex ->
+                            previousTable.indexes.none { previousIndex ->
+                                val sameDefinition = previousIndex.type == desiredIndex.type &&
+                                    previousIndex.columnNames.normalizedNames() == desiredIndex.columnNames.normalizedNames()
+                                previousIndex.name.equals(desiredIndex.name, ignoreCase = true) || sameDefinition
+                            }
+                        }
+                    } else {
+                        previousTable.indexes
+                    },
+                    comment = when {
+                        !settings.options.includeComments -> previousTable.comment
+                        !desiredTable.comment.isNullOrBlank() -> desiredTable.comment
+                        else -> previousTable.comment
+                    },
+                )
+            },
+        )
+    }
+
+    private fun List<String>.normalizedNames(): List<String> {
+        return map { name -> name.lowercase() }
     }
 
     private fun JimmerDdlSnapshot.toSchemaFor(

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerFiles.kt
@@ -4,21 +4,27 @@ import java.io.File
 
 object JimmerDdlCompilerFiles {
     private const val SNAPSHOT_DIR_NAME = ".jimmer-ddl"
-    private const val SNAPSHOT_FILE_NAME = "entity-table-snapshot.properties"
+    private const val SNAPSHOT_DIRECTORY_NAME = "entity-table-snapshot"
+    private const val SOURCE_FINGERPRINT_FILE_NAME = "source-fingerprint.properties"
 
     fun resolveOutputFile(settings: JimmerDdlCompilerSettings): File {
         val outputDir = File(settings.outputDir)
         return File(outputDir, settings.outputFileName)
     }
 
-    fun resolveSnapshotFile(settings: JimmerDdlCompilerSettings): File? {
+    fun resolveSnapshotDirectory(settings: JimmerDdlCompilerSettings): File? {
         val projectDir = settings.outputDir.toProjectDir() ?: return null
-        return projectDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+        return projectDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_DIRECTORY_NAME)
     }
 
-    fun resolveGeneratedSnapshotFile(settings: JimmerDdlCompilerSettings): File {
+    fun resolveGeneratedSnapshotDirectory(settings: JimmerDdlCompilerSettings): File {
         val resourcesDir = settings.outputDir.toGeneratedResourcesDir()
-        return resourcesDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_FILE_NAME)
+        return resourcesDir.resolve(SNAPSHOT_DIR_NAME).resolve(SNAPSHOT_DIRECTORY_NAME)
+    }
+
+    fun resolveBuildSourceFingerprintFile(settings: JimmerDdlCompilerSettings): File? {
+        val projectDir = settings.outputDir.toProjectDir() ?: return null
+        return projectDir.resolve("build/jimmer-ddl").resolve(SOURCE_FINGERPRINT_FILE_NAME)
     }
 
     fun writeOutputFile(

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSettings.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerSettings.kt
@@ -49,6 +49,7 @@ data class JimmerDdlCompilerSettings(
     val nullabilityRepairOnly: Boolean = false,
     val sourceFingerprint: String? = null,
     val jdbc: JimmerDdlJdbcSettings = JimmerDdlJdbcSettings(),
+    val allowDestructiveChanges: Boolean = false,
 ) {
     fun includesClass(qualifiedName: String?): Boolean {
         if (qualifiedName.isNullOrBlank()) {
@@ -114,6 +115,7 @@ data class JimmerDdlCompilerSettings(
                 ),
                 includeManyToManyTables = options.option("jimmerDdl.includeManyToManyTables", defaultValue = "true").toBooleanStrictOrNull() ?: true,
                 compareDatabase = options.option("jimmerDdl.compareDatabase", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                allowDestructiveChanges = options.option("jimmerDdl.allowDestructiveChanges", defaultValue = "false").toBooleanStrictOrNull() ?: false,
                 nullabilityRepairOnly = options.option("jimmerDdl.nullabilityRepairOnly", defaultValue = "false").toBooleanStrictOrNull() ?: false,
                 sourceFingerprint = options.option("jimmerDdl.sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() },
                 jdbc = jdbc,
@@ -148,6 +150,7 @@ data class JimmerDdlCompilerSettings(
                 ),
                 includeManyToManyTables = options.profileOption(profileName, "includeManyToManyTables", defaultValue = "true").toBooleanStrictOrNull() ?: true,
                 compareDatabase = options.profileOption(profileName, "compareDatabase", defaultValue = "true").toBooleanStrictOrNull() ?: true,
+                allowDestructiveChanges = options.profileOption(profileName, "allowDestructiveChanges", defaultValue = "false").toBooleanStrictOrNull() ?: false,
                 nullabilityRepairOnly = options.profileOption(profileName, "nullabilityRepairOnly", defaultValue = "false").toBooleanStrictOrNull() ?: false,
                 sourceFingerprint = options.profileOption(profileName, "sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() }
                     ?: options.option("jimmerDdl.sourceFingerprint", defaultValue = "").takeIf { it.isNotBlank() },

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
@@ -70,25 +70,34 @@ object JimmerDdlDatabaseSchemaReader {
         metaData.findColumns(connection.catalog, schemaName, tableName).use { resultSet ->
             while (resultSet.next()) {
                 val columnName = resultSet.getString("COLUMN_NAME") ?: continue
-                val desiredColumn = desiredColumns[columnName.lowercase()] ?: continue
                 val jdbcType = resultSet.getInt("DATA_TYPE")
                 val length = resultSet.getIntOrNull("COLUMN_SIZE")
                 val scale = resultSet.getIntOrNull("DECIMAL_DIGITS")
                 val nullable = resultSet.getInt("NULLABLE") == DatabaseMetaData.columnNullable
-                columns += desiredColumn.copy(
-                    columnName,
-                    jdbcType.toLogicalType(),
-                    nullable,
-                    length,
-                    desiredColumn.precision,
-                    scale,
-                    resultSet.getStringOrNull("COLUMN_DEF"),
-                    desiredColumn.comment,
-                    primaryKeys.any { key -> key.equals(columnName, ignoreCase = true) },
-                    desiredColumn.autoIncrement,
-                    desiredColumn.sequenceName,
-                    resultSet.getStringOrNull("TYPE_NAME"),
-                )
+                val desiredColumn = desiredColumns[columnName.lowercase()]
+                columns += if (desiredColumn != null) {
+                    desiredColumn.copy(
+                        columnName,
+                        jdbcType.toLogicalType(),
+                        nullable,
+                        length,
+                        desiredColumn.precision,
+                        scale,
+                        resultSet.getStringOrNull("COLUMN_DEF"),
+                        desiredColumn.comment,
+                        primaryKeys.any { key -> key.equals(columnName, ignoreCase = true) },
+                        desiredColumn.autoIncrement,
+                        desiredColumn.sequenceName,
+                        resultSet.getStringOrNull("TYPE_NAME"),
+                    )
+                } else {
+                    AutoDdlColumn(
+                        name = columnName,
+                        logicalType = jdbcType.toLogicalType(),
+                        nullable = nullable,
+                        primaryKey = primaryKeys.any { key -> key.equals(columnName, ignoreCase = true) },
+                    )
+                }
             }
         }
         return AutoDdlTable(

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlEntityTableSnapshot.kt
@@ -15,11 +15,13 @@ import java.util.Base64
 import java.util.Properties
 
 private const val SOURCE_FINGERPRINT_KEY = "__sourceFingerprint"
-private const val TABLE_HASH_PREFIX = "__tableHash."
-private const val TABLE_SCHEMA_PREFIX = "__tableSchema."
+private const val TABLE_NAME_KEY = "tableName"
+private const val TABLE_HASH_KEY = "tableHash"
+private const val TABLE_SCHEMA_KEY = "tableSchema"
+private const val ENTITY_TABLE_PREFIX = "entity."
+private val SAFE_SNAPSHOT_FILE_NAME = Regex("[a-z0-9][a-z0-9._-]*")
 
 data class JimmerDdlSnapshot(
-    val sourceFingerprint: String? = null,
     val entityTables: Map<String, String> = emptyMap(),
     val tableHashes: Map<String, String> = emptyMap(),
     val tableSchemas: Map<String, AutoDdlTable> = emptyMap(),
@@ -85,8 +87,8 @@ object JimmerDdlEntityTableSnapshot {
     }
 
     fun readSnapshot(settings: JimmerDdlCompilerSettings): JimmerDdlSnapshot {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return JimmerDdlSnapshot()
-        return snapshotFile.readSnapshot()
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings) ?: return JimmerDdlSnapshot()
+        return snapshotDirectory.readSnapshot()
     }
 
     private fun planRenameTables(
@@ -122,12 +124,11 @@ object JimmerDdlEntityTableSnapshot {
         schema: AutoDdlSchema,
         settings: JimmerDdlCompilerSettings,
     ) {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveSnapshotFile(settings) ?: return
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings) ?: return
         writeSnapshot(
-            snapshotFile = snapshotFile,
+            snapshotDirectory = snapshotDirectory,
             entities = entities,
             schema = schema,
-            settings = settings,
         )
     }
 
@@ -136,42 +137,72 @@ object JimmerDdlEntityTableSnapshot {
         schema: AutoDdlSchema,
         settings: JimmerDdlCompilerSettings,
     ) {
-        val snapshotFile = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
+        val snapshotDirectory = JimmerDdlCompilerFiles.resolveGeneratedSnapshotDirectory(settings)
         writeSnapshot(
-            snapshotFile = snapshotFile,
+            snapshotDirectory = snapshotDirectory,
             entities = entities,
             schema = schema,
-            settings = settings,
         )
+        writeGeneratedSourceFingerprint(settings)
     }
 
     private fun writeSnapshot(
-        snapshotFile: File,
+        snapshotDirectory: File,
         entities: List<LsiClass>,
         schema: AutoDdlSchema,
-        settings: JimmerDdlCompilerSettings,
     ) {
-        val previous = snapshotFile.readSnapshot()
-        val current = entities.toSnapshot()
-        val tableHashes = schema.toTableHashes()
-        snapshotFile.parentFile.mkdirs()
-        val sourceFingerprint = settings.sourceFingerprint ?: previous.sourceFingerprint
-        val content = buildString {
-            appendLine("# Jimmer DDL entity-to-table snapshot. Do not edit manually.")
-            sourceFingerprint?.takeIf { it.isNotBlank() }?.let {
-                appendLine("$SOURCE_FINGERPRINT_KEY=${sourceFingerprint.escapeProperty()}")
-            }
-            current.toSortedMap().forEach { (qualifiedName, tableName) ->
-                appendLine("${qualifiedName.escapeProperty()}=${tableName.escapeProperty()}")
-            }
-            tableHashes.toSortedMap().forEach { (tableName, hash) ->
-                appendLine("$TABLE_HASH_PREFIX${tableName.escapeProperty()}=${hash.escapeProperty()}")
-            }
-            schema.tables.sortedBy { table -> table.name.lowercase() }.forEach { table ->
-                appendLine("$TABLE_SCHEMA_PREFIX${table.name.lowercase().escapeProperty()}=${table.toCanonicalText().encodeBase64().escapeProperty()}")
-            }
+        val entityNamesByTable = entities.toSnapshot()
+            .entries
+            .groupBy(
+                keySelector = { entry -> entry.value.lowercase() },
+                valueTransform = { entry -> entry.key },
+            )
+        snapshotDirectory.mkdirs()
+        val snapshotFiles = schema.tables.associateWith { table ->
+            snapshotDirectory.resolve(table.name.toSnapshotFileName())
         }
-        snapshotFile.writeText(content)
+        val expectedFileNames = snapshotFiles.values.mapTo(mutableSetOf()) { file -> file.name }
+        snapshotDirectory.listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .filterNot { file -> file.name in expectedFileNames }
+            .forEach { file ->
+                check(file.delete()) { "Cannot delete stale Jimmer DDL snapshot lockfile: ${file.absolutePath}" }
+            }
+        snapshotFiles.entries
+            .sortedBy { (table) -> table.name.lowercase() }
+            .forEach { (table, snapshotFile) ->
+                val tableName = table.name.lowercase()
+                val canonicalSchema = table.toCanonicalText()
+                val content = buildString {
+                    appendLine("# Jimmer DDL structural snapshot. Do not edit manually.")
+                    appendLine("$TABLE_NAME_KEY=${table.name.escapeProperty()}")
+                    appendLine("$TABLE_HASH_KEY=${canonicalSchema.sha256()}")
+                    appendLine("$TABLE_SCHEMA_KEY=${canonicalSchema.encodeBase64().escapeProperty()}")
+                    entityNamesByTable[tableName]
+                        .orEmpty()
+                        .sorted()
+                        .forEach { qualifiedName ->
+                            appendLine("$ENTITY_TABLE_PREFIX${qualifiedName.escapeProperty()}=${table.name.escapeProperty()}")
+                        }
+                }
+                snapshotFile.writeTextIfChanged(content)
+            }
+    }
+
+    private fun writeGeneratedSourceFingerprint(settings: JimmerDdlCompilerSettings) {
+        val fingerprintFile = JimmerDdlCompilerFiles.resolveBuildSourceFingerprintFile(settings) ?: return
+        val sourceFingerprint = settings.sourceFingerprint?.takeIf { it.isNotBlank() }
+        if (sourceFingerprint == null) {
+            if (fingerprintFile.exists()) {
+                check(fingerprintFile.delete()) { "Cannot delete stale Jimmer DDL source fingerprint: ${fingerprintFile.absolutePath}" }
+            }
+            return
+        }
+        val content = buildString {
+            appendLine("# Build-local Jimmer DDL source fingerprint. Do not commit this file.")
+            appendLine("$SOURCE_FINGERPRINT_KEY=${sourceFingerprint.escapeProperty()}")
+        }
+        fingerprintFile.writeTextIfChanged(content)
     }
 
     private fun List<LsiClass>.toSnapshot(): Map<String, String> {
@@ -183,41 +214,62 @@ object JimmerDdlEntityTableSnapshot {
     }
 
     private fun File.readSnapshot(): JimmerDdlSnapshot {
-        if (!isFile) {
+        if (!isDirectory) {
             return JimmerDdlSnapshot()
-        }
-        val props = inputStream().use { input ->
-            Properties().apply { load(input) }
         }
         val entityTables = linkedMapOf<String, String>()
         val tableHashes = linkedMapOf<String, String>()
         val tableSchemas = linkedMapOf<String, AutoDdlTable>()
-        props.entries.forEach { (key, value) ->
-            val name = key.toString()
-            val text = value.toString()
-            when {
-                name == SOURCE_FINGERPRINT_KEY -> Unit
-                name.startsWith(TABLE_HASH_PREFIX) -> {
-                    val tableName = name.removePrefix(TABLE_HASH_PREFIX).lowercase()
-                    tableHashes[tableName] = text
+        listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .sortedBy { file -> file.name }
+            .forEach { snapshotFile ->
+                val props = snapshotFile.reader(Charsets.UTF_8).use { input ->
+                    Properties().apply { load(input) }
                 }
-                name.startsWith(TABLE_SCHEMA_PREFIX) -> {
-                    val tableName = name.removePrefix(TABLE_SCHEMA_PREFIX).lowercase()
-                    text.decodeTableSchema(tableName)?.let { table ->
-                        tableSchemas[tableName] = table
+                val tableName = props.getProperty(TABLE_NAME_KEY)
+                    ?.takeIf { it.isNotBlank() }
+                    ?.lowercase()
+                    ?: return@forEach
+                props.getProperty(TABLE_HASH_KEY)
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { hash -> tableHashes[tableName] = hash }
+                props.getProperty(TABLE_SCHEMA_KEY)
+                    ?.decodeTableSchema(tableName)
+                    ?.let { table -> tableSchemas[tableName] = table }
+                props.entries.forEach { (key, value) ->
+                    val name = key.toString()
+                    if (name.startsWith(ENTITY_TABLE_PREFIX)) {
+                        val qualifiedName = name.removePrefix(ENTITY_TABLE_PREFIX)
+                        value.toString().takeIf { it.isNotBlank() }?.let { mappedTableName ->
+                            entityTables[qualifiedName] = mappedTableName
+                        }
                     }
                 }
-                !name.startsWith("__") -> {
-                    entityTables[name] = text
-                }
             }
-        }
         return JimmerDdlSnapshot(
-            sourceFingerprint = props.getProperty(SOURCE_FINGERPRINT_KEY),
             entityTables = entityTables,
             tableHashes = tableHashes,
             tableSchemas = tableSchemas,
         )
+    }
+
+    private fun String.toSnapshotFileName(): String {
+        val normalized = lowercase()
+        val baseName = if (normalized.length <= 180 && SAFE_SNAPSHOT_FILE_NAME.matches(normalized)) {
+            normalized
+        } else {
+            normalized.sha256()
+        }
+        return "$baseName.properties"
+    }
+
+    private fun File.writeTextIfChanged(content: String) {
+        if (isFile && readText() == content) {
+            return
+        }
+        parentFile.mkdirs()
+        writeText(content)
     }
 
     private fun AutoDdlSchema.toTableHashes(): Map<String, String> {

--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/apt/JimmerDdlCompilerAptProcessor.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/apt/JimmerDdlCompilerAptProcessor.kt
@@ -40,6 +40,7 @@ private const val JIMMER_ENTITY = "org.babyfish.jimmer.sql.Entity"
     "jimmerDdl.includeSequences",
     "jimmerDdl.includeManyToManyTables",
     "jimmerDdl.compareDatabase",
+    "jimmerDdl.allowDestructiveChanges",
     "jimmerDdl.nullabilityRepairOnly",
     "jimmerDdl.sourceFingerprint",
 )
@@ -70,6 +71,7 @@ class JimmerDdlCompilerAptProcessor : AbstractProcessor() {
                 "jimmerDdl.includeSequences",
                 "jimmerDdl.includeManyToManyTables",
                 "jimmerDdl.compareDatabase",
+                "jimmerDdl.allowDestructiveChanges",
                 "jimmerDdl.nullabilityRepairOnly",
                 "jimmerDdl.sourceFingerprint",
             )

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
@@ -163,14 +163,16 @@ class JimmerDdlCompilerTest {
         val sql = sqlFile.readText()
         assertContains(sql, """CREATE TABLE IF NOT EXISTS "apt_book"""")
         assertContains(sql, """"id" BIGINT NOT NULL""")
-        assertContains(sql, """"title" VARCHAR(255)""")
-        assertContains(sql, """"subtitle" VARCHAR(255)""")
+        assertContains(sql, """"title" TEXT""")
+        assertContains(sql, """"subtitle" TEXT""")
         assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "title" DROP NOT NULL;""")
         assertContains(sql, """ALTER TABLE "apt_book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
 
-        val snapshotFile = projectDir.resolve("build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot.properties")
-        assertTrue(snapshotFile.isFile, "APT should generate snapshot file: ${snapshotFile.absolutePath}")
-        assertContains(snapshotFile.readText(), "demo.AptBook=apt_book")
+        val snapshotDirectory = projectDir.resolve("build/generated/jimmer-ddl/main/resources/.jimmer-ddl/entity-table-snapshot")
+        val snapshotFile = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.singleOrNull()
+        assertTrue(snapshotFile?.isFile == true, "APT should generate one table snapshot under: ${snapshotDirectory.absolutePath}")
+        assertContains(snapshotFile.readText(), "entity.demo.AptBook=apt_book")
     }
 
     @Test
@@ -232,6 +234,121 @@ class JimmerDdlCompilerTest {
     }
 
     @Test
+    fun `snapshot stores each table in an independent structural lockfile`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-test").toFile()
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration").absolutePath,
+            compareDatabase = false,
+            sourceFingerprint = "first-source-fingerprint",
+        )
+        val entities = listOf(
+            bookEntity(),
+            bookEntity(
+                simpleName = "Author",
+                qualifiedName = "demo.Author",
+                tableName = "author",
+            ),
+        )
+        val result = JimmerDdlCompiler.compile(
+            classes = entities,
+            settings = settings,
+        )
+
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = result.entities,
+            schema = result.snapshotSchema,
+            settings = settings,
+        )
+
+        val snapshotDirectory = projectDir.resolve(".jimmer-ddl/entity-table-snapshot")
+        val initialFiles = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.sortedBy { file -> file.name }
+            .orEmpty()
+        assertEquals(2, initialFiles.size)
+        assertTrue(initialFiles.all { file -> "__sourceFingerprint" !in file.readText() })
+        val initialContents = initialFiles.associate { file -> file.name to file.readBytes() }
+
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = result.entities,
+            schema = result.snapshotSchema,
+            settings = settings.copy(sourceFingerprint = "second-source-fingerprint"),
+        )
+
+        val rewrittenFiles = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            ?.associate { file -> file.name to file.readBytes() }
+            .orEmpty()
+        assertEquals(initialContents.keys, rewrittenFiles.keys)
+        initialContents.forEach { (name, content) ->
+            assertTrue(content.contentEquals(rewrittenFiles.getValue(name)))
+        }
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(
+                bookEntity(extraField = true),
+                entities.last(),
+            ),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = changed.entities,
+            schema = changed.snapshotSchema,
+            settings = settings,
+        )
+
+        val finalContents = snapshotDirectory.listFiles { file -> file.extension == "properties" }
+            .orEmpty()
+            .associate { file -> file.name to file.readBytes() }
+        val authorFileName = initialFiles.single { file -> "tableName=author" in file.readText() }.name
+        val bookFileName = initialFiles.single { file -> "tableName=book" in file.readText() }.name
+        assertTrue(initialContents.getValue(authorFileName).contentEquals(finalContents.getValue(authorFileName)))
+        assertFalse(initialContents.getValue(bookFileName).contentEquals(finalContents.getValue(bookFileName)))
+    }
+
+    @Test
+    fun `rewriting snapshot removes lockfiles for deleted tables`() {
+        val projectDir = createTempDirectory(prefix = "jimmer-ddl-test").toFile()
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration").absolutePath,
+            compareDatabase = false,
+        )
+        val book = bookEntity()
+        val author = bookEntity(
+            simpleName = "Author",
+            qualifiedName = "demo.Author",
+            tableName = "author",
+        )
+        val initial = JimmerDdlCompiler.compile(
+            classes = listOf(book, author),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = initial.entities,
+            schema = initial.snapshotSchema,
+            settings = settings,
+        )
+
+        val remaining = JimmerDdlCompiler.compile(
+            classes = listOf(book),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = remaining.entities,
+            schema = remaining.snapshotSchema,
+            settings = settings,
+        )
+
+        val snapshot = JimmerDdlEntityTableSnapshot.readSnapshot(settings)
+        assertEquals(setOf("book"), snapshot.tableHashes.keys)
+        assertEquals(mapOf("demo.Book" to "book"), snapshot.entityTables)
+        val snapshotDirectory = projectDir.resolve(".jimmer-ddl/entity-table-snapshot")
+        assertEquals(1, snapshotDirectory.listFiles { file -> file.extension == "properties" }.orEmpty().size)
+    }
+
+    @Test
     fun `postgresql ddl contains idempotent table column and nullable repair statements`() {
         val entity = bookEntity()
         val result = JimmerDdlCompiler.compile(
@@ -243,8 +360,83 @@ class JimmerDdlCompilerTest {
         )
 
         assertContains(result.sql, "CREATE TABLE IF NOT EXISTS \"book\"")
-        assertContains(result.sql, """"title" VARCHAR(255) NOT NULL""")
+        assertContains(result.sql, """"title" TEXT NOT NULL""")
         assertContains(result.sql, """ALTER TABLE "book" ALTER COLUMN "subtitle" DROP NOT NULL;""")
+    }
+
+    @Test
+    fun `nested jimmer embeddable properties are expanded into leaf columns`() {
+        val coordinates = TestClass(
+            simpleName = "Coordinates",
+            qualifiedName = "demo.Coordinates",
+            annotations = listOf(embeddable()),
+            fields = listOf(
+                TestField(
+                    name = "latitude",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                )
+            ),
+        )
+        val address = TestClass(
+            simpleName = "Address",
+            qualifiedName = "demo.Address",
+            annotations = listOf(embeddable()),
+            fields = listOf(
+                TestField(
+                    name = "street",
+                    type = TestType("String"),
+                    typeName = "String",
+                ),
+                TestField(
+                    name = "coordinates",
+                    type = TestType(
+                        simpleName = "Coordinates",
+                        qualifiedName = "demo.Coordinates",
+                        lsiClass = coordinates,
+                    ),
+                    typeName = "demo.Coordinates",
+                    fieldTypeClass = coordinates,
+                ),
+            ),
+        )
+        val warehouse = TestClass(
+            simpleName = "Warehouse",
+            qualifiedName = "demo.Warehouse",
+            annotations = listOf(entity(), table("warehouse")),
+            fields = listOf(
+                TestField(
+                    name = "id",
+                    type = TestType("Long"),
+                    typeName = "Long",
+                    annotations = listOf(id()),
+                ),
+                TestField(
+                    name = "address",
+                    type = TestType(
+                        simpleName = "Address",
+                        qualifiedName = "demo.Address",
+                        lsiClass = address,
+                    ),
+                    typeName = "demo.Address",
+                    fieldTypeClass = address,
+                ),
+            ),
+        )
+
+        val result = JimmerDdlCompiler.compile(
+            classes = listOf(warehouse),
+            settings = JimmerDdlCompilerSettings(
+                databaseType = DatabaseType.POSTGRESQL,
+                outputFormat = JimmerDdlOutputFormat.PLAIN,
+                compareDatabase = false,
+            ),
+        )
+
+        assertContains(result.sql, """"street" TEXT NOT NULL""")
+        assertContains(result.sql, """"latitude" BIGINT NOT NULL""")
+        assertFalse("\"address\"" in result.sql)
+        assertFalse("\"coordinates\"" in result.sql)
     }
 
     @Test
@@ -304,7 +496,7 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" VARCHAR(255);""")
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" TEXT;""")
         assertFalse("CREATE TABLE" in changed.sql)
     }
 
@@ -364,7 +556,7 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" VARCHAR(255);""")
+        assertContains(changed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "summary" TEXT;""")
         assertContains(changed.sql, """ALTER COLUMN "title" TYPE INTEGER""")
         assertContains(changed.sql, """USING CASE""")
         assertTrue(changed.warnings.none { warning -> "skipped column structure changes" in warning })
@@ -380,6 +572,7 @@ class JimmerDdlCompilerTest {
             outputFormat = JimmerDdlOutputFormat.PLAIN,
             outputDir = outputDir.absolutePath,
             compareDatabase = false,
+            sourceFingerprint = "generated-source-fingerprint",
         )
         val first = JimmerDdlCompiler.compile(
             classes = listOf(bookEntity()),
@@ -390,9 +583,9 @@ class JimmerDdlCompilerTest {
             schema = first.schema,
             settings = settings,
         )
-        val sourceSnapshot = JimmerDdlCompilerFiles.resolveSnapshotFile(settings)
+        val sourceSnapshot = JimmerDdlCompilerFiles.resolveSnapshotDirectory(settings)
         requireNotNull(sourceSnapshot)
-        val sourceContent = sourceSnapshot.readText()
+        val sourceContent = sourceSnapshot.readSnapshotContents()
         val changed = JimmerDdlCompiler.compile(
             classes = listOf(bookEntity(extraField = true)),
             settings = settings,
@@ -404,10 +597,14 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
-        val generatedSnapshot = JimmerDdlCompilerFiles.resolveGeneratedSnapshotFile(settings)
-        assertTrue(generatedSnapshot.isFile)
-        assertEquals(sourceContent, sourceSnapshot.readText())
-        assertFalse(sourceContent == generatedSnapshot.readText())
+        val generatedSnapshot = JimmerDdlCompilerFiles.resolveGeneratedSnapshotDirectory(settings)
+        assertTrue(generatedSnapshot.isDirectory)
+        assertEquals(sourceContent, sourceSnapshot.readSnapshotContents())
+        assertFalse(sourceContent == generatedSnapshot.readSnapshotContents())
+        val sourceFingerprint = JimmerDdlCompilerFiles.resolveBuildSourceFingerprintFile(settings)
+        requireNotNull(sourceFingerprint)
+        assertTrue(sourceFingerprint.isFile)
+        assertContains(sourceFingerprint.readText(), "__sourceFingerprint=generated-source-fingerprint")
     }
 
     @Test
@@ -482,13 +679,15 @@ class JimmerDdlCompilerTest {
     }
 
     private fun bookEntity(
+        simpleName: String = "Book",
+        qualifiedName: String = "demo.Book",
         tableName: String = "book",
         extraField: Boolean = false,
         titleTypeName: String = "String",
     ): TestClass {
         return TestClass(
-            simpleName = "Book",
-            qualifiedName = "demo.Book",
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
             annotations = listOf(entity(), table(tableName)),
             fields = listOf(
                 TestField(
@@ -534,6 +733,10 @@ class JimmerDdlCompilerTest {
         return TestAnnotation("org.babyfish.jimmer.sql.MappedSuperclass", "MappedSuperclass")
     }
 
+    private fun embeddable(): TestAnnotation {
+        return TestAnnotation("org.babyfish.jimmer.sql.Embeddable", "Embeddable")
+    }
+
     private fun table(name: String): TestAnnotation {
         return TestAnnotation("org.babyfish.jimmer.sql.Table", "Table", mapOf("name" to name))
     }
@@ -558,6 +761,12 @@ class JimmerDdlCompilerTest {
         val file = sourceDir.resolve(path)
         file.parentFile.mkdirs()
         file.writeText(content)
+    }
+
+    private fun File.readSnapshotContents(): Map<String, String> {
+        return listFiles { file -> file.isFile && file.extension == "properties" }
+            .orEmpty()
+            .associate { file -> file.name to file.readText() }
     }
 
     private fun DiagnosticCollector<JavaFileObject>.toErrorMessage(): String {

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlCompilerTest.kt
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.ddl.compiler
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.sql.DriverManager
 import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
 import javax.tools.StandardLocation
@@ -25,6 +26,27 @@ import site.addzero.util.db.DatabaseType
 import kotlin.io.path.createTempDirectory
 
 class JimmerDdlCompilerTest {
+
+    @Test
+    fun `destructive changes are disabled by default and configurable per profile`() {
+        assertFalse(JimmerDdlCompilerSettings.fromOptions(emptyMap()).allowDestructiveChanges)
+        assertTrue(
+            JimmerDdlCompilerSettings.fromOptions(
+                mapOf("jimmerDdl.allowDestructiveChanges" to "true")
+            ).allowDestructiveChanges
+        )
+
+        val profiles = JimmerDdlCompilerSettings.allFromOptions(
+            mapOf(
+                "jimmerDdl.profiles" to "safe,explicit",
+                "jimmerDdl.allowDestructiveChanges" to "true",
+                "jimmerDdl.profile.safe.allowDestructiveChanges" to "false",
+            )
+        )
+        assertFalse(profiles[0].allowDestructiveChanges)
+        assertTrue(profiles[1].allowDestructiveChanges)
+        assertContains(JimmerDdlCompilerAptProcessor().supportedOptions, "jimmerDdl.allowDestructiveChanges")
+    }
 
     @Test
     fun `apt processor generates ddl file from java jimmer entity`() {
@@ -231,6 +253,68 @@ class JimmerDdlCompilerTest {
         )
 
         assertEquals(listOf(RenameTable("biz_user", "biz_user_ext")), operations)
+    }
+
+    @Test
+    fun `table rename preserves the old table by default`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(tableName = "biz_user")),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val renamed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(tableName = "biz_user_ext")),
+            settings = settings,
+        )
+
+        assertContains(renamed.sql, "CREATE TABLE IF NOT EXISTS \"biz_user_ext\"")
+        assertFalse(" RENAME TO " in renamed.sql)
+        assertTrue(renamed.warnings.any { warning -> "allowDestructiveChanges is false" in warning })
+    }
+
+    @Test
+    fun `table rename emits rename ddl when destructive changes are enabled`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+            allowDestructiveChanges = true,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(tableName = "biz_user")),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val renamed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(tableName = "biz_user_ext")),
+            settings = settings,
+        )
+
+        assertContains(renamed.sql, "ALTER TABLE \"biz_user\" RENAME TO \"biz_user_ext\";")
+        assertFalse("CREATE TABLE IF NOT EXISTS \"biz_user_ext\"" in renamed.sql)
     }
 
     @Test
@@ -501,7 +585,7 @@ class JimmerDdlCompilerTest {
     }
 
     @Test
-    fun `removed property emits drop column ddl`() {
+    fun `removed property preserves the old column by default`() {
         val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
             .toFile()
             .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
@@ -526,7 +610,176 @@ class JimmerDdlCompilerTest {
             settings = settings,
         )
 
+        assertFalse("""DROP COLUMN IF EXISTS "summary""" in changed.sql)
+    }
+
+    @Test
+    fun `removed property emits drop column when destructive changes are enabled`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+            allowDestructiveChanges = true,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true)),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val changed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = false)),
+            settings = settings,
+        )
+
         assertContains(changed.sql, """ALTER TABLE "book" DROP COLUMN IF EXISTS "summary";""")
+    }
+
+    @Test
+    fun `skipped column drop remains pending after snapshot advancement`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = true)),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val safeResult = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = false)),
+            settings = settings,
+        )
+        assertFalse("""DROP COLUMN IF EXISTS "summary""" in safeResult.sql)
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = safeResult.entities,
+            schema = safeResult.snapshotSchema,
+            settings = settings,
+        )
+
+        val destructiveResult = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(extraField = false)),
+            settings = settings.copy(allowDestructiveChanges = true),
+        )
+
+        assertContains(destructiveResult.sql, """ALTER TABLE "book" DROP COLUMN IF EXISTS "summary";""")
+    }
+
+    @Test
+    fun `database comparison only drops unknown columns when destructive changes are enabled`() {
+        val databaseName = "jimmer_ddl_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:h2:mem:$databaseName;DB_CLOSE_DELAY=-1"
+        DriverManager.getConnection(jdbcUrl).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute(
+                    """
+                        CREATE TABLE book (
+                            id BIGINT NOT NULL PRIMARY KEY,
+                            title VARCHAR NOT NULL,
+                            subtitle VARCHAR,
+                            summary VARCHAR
+                        )
+                    """.trimIndent()
+                )
+            }
+        }
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.H2,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            compareDatabase = true,
+            jdbc = JimmerDdlJdbcSettings(url = jdbcUrl),
+        )
+
+        val safeResult = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity()),
+            settings = settings,
+        )
+        val destructiveResult = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity()),
+            settings = settings.copy(allowDestructiveChanges = true),
+        )
+
+        assertFalse("""DROP COLUMN IF EXISTS "SUMMARY""" in safeResult.sql)
+        assertContains(destructiveResult.sql, """ALTER TABLE "book" DROP COLUMN IF EXISTS "SUMMARY";""")
+    }
+
+    @Test
+    fun `renamed property column preserves the old column by default`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(titleColumnName = "book_title")),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val renamed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(titleColumnName = "title")),
+            settings = settings,
+        )
+
+        assertContains(renamed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "title"""")
+        assertFalse("""DROP COLUMN IF EXISTS "book_title""" in renamed.sql)
+    }
+
+    @Test
+    fun `renamed property column drops the old column when destructive changes are enabled`() {
+        val outputDir = createTempDirectory(prefix = "jimmer-ddl-test")
+            .toFile()
+            .resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        val settings = JimmerDdlCompilerSettings(
+            databaseType = DatabaseType.POSTGRESQL,
+            outputFormat = JimmerDdlOutputFormat.PLAIN,
+            outputDir = outputDir.absolutePath,
+            compareDatabase = false,
+            allowDestructiveChanges = true,
+        )
+        val original = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(titleColumnName = "book_title")),
+            settings = settings,
+        )
+        JimmerDdlEntityTableSnapshot.writeSnapshot(
+            entities = original.entities,
+            schema = original.snapshotSchema,
+            settings = settings,
+        )
+
+        val renamed = JimmerDdlCompiler.compile(
+            classes = listOf(bookEntity(titleColumnName = "title")),
+            settings = settings,
+        )
+
+        assertContains(renamed.sql, """ALTER TABLE "book" ADD COLUMN IF NOT EXISTS "title"""")
+        assertContains(renamed.sql, """ALTER TABLE "book" DROP COLUMN IF EXISTS "book_title";""")
     }
 
     @Test
@@ -684,6 +937,7 @@ class JimmerDdlCompilerTest {
         tableName: String = "book",
         extraField: Boolean = false,
         titleTypeName: String = "String",
+        titleColumnName: String = "title",
     ): TestClass {
         return TestClass(
             simpleName = simpleName,
@@ -700,7 +954,8 @@ class JimmerDdlCompilerTest {
                     name = "title",
                     type = TestType(titleTypeName),
                     typeName = titleTypeName,
-                    annotations = listOf(column("title")),
+                    annotations = listOf(column(titleColumnName)),
+                    columnName = titleColumnName,
                 ),
                 TestField(
                     name = "subtitle",


### PR DESCRIPTION
## Problem

The DDL compiler stores every entity mapping and table schema in one Git-tracked properties file, so unrelated entity changes rewrite the same snapshot and frequently conflict across branches.

The compiler also hard-coded destructive schema diffs to `true`. Removing or renaming an entity column could therefore emit `DROP COLUMN` by default, and inferred table renames bypassed the diff option entirely. Conversely, database comparison filtered unknown physical columns, so an explicit destructive run could not remove them.

This supersedes #1466 with safe defaults and additional regression coverage.

## Changes

- Store the durable schema baseline as independent `.jimmer-ddl/entity-table-snapshot/<table>.properties` lockfiles.
- Keep the optional source fingerprint in disposable `build/jimmer-ddl` state instead of structural lockfiles.
- Skip unchanged lockfile writes, remove stale lockfiles, and stage generated lockfiles as a directory under generated resources.
- Add `jimmerDdl.allowDestructiveChanges`, defaulting to `false`, to shared settings, profiles, KSP options, and APT supported options.
- Gate dropped columns/constraints and inferred table renames behind the explicit opt-in.
- Preserve skipped destructive state in offline snapshots so a later opt-in can still emit the pending drop.
- Include unknown physical columns in database comparison so the option behaves consistently against a real database.
- Document the data-loss risk and consumer responsibility when destructive generation is enabled.
- Upgrade active LSI and DDL generator artifacts to `2026.07.30`; keep archived dialect artifacts on `2026.07.15.2`.

The former aggregate `entity-table-snapshot.properties` format is replaced; this PR intentionally does not add a compatibility reader.

## Architecture context

The compiler uses [LSI](https://github.com/zjarlin/lsi) as an abstraction over metaprogramming symbols from APT and KSP. Its role is analogous to AndroidX Room's [compiler processing abstraction](https://github.com/androidx/androidx/tree/androidx-main/room/room-compiler-processing), commonly consumed as:

```kotlin
implementation("androidx.room:room-compiler-processing:<version>")
```

This is an architectural comparison, not a Room dependency: Jimmer DDL currently uses LSI. LSI may eventually unify more preprocessing environments and even provide shared foundations for DTO-language processing, but the community cannot pause current compiler work while that larger architecture evolves. This PR therefore targets the published LSI boundary that exists today.

[DDL generator](https://github.com/zjarlin/ddlgenerator) remains the separate schema model, diff planner, and dialect-rendering layer. Keeping symbol processing and DDL planning behind these two focused libraries lets this compiler support both APT and KSP without duplicating the schema logic.

## Published dependencies

- LSI `2026.07.30`: [core](https://repo.maven.apache.org/maven2/site/addzero/lsi-core/2026.07.30/lsi-core-2026.07.30.pom), [KSP](https://repo.maven.apache.org/maven2/site/addzero/lsi-ksp/2026.07.30/lsi-ksp-2026.07.30.pom), [APT](https://repo.maven.apache.org/maven2/site/addzero/lsi-apt/2026.07.30/lsi-apt-2026.07.30.pom)
- DDL generator `2026.07.30`: [core](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-core/2026.07.30/ddlgenerator-core-2026.07.30.pom), [LSI adaptor](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-lsi-adaptor/2026.07.30/ddlgenerator-lsi-adaptor-2026.07.30.pom), [PostgreSQL](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-dialect-postgresql/2026.07.30/ddlgenerator-dialect-postgresql-2026.07.30.pom), [MySQL](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-dialect-mysql/2026.07.30/ddlgenerator-dialect-mysql-2026.07.30.pom), [H2](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-dialect-h2/2026.07.30/ddlgenerator-dialect-h2-2026.07.30.pom)

## Verification

- Base: `babyfish-ct/jimmer@e45291e17d27c01073e413984df2e8046e114b29`
- `./gradlew :jimmer-ddl-compiler:test --rerun-tasks` (20 tests, 0 failures)
- `./gradlew :jimmer-ddl-compiler:check --rerun-tasks`
- `./gradlew :jimmer-ddl-compiler:publishToMavenLocal`
- H2 database comparison verifies unknown columns are retained by default and dropped only after explicit opt-in.
- Offline snapshot tests verify removed columns and column/table renames in both safe and destructive modes.
- A real Kotlin `2.1.20` / KSP `2.1.20-2.0.0` smoke project using the Maven Local compiler generated the per-table snapshot; removing `summary` emitted no drop with the default option, while an explicit opt-in emitted `ALTER TABLE "book" DROP COLUMN IF EXISTS "summary";`.
- APT generation, per-table lockfile isolation, stale lockfile cleanup, build-only source fingerprint, and recursive `@Embeddable` tests pass.

## Existing dependency note

Both the previous `2026.07.15.2` and the proposed `2026.07.30` addzero POMs declare `kotlin-stdlib:2.4.20-Beta1` (and LSI KSP declares `symbol-processing-api:2.3.9`), while Jimmer builds with Kotlin `2.1.20`. The compiler module already uses `-Xskip-metadata-version-check`; this PR does not introduce or resolve that existing dependency-version mismatch.

This upstream-only rework does not include OKM-specific Gradle snapshot syncing, Flyway execution, application restart, or business API changes.
