### PR TITLE
Fix SQL Server for-update lock hint rendering

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
@@ -8,6 +8,7 @@ import org.babyfish.jimmer.sql.ast.impl.associated.VirtualPredicateMergedResult;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbol;
+import org.babyfish.jimmer.sql.ast.impl.query.ForUpdate;
 import org.babyfish.jimmer.sql.ast.impl.query.MergedBaseQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableStatementImplementor;
 import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderMode;
@@ -29,6 +30,8 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
     private final JSqlClientImplementor sqlClient;
 
     private StatementFrame statementFrame;
+
+    private ForUpdateFrame forUpdateFrame;
 
     private JoinTypeMergeFrame joinTypeMergeFrame;
 
@@ -95,6 +98,20 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     public void popStatement() {
         this.statementFrame = this.statementFrame.parent;
+    }
+
+    public void pushForUpdate(@Nullable ForUpdate forUpdate) {
+        this.forUpdateFrame = new ForUpdateFrame(this.forUpdateFrame, forUpdate);
+    }
+
+    public void popForUpdate() {
+        this.forUpdateFrame = this.forUpdateFrame.parent;
+    }
+
+    @Nullable
+    public ForUpdate getForUpdate() {
+        ForUpdateFrame frame = this.forUpdateFrame;
+        return frame != null ? frame.forUpdate : null;
     }
 
     public void pushRenderedBaseTable(RealTable realBaseTable) {
@@ -596,6 +613,19 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
             builder.append(frame.statement);
         }
         return builder.toString();
+    }
+
+    private static class ForUpdateFrame {
+
+        final ForUpdateFrame parent;
+
+        @Nullable
+        final ForUpdate forUpdate;
+
+        private ForUpdateFrame(ForUpdateFrame parent, @Nullable ForUpdate forUpdate) {
+            this.parent = parent;
+            this.forUpdate = forUpdate;
+        }
     }
 
     private static class BaseTableRenderFrame {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
@@ -11,6 +11,7 @@ import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.table.*;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.PropExpressionImplementor;
+import org.babyfish.jimmer.sql.dialect.ForUpdateRenderPosition;
 import org.babyfish.jimmer.sql.dialect.OracleDialect;
 import org.babyfish.jimmer.sql.fetcher.Field;
 import org.babyfish.jimmer.sql.fetcher.impl.FetcherSelection;
@@ -221,6 +222,7 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
         SqlBuilder builder = abstractBuilder.assertSimple();
         AstContext astContext = builder.getAstContext();
         astContext.pushStatement(getMutableQuery());
+        astContext.pushForUpdate(data.forUpdate);
         try {
             if (data.withoutSortingAndPaging || astContext.isQueryWithoutSortingAndPaging() ||
                     (data.offset == 0 && data.limit == Integer.MAX_VALUE)) {
@@ -247,10 +249,13 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
                     });
                 }
             }
-            if (data.forUpdate != null) {
+            if (data.forUpdate != null &&
+                    getSqlClient().getDialect().getForUpdateRenderPosition() ==
+                            ForUpdateRenderPosition.QUERY_SUFFIX) {
                 getSqlClient().getDialect().renderForUpdate(builder, data.forUpdate);
             }
         } finally {
+            astContext.popForUpdate();
             astContext.popStatement();
         }
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
@@ -395,6 +395,10 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
     }
 
     private void renderForUpdate(SqlBuilder builder) {
+        renderForUpdate(builder, false);
+    }
+
+    private void renderForUpdate(SqlBuilder builder, boolean derivedTable) {
         if (parent != null) {
             return;
         }
@@ -405,6 +409,11 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
         }
         Dialect dialect = astContext.getSqlClient().getDialect();
         if (dialect.getForUpdateRenderPosition() == ForUpdateRenderPosition.TABLE_ALIAS_SUFFIX) {
+            if (derivedTable) {
+                throw new IllegalArgumentException(
+                        "For update at table alias suffix is not supported for derived tables"
+                );
+            }
             dialect.renderForUpdate(builder, forUpdate);
         }
     }
@@ -591,12 +600,14 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
         }
         if (aliasOnly) {
             builder.sqlAlias(this);
+            renderForUpdate(builder, false);
         } else {
             builder.enter(AbstractSqlBuilder.ScopeType.SUB_QUERY);
             baseTableImpl.renderBaseQueryCore(builder);
             builder.leave();
             if (!baseTableImpl.isCte()) {
                 builder.sql(" ").sqlAlias(this);
+                renderForUpdate(builder, true);
             }
         }
         if (!childTables.isEmpty()) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/RealTableImpl.java
