### PR TITLE
fix: reject DTO imports shadowed by built-in types

### DIFF
--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/Importing.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/Importing.java
@@ -62,12 +62,22 @@ class Importing {
                             "\" cannot be imported because it is built-in type"
             );
         }
-        if (typeMap.put(alias.getText(), qualifiedName) != null) {
+        String aliasText = alias.getText();
+        if (STANDARD_TYPES.containsKey(aliasText)) {
+            throw ctx.exception(
+                    alias.getLine(),
+                    alias.getCharPositionInLine(),
+                    "\"" +
+                            aliasText +
+                            "\" cannot be used as imported alias because it is built-in type"
+            );
+        }
+        if (typeMap.put(aliasText, qualifiedName) != null) {
             throw ctx.exception(
                     alias.getLine(),
                     alias.getCharPositionInLine(),
                     "Duplicated imported alias \"" +
-                            alias.getText() +
+                            aliasText +
                             "\""
             );
         }

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1095,6 +1095,31 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testImportedAliasCannotConflictWithBuiltInType() {
+        DtoAstException simpleNameEx = Assertions.assertThrows(
+                DtoAstException.class,
+                () -> MyDtoCompiler.book(
+                        "import com.example.Int\n" +
+                                "BookView { value: Int }"
+                )
+        );
+        Assertions.assertTrue(simpleNameEx.getMessage().contains(
+                "\"Int\" cannot be used as imported alias because it is built-in type"
+        ));
+
+        DtoAstException renamedEx = Assertions.assertThrows(
+                DtoAstException.class,
+                () -> MyDtoCompiler.book(
+                        "import com.example.CustomType as Int\n" +
+                                "BookView { value: Int }"
+                )
+        );
+        Assertions.assertTrue(renamedEx.getMessage().contains(
+                "\"Int\" cannot be used as imported alias because it is built-in type"
+        ));
+    }
+
+    @Test
     public void testAnnotation() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
                 "import org.framework.annotations.{A, B, C, D}\n" +


### PR DESCRIPTION
fixes #1470