### PR TITLE
Allow a base property to be referenced multiple times in specification

### DIFF
--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoTypeBuilder.java
@@ -378,26 +378,14 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         if (builders == null) {
             builders = new ArrayList<>();
             positivePropMap.put(baseProp, builders);
-        } else {
-            boolean valid = false;
-            if (builders.size() < 2) {
-                String oldFuncName = builders.get(0).getFuncName();
-                String newFuncName = propBuilder.getFuncName();
-                if (!Objects.equals(oldFuncName, newFuncName) &&
-                        ("flat".equals(oldFuncName) || Constants.QBE_FUNC_NAMES.contains(oldFuncName)) &&
-                        ("flat".equals(newFuncName) || Constants.QBE_FUNC_NAMES.contains(newFuncName))) {
-                    valid = true;
-                }
-            }
-            if (!valid) {
-                throw ctx.exception(
-                        propBuilder.getBaseLine(),
-                        propBuilder.getBaseColumn(),
-                        "Base property \"" +
-                                baseProp +
-                                "\" cannot be referenced too many times"
-                );
-            }
+        } else if (!isValidMultipleReference(builders, propBuilder)) {
+            throw ctx.exception(
+                    propBuilder.getBaseLine(),
+                    propBuilder.getBaseColumn(),
+                    "Base property \"" +
+                            baseProp +
+                            "\" cannot be referenced too many times"
+            );
         }
         builders.add(propBuilder);
         if (propBuilder.getAlias() != null) {
@@ -414,6 +402,23 @@ class DtoTypeBuilder<T extends BaseType, P extends BaseProp> {
         } else {
             flatPositiveProps.add(propBuilder);
         }
+    }
+
+    private boolean isValidMultipleReference(
+            List<DtoPropBuilder<T, P>> builders,
+            DtoPropBuilder<T, P> propBuilder
+    ) {
+        if (modifiers.contains(DtoModifier.SPECIFICATION)) {
+            return true;
+        }
+        if (builders.size() < 2) {
+            String oldFuncName = builders.get(0).getFuncName();
+            String newFuncName = propBuilder.getFuncName();
+            return !Objects.equals(oldFuncName, newFuncName) &&
+                    ("flat".equals(oldFuncName) || Constants.QBE_FUNC_NAMES.contains(oldFuncName)) &&
+                    ("flat".equals(newFuncName) || Constants.QBE_FUNC_NAMES.contains(newFuncName));
+        }
+        return false;
     }
 
     private void handleNegativeProp(DtoParser.NegativePropContext prop) {

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1202,6 +1202,44 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testReferenceTwiceInSpecification() {
+        DtoType<BaseType, BaseProp> dtoType = MyDtoCompiler.book(
+                "specification BookSpecification {\n" +
+                        "    name\n" +
+                        "    like(name) as nameLike\n" +
+                        "}"
+        ).get(0);
+        assertContentEquals(
+                "specification BookSpecification {" +
+                        "--->@optional name, " +
+                        "--->@optional like(name) as nameLike" +
+                        "}",
+                dtoType.toString()
+        );
+    }
+
+    @Test
+    public void testReferenceManyTimesInSpecification() {
+        DtoType<BaseType, BaseProp> dtoType = MyDtoCompiler.book(
+                "specification BookSpecification {\n" +
+                        "    ge(price)\n" +
+                        "    gt(price)\n" +
+                        "    lt(price)\n" +
+                        "    le(price)\n" +
+                        "}"
+        ).get(0);
+        assertContentEquals(
+                "specification BookSpecification {" +
+                        "--->@optional ge(price) as minPrice, " +
+                        "--->@optional gt(price) as minPriceExclusive, " +
+                        "--->@optional lt(price) as maxPriceExclusive, " +
+                        "--->@optional le(price) as maxPrice" +
+                        "}",
+                dtoType.toString()
+        );
+    }
+
+    @Test
     public void testDoc() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.treeNode(
                 "/**\n" +


### PR DESCRIPTION
Fixes #1316

Allow the same base property to be referenced multiple times in a `specification` DTO, e.g.

```
specification UserSpec {
   name
   like(name) as nameLike
}
```

Previously this failed to compile with `Base property "..." cannot be referenced too many times`.

Changes:
- `DtoTypeBuilder.handlePositiveProp0`: extracted the duplicate-reference validation into `isValidMultipleReference`. For specification DTOs, unlimited references to the same base property are now allowed (property aliases must still be unique). Non-specification DTOs keep the existing behavior.
- Added `testReferenceTwiceInSpecification` and `testReferenceManyTimesInSpecification` covering the issue example and multiple QBE functions on the same field.