@@ -17,12 +17,15 @@ import org.babyfish.jimmer.sql.ast.impl.base.BaseQueryRead;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseQueryReadSupport;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
+import org.babyfish.jimmer.sql.ast.impl.query.ForUpdate;
 import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderContext;
 import org.babyfish.jimmer.sql.ast.impl.query.TableUsageVisitor;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.util.AbstractDataManager;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
+import org.babyfish.jimmer.sql.dialect.Dialect;
+import org.babyfish.jimmer.sql.dialect.ForUpdateRenderPosition;
 import org.babyfish.jimmer.sql.meta.*;
 import org.babyfish.jimmer.sql.runtime.LogicalDeletedBehavior;
 import org.babyfish.jimmer.sql.runtime.SqlBuilder;
@@ -323,6 +326,7 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                         .sql(tableImplementor.getImmutableType().getTableName(builder.getAstContext().getSqlClient().getMetadataStrategy()))
                         .sql(" ")
                         .sqlAlias(this);
+                renderForUpdate(builder);
                 filterPredicate = null;
             }
             if (filterPredicate != null) {
@@ -365,6 +369,7 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                     .sql(rootType.getTableName(strategy))
                     .sql(" ")
                     .sql(rootAlias);
+            renderForUpdate(builder);
         } else {
             builder
                     .sql(rootType.getTableName(strategy))
@@ -387,6 +392,21 @@ class RealTableImpl extends AbstractDataManager<RealTable.Key, RealTable> implem
                 TableImplementor.RenderMode.NORMAL
         );
         renderJoinedTypeStageJoins(builder, tableImplementor, rootType, rootAlias, strategy);
