### PR TITLE
fix(DTO): report correct literal kind in !where diagnostics

### DIFF
--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
@@ -492,7 +492,7 @@ class PropConfigBuilder<T extends BaseType, P extends BaseProp> {
                 throw ctx.exception(
                         value.start.getLine(),
                         value.start.getCharPositionInLine(),
-                        "Illegal string literal, the left operand is not boolean"
+                        "Illegal boolean literal, the left operand is not boolean"
                 );
             }
             return "true".equals(value.booleanToken.getText());
@@ -526,13 +526,11 @@ class PropConfigBuilder<T extends BaseType, P extends BaseProp> {
                     }
                     return bi;
                 default:
-                    if (simplePropType != SimplePropType.STRING) {
-                        throw ctx.exception(
-                                value.start.getLine(),
-                                value.start.getCharPositionInLine(),
-                                "Illegal integer literal, the left operand is not integer"
-                        );
-                    }
+                    throw ctx.exception(
+                            value.start.getLine(),
+                            value.start.getCharPositionInLine(),
+                            "Illegal integer literal, the left operand is not integer"
+                    );
             }
         }
         switch (simplePropType) {

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1468,6 +1468,44 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testWhereBooleanLiteralOnStringOperandReportsBooleanDiagnostic() {
+        DtoAstException ex = Assertions.assertThrows(DtoAstException.class, () -> {
+            MyDtoCompiler.treeNode(
+                    "TreeNodeView {\n" +
+                            "    name\n" +
+                            "    !where(name = true)\n" +
+                            "    childNodes*\n" +
+                            "}\n"
+            );
+        });
+        Assertions.assertEquals(
+                "file:/User/test/TreeNode.dto:3 : Illegal boolean literal, the left operand is not boolean\n" +
+                        "    !where(name = true)\n" +
+                        "                  ^",
+                ex.getMessage()
+        );
+    }
+
+    @Test
+    public void testWhereIntegerLiteralOnStringOperandReportsIntegerDiagnostic() {
+        DtoAstException ex = Assertions.assertThrows(DtoAstException.class, () -> {
+            MyDtoCompiler.treeNode(
+                    "TreeNodeView {\n" +
+                            "    name\n" +
+                            "    !where(name = 10)\n" +
+                            "    childNodes*\n" +
+                            "}\n"
+            );
+        });
+        Assertions.assertEquals(
+                "file:/User/test/TreeNode.dto:3 : Illegal integer literal, the left operand is not integer\n" +
+                        "    !where(name = 10)\n" +
+                        "                  ^",
+                ex.getMessage()
+        );
+    }
+
+    @Test
     public void testIssue1036() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.treeNode(
                 "TreeNodeView {\n" +


### PR DESCRIPTION
## Summary

`PropConfigBuilder#createPropValue` reported the wrong literal kind for two mismatch paths:

1. A boolean literal on a non-boolean operand used the copy-pasted message `Illegal string literal, the left operand is not boolean`.
2. An integer literal on a `STRING` operand skipped the integer-branch error and fell through to the float/decimal switch, producing `Illegal float/decimal literal...` even though no float literal was present.

Both failures still rejected the DTO; only the diagnostic text was wrong.

## Changes

- Boolean mismatch message: `Illegal boolean literal, the left operand is not boolean`
- Integer branch `default`: always throw `Illegal integer literal, the left operand is not integer` (including `STRING`), so control no longer falls through to the float/decimal path

## Test plan

- [x] RED then GREEN:
  - `DtoCompilerTest.testWhereBooleanLiteralOnStringOperandReportsBooleanDiagnostic`
  - `DtoCompilerTest.testWhereIntegerLiteralOnStringOperandReportsIntegerDiagnostic`
- [x] `./gradlew :jimmer-dto-compiler:test` (module suite GREEN)

Fixes #1473