### PR TITLE
fix(core): allow formulas to depend on transient resolvers

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutablePropImpl.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/impl/ImmutablePropImpl.java
@@ -1717,6 +1717,7 @@ class ImmutablePropImpl implements ImmutableProp, ImmutablePropImplementor {
             ImmutableType targetType = prop.getTargetType();
             if (i + 1 == len) {
                 boolean isValid = prop.isFormula() ||
+                        prop.hasTransientResolver() ||
                         len > 1 ||
                         prop.hasStorage() ||
                         prop.isReferenceList(TargetLevel.PERSISTENT);
@@ -1726,7 +1727,8 @@ class ImmutablePropImpl implements ImmutableProp, ImmutablePropImplementor {
                                     formulaProp +
                                     "\", its dependency property \"" +
                                     prop +
-                                    "\" must be column-mapped property or another formula property"
+                                    "\" must be column-mapped property, another formula property " +
+                                    "or transient property with resolver"
                     );
                 }
             } else if (targetType == null) {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/FetcherTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/FetcherTest.kt
@@ -12,6 +12,7 @@ import org.babyfish.jimmer.sql.kt.model.classic.book.fetchBy
 import org.babyfish.jimmer.sql.kt.model.classic.book.id
 import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
 import org.babyfish.jimmer.sql.kt.model.classic.store.fetchBy
+import org.babyfish.jimmer.sql.kt.model.classic.store.id
 import org.babyfish.jimmer.sql.kt.model.embedded.Dependency
 import org.babyfish.jimmer.sql.kt.model.embedded.dto.DependencyView
 import org.babyfish.jimmer.sql.kt.model.fetcher.Issue1434Message
@@ -619,6 +620,32 @@ class FetcherTest : AbstractQueryTest() {
                     |--->--->"avgPrice":80.333333333333,
                     |--->--->"website":null
                     |--->}
+                    |]""".trimMargin()
+            )
+        }
+    }
+
+    @Test
+    fun testFormulaBasedOnTransientResolver() {
+        executeAndExpect(
+            sqlClient.createQuery(BookStore::class) {
+                orderBy(table.id)
+                select(table.fetchBy {
+                    avgPriceText()
+                })
+            }
+        ) {
+            sql("select tb_1_.ID from BOOK_STORE tb_1_ order by tb_1_.ID asc")
+            statement(1).sql(
+                "select tb_1_.STORE_ID, coalesce(avg(tb_1_.PRICE), ?) " +
+                    "from BOOK tb_1_ " +
+                    "where tb_1_.STORE_ID in (?, ?) " +
+                    "group by tb_1_.STORE_ID"
+            )
+            rows(
+                """[
+                    |--->{"id":1,"avgPriceText":"58.500000000000"},
+                    |--->{"id":2,"avgPriceText":"80.333333333333"}
                     |]""".trimMargin()
             )
         }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/TypedTransientResolverTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/query/TypedTransientResolverTest.kt
@@ -7,6 +7,7 @@ import org.babyfish.jimmer.sql.kt.common.AbstractQueryTest
 import org.babyfish.jimmer.sql.kt.common.createCache
 import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
 import org.babyfish.jimmer.sql.kt.model.classic.store.fetchBy
+import org.babyfish.jimmer.sql.kt.model.classic.store.id
 import org.junit.Test
 
 class TypedTransientResolverTest : AbstractQueryTest() {
@@ -99,6 +100,46 @@ class TypedTransientResolverTest : AbstractQueryTest() {
                         "--->{\"id\":1,\"name\":\"O'REILLY\",\"version\":0,\"website\":null,\"nameWithVersion\":\"O'REILLY#0\"}," +
                         "--->{\"id\":2,\"name\":\"MANNING\",\"version\":0,\"website\":null,\"nameWithVersion\":\"MANNING#0\"}" +
                         "]"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testFormulaBasedOnCachedTransientResolver() {
+        val cachedSqlClient = sqlClient {
+            setCacheFactory(
+                object : KCacheFactory {
+                    override fun createResolverCache(prop: ImmutableProp): Cache<*, *> =
+                        createCache<Any, Any>(prop)
+                }
+            )
+        }
+        for (i in 0..1) {
+            executeAndExpect(
+                cachedSqlClient.createQuery(BookStore::class) {
+                    orderBy(table.id)
+                    select(
+                        table.fetchBy {
+                            avgPriceText()
+                        }
+                    )
+                }
+            ) {
+                sql("select tb_1_.ID from BOOK_STORE tb_1_ order by tb_1_.ID asc")
+                if (i == 0) {
+                    statement(1).sql(
+                        "select tb_1_.STORE_ID, coalesce(avg(tb_1_.PRICE), ?) " +
+                            "from BOOK tb_1_ " +
+                            "where tb_1_.STORE_ID in (?, ?) " +
+                            "group by tb_1_.STORE_ID"
+                    )
+                }
+                rows(
+                    """[
+                        |--->{"id":1,"avgPriceText":"58.500000000000"},
+                        |--->{"id":2,"avgPriceText":"80.333333333333"}
+                        |]""".trimMargin()
                 )
             }
         }

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/classic/store/BookStore.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/classic/store/BookStore.kt
@@ -1,5 +1,6 @@
 package org.babyfish.jimmer.sql.kt.model.classic.store
 
+import org.babyfish.jimmer.Formula
 import org.babyfish.jimmer.sql.*
 import org.babyfish.jimmer.sql.kt.model.calc.BookStoreAvgPriceResolver
 import org.babyfish.jimmer.sql.kt.model.calc.BookStoreNameWithVersionResolver
@@ -40,6 +41,10 @@ interface BookStore {
      */
     @Transient(BookStoreAvgPriceResolver::class)
     val avgPrice: BigDecimal
+
+    @Formula(dependencies = ["avgPrice"])
+    val avgPriceText: String
+        get() = avgPrice.toPlainString()
 
     @Transient(BookStoreNameWithVersionResolver::class)
     val nameWithVersion: String

--- a/project/jimmer-sql-test/jimmer-sql-test-model/src/main/java/org/babyfish/jimmer/sql/model/BookStore.java
+++ b/project/jimmer-sql-test/jimmer-sql-test-model/src/main/java/org/babyfish/jimmer/sql/model/BookStore.java
@@ -41,6 +41,11 @@ public interface BookStore {
     @Transient(BookStoreAvgPriceResolver.class)
     BigDecimal avgPrice();
 
+    @Formula(dependencies = "avgPrice")
+    default String avgPriceText() {
+        return avgPrice().toPlainString();
+    }
+
     @Transient(BookStoreNameWithVersionResolver.class)
     String nameWithVersion();
 

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/FormulaTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/fetcher/FormulaTest.java
@@ -7,6 +7,41 @@ import org.junit.jupiter.api.Test;
 public class FormulaTest extends AbstractQueryTest {
 
     @Test
+    public void testFormulaBasedOnTransientResolver() {
+        BookStoreTable table = BookStoreTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(table)
+                        .orderBy(table.name().asc())
+                        .select(
+                                table.fetch(
+                                        BookStoreFetcher.$.avgPriceText()
+                                )
+                        ),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID " +
+                                    "from BOOK_STORE tb_1_ " +
+                                    "order by tb_1_.NAME asc"
+                    );
+                    ctx.statement(1).sql(
+                            "select tb_1_.ID, coalesce(round(avg(tb_2_.PRICE), 2), ?) " +
+                                    "from BOOK_STORE tb_1_ " +
+                                    "left join BOOK tb_2_ on tb_1_.ID = tb_2_.STORE_ID " +
+                                    "where tb_1_.ID in (?, ?) " +
+                                    "group by tb_1_.ID"
+                    );
+                    ctx.rows(
+                            "[" +
+                                    "--->{\"id\":\"2fa3955e-3e83-49b9-902e-0465c109c779\",\"avgPriceText\":\"80.33\"}," +
+                                    "--->{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\",\"avgPriceText\":\"58.50\"}" +
+                                    "]"
+                    );
+                }
+        );
+    }
+
+    @Test
     public void testHasStore() {
         BookTable table = BookTable.$;
         executeAndExpect(


### PR DESCRIPTION
## Problem

Formula dependency validation rejects resolver-backed transient properties, even though the fetcher and transient resolver pipeline can load them before formula evaluation.

## Changes

- Allow a formula dependency whose property has a transient resolver.
- Add Java APT and Kotlin KSP query coverage.
- Verify formula evaluation when the transient resolver value comes from cache.

## Verification

- `./gradlew :jimmer-core:test :jimmer-sql:test :jimmer-sql-kotlin:test --console=plain`
- `./gradlew :jimmer-core:publishToMavenLocal :jimmer-sql:publishToMavenLocal :jimmer-sql-kotlin:publishToMavenLocal --console=plain`