+    }
+
+    private void renderForUpdate(SqlBuilder builder) {
+        if (parent != null) {
+            return;
+        }
+        AstContext astContext = builder.getAstContext();
+        ForUpdate forUpdate = astContext.getForUpdate();
+        if (forUpdate == null) {
+            return;
+        }
+        Dialect dialect = astContext.getSqlClient().getDialect();
+        if (dialect.getForUpdateRenderPosition() == ForUpdateRenderPosition.TABLE_ALIAS_SUFFIX) {
+            dialect.renderForUpdate(builder, forUpdate);
+        }
     }
 
     private void renderJoinedTypeQueryStageJoins(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -600,5 +600,9 @@ public interface Dialect extends SqlTypeStrategy {
         return rs.getTimestamp(col);
     }
 
+    default ForUpdateRenderPosition getForUpdateRenderPosition() {
+        return ForUpdateRenderPosition.QUERY_SUFFIX;
+    }
+
     void renderForUpdate(AbstractSqlBuilder<?> builder, ForUpdate forUpdate);
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/ForUpdateRenderPosition.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/ForUpdateRenderPosition.java
@@ -1,0 +1,6 @@
+package org.babyfish.jimmer.sql.dialect;
+
+public enum ForUpdateRenderPosition {
+    QUERY_SUFFIX,
+    TABLE_ALIAS_SUFFIX
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SqlServerDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SqlServerDialect.java
@@ -218,6 +218,11 @@ public class SqlServerDialect extends DefaultDialect {
     }
 
     @Override
+    public ForUpdateRenderPosition getForUpdateRenderPosition() {
+        return ForUpdateRenderPosition.TABLE_ALIAS_SUFFIX;
+    }
+
+    @Override
     public void renderForUpdate(AbstractSqlBuilder<?> builder, ForUpdate forUpdate) {
         if (forUpdate.getLockMode() != LockMode.UPDATE) {
             throw new IllegalArgumentException("SqlServer only supports LockMode.UPDATE");

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/ForUpdateTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/ForUpdateTest.java
@@ -1,0 +1,47 @@
+package org.babyfish.jimmer.sql.query;
+
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.dialect.SQLiteDialect;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ForUpdateTest extends AbstractQueryTest {
+
+    @Test
+    public void testDefaultRenderPosition() {
+        BookTable book = BookTable.$;
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(book)
+                        .where(book.name().eq("Learning GraphQL"))
+                        .select(book.id())
+                        .forUpdate(),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID from BOOK tb_1_ " +
+                                    "where tb_1_.NAME = ? for update"
+                    );
+                    ctx.variables("Learning GraphQL");
+                }
+        );
+    }
+
+    @Test
+    public void testSQLiteDoesNotSupportForUpdate() {
+        BookTable book = BookTable.$;
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jdbc(con ->
+                        getSqlClient(it -> {
+                            it.setDialect(new SQLiteDialect());
+                        })
+                                .createQuery(book)
+                                .select(book.id())
+                                .forUpdate()
+                                .execute(con)
+                )
+        );
+        Assertions.assertEquals("Sqlite does not support `for update`", ex.getMessage());
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
@@ -2,9 +2,13 @@ package org.babyfish.jimmer.sql.sqlserver;
 
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.query.LockMode;
+import org.babyfish.jimmer.sql.ast.query.LockWait;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.dialect.SqlServerDialect;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
 import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.model.inheritance.joinedtable.OrganizationTable;
 import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
 import org.babyfish.jimmer.sql.runtime.Executor;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
@@ -31,6 +35,100 @@ public class SqlServerQueryTest extends AbstractQueryTest {
                                     "where tb_1_.NAME = ? order by tb_1_.ID asc"
                     );
                     ctx.variables("Learning GraphQL");
+                }
+        );
+    }
+
+    @Test
+    public void testForUpdateWithJoin() {
+        BookTable book = BookTable.$;
+        executeAndExpect(
+                sqlOnlyClient()
+                        .createQuery(book)
+                        .where(book.store().name().eq("MANNING"))
+                        .select(book.id())
+                        .forUpdate(),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID from BOOK tb_1_ with(updlock, rowlock) " +
+                                    "inner join BOOK_STORE tb_2_ on tb_1_.STORE_ID = tb_2_.ID " +
+                                    "where tb_2_.NAME = ?"
+                    );
+                    ctx.variables("MANNING");
+                }
+        );
+    }
+
+    @Test
+    public void testForUpdateDoesNotLeakIntoSubQuery() {
+        JSqlClient sqlClient = sqlOnlyClient();
+        BookStoreTable store = BookStoreTable.$;
+        BookTable book = BookTable.$;
+        executeAndExpect(
+                sqlClient
+                        .createQuery(store)
+                        .where(
+                                sqlClient
+                                        .createSubQuery(book)
+                                        .where(
+                                                book.store().eq(store),
+                                                book.name().eq("Learning GraphQL")
+                                        )
+                                        .select(book.id())
+                                        .exists()
+                        )
+                        .select(store.id())
+                        .forUpdate(),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID from BOOK_STORE tb_1_ with(updlock, rowlock) " +
+                                    "where exists(" +
+                                    "select 1 from BOOK tb_2_ " +
+                                    "where tb_2_.STORE_ID = tb_1_.ID and tb_2_.NAME = ?" +
+                                    ")"
+                    );
+                    ctx.variables("Learning GraphQL");
+                }
+        );
+    }
+
+    @Test
+    public void testForUpdateWithSkipLocked() {
+        BookTable book = BookTable.$;
+        executeAndExpect(
+                sqlOnlyClient()
+                        .createQuery(book)
+                        .where(book.name().eq("Learning GraphQL"))
+                        .select(book.id())
+                        .forUpdate(LockMode.UPDATE, LockWait.SKIP_LOCKED),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID from BOOK tb_1_ with(updlock, rowlock, readpast) " +
+                                    "where tb_1_.NAME = ?"
+                    );
+                    ctx.variables("Learning GraphQL");
+                }
+        );
+    }
+
+    @Test
+    public void testForUpdateWithJoinedInheritanceRoot() {
+        OrganizationTable organization = OrganizationTable.$;
+        executeAndExpect(
+                sqlOnlyClient()
+                        .createQuery(organization)
+                        .where(organization.id().eq(200L))
+                        .select(organization.id(), organization.taxCode())
+                        .forUpdate(),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID, tb_1__sub.TAX_CODE " +
+                                    "from JOINED_CLIENT tb_1_ with(updlock, rowlock) " +
+                                    "inner join JOINED_ORGANIZATION tb_1__sub " +
+                                    "on tb_1_.ID = tb_1__sub.ID " +
+                                    "where tb_1_.ID = ? and tb_1_.CLIENT_TYPE = ?"
+                    );
+                    ctx.variables(200L, "ORG");
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
@@ -1,0 +1,63 @@
+package org.babyfish.jimmer.sql.sqlserver;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.common.AbstractQueryTest;
+import org.babyfish.jimmer.sql.dialect.SqlServerDialect;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.Executor;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.Collections;
+
+public class SqlServerQueryTest extends AbstractQueryTest {
+
+    @Test
+    public void testForUpdateWithOrderBy() {
+        BookTable book = BookTable.$;
+        executeAndExpect(
+                sqlOnlyClient()
+                        .createQuery(book)
+                        .where(book.name().eq("Learning GraphQL"))
+                        .orderBy(book.id())
+                        .select(book.id())
+                        .forUpdate(),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.ID from BOOK tb_1_ with(updlock, rowlock) " +
+                                    "where tb_1_.NAME = ? order by tb_1_.ID asc"
+                    );
+                    ctx.variables("Learning GraphQL");
+                }
+        );
+    }
+
+    private JSqlClient sqlOnlyClient() {
+        return getSqlClient(it -> {
+            it.setDialect(new SqlServerDialect());
+            it.setExecutor(new Executor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <R> R execute(Args<R> args) {
+                    getExecutions().add(Execution.simple(args.sql, args.purpose, args.variables));
+                    return (R) Collections.emptyList();
+                }
+
+                @Override
+                public BatchContext executeBatch(
+                        Connection con,
+                        String sql,
+                        ImmutableProp generatedIdProp,
+                        ExecutionPurpose purpose,
+                        JSqlClientImplementor sqlClient,
+                        boolean constraintViolationTranslatable
+                ) {
+                    throw new AssertionError("Batch execution is not expected");
+                }
+            });
+        });
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlserver/SqlServerQueryTest.java
@@ -4,6 +4,7 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.ast.query.LockMode;
 import org.babyfish.jimmer.sql.ast.query.LockWait;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable1;
 import org.babyfish.jimmer.sql.common.AbstractQueryTest;
 import org.babyfish.jimmer.sql.dialect.SqlServerDialect;
 import org.babyfish.jimmer.sql.model.BookStoreTable;
@@ -12,6 +13,7 @@ import org.babyfish.jimmer.sql.model.inheritance.joinedtable.OrganizationTable;
 import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
 import org.babyfish.jimmer.sql.runtime.Executor;
 import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -130,6 +132,52 @@ public class SqlServerQueryTest extends AbstractQueryTest {
                     );
                     ctx.variables(200L, "ORG");
                 }
+        );
+    }
+
+    @Test
+    public void testForUpdateWithCteRoot() {
+        JSqlClient sqlClient = sqlOnlyClient();
+        BookTable book = BookTable.$;
+        BaseTable1<BookTable> cte = sqlClient
+                .createBaseQuery(book)
+                .addSelect(book)
+                .asCteBaseTable();
+        executeAndExpect(
+                sqlClient
+                        .createQuery(cte)
+                        .select(cte.get_1().id())
+                        .forUpdate(),
+                ctx -> ctx.sql(
+                        "with tb_1_(c1) as (" +
+                                "select tb_2_.ID from BOOK tb_2_" +
+                                ") " +
+                                "select tb_1_.c1 from tb_1_ with(updlock, rowlock)"
+                )
+        );
+    }
+
+    @Test
+    public void testForUpdateWithDerivedTableRootIsRejected() {
+        JSqlClient sqlClient = sqlOnlyClient();
+        BookTable book = BookTable.$;
+        BaseTable1<BookTable> derivedTable = sqlClient
+                .createBaseQuery(book)
+                .addSelect(book)
+                .asBaseTable();
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jdbc(con ->
+                        sqlClient
+                                .createQuery(derivedTable)
+                                .select(derivedTable.get_1().id())
+                                .forUpdate()
+                                .execute(con)
+                )
+        );
+        Assertions.assertEquals(
+                "For update at table alias suffix is not supported for derived tables",
+                ex.getMessage()
         );
     }
 


### PR DESCRIPTION
## Summary

- add a dialect-neutral render position for `for update` clauses
- render SQL Server locking hints immediately after the current query root alias
- keep existing trailing `for update` behavior for other dialects
- preserve SQLite unsupported validation and reject unsupported derived-table roots explicitly

## Problem

SQL Server expresses pessimistic locking as a table hint. Jimmer currently appends the hint to the completed query:

```sql
select ...
from BOOK tb_1_
order by tb_1_.ID asc with(updlock, rowlock)
```

That placement is invalid in SQL Server. The hint must follow the table alias:

```sql
select ...
from BOOK tb_1_ with(updlock, rowlock)
order by tb_1_.ID asc
```

## Design

`Dialect#getForUpdateRenderPosition()` defaults to `QUERY_SUFFIX`. `SqlServerDialect` selects `TABLE_ALIAS_SUFFIX`. The current query stores its nullable lock request in a scoped AST frame, so joined tables and nested subqueries do not inherit the outer hint. CTE roots are supported, while derived-table roots are rejected because SQL Server cannot express an equivalent table hint on the derived table alias.

## Tests

Covered:

- ordered SQL Server query
- joined table root-only hinting
- nested-subquery isolation
- `SKIP_LOCKED` / `readpast`
- joined-inheritance roots
- CTE roots and derived-table rejection
- default trailing render position
- existing SQLite unsupported behavior

Verification:

```text
./gradlew :jimmer-sql:compileJava :jimmer-sql:test
BUILD SUCCESSFUL
```