### PR TITLE
Allow trailing DocComment at the end of a DTO body

### DIFF
--- a/project/jimmer-dto-compiler/src/main/antlr/org/babyfish/jimmer/dto/compiler/Dto.g4
+++ b/project/jimmer-dto-compiler/src/main/antlr/org/babyfish/jimmer/dto/compiler/Dto.g4
@@ -12,6 +12,7 @@ dto
     exportStatement?
     (importStatements += importStatement)*
     (dtoTypes += dtoType | fragments += dtoFragment)*
+    (trailingDoc = DocComment)?
     EOF
     ;
 
@@ -71,6 +72,7 @@ dtoBody
         )
         (',' | ';')?
     )*
+    (trailingDoc = DocComment)?
     '}'
     ;
 
@@ -86,7 +88,7 @@ explicitProp
 
 typesBlock
     :
-    '#types' '{' (typesElements += typesElement)* '}'
+    '#types' '{' (typesElements += typesElement)* (trailingDoc = DocComment)? '}'
     ;
 
 typesElement
@@ -140,7 +142,7 @@ macro
 
 aliasGroup
     :
-    pattern = aliasPattern '{' (macros += macro)* (props += positiveProp)* '}'
+    pattern = aliasPattern '{' (macros += macro)* (props += positiveProp)* (trailingDoc = DocComment)? '}'
     ;
 
 aliasPattern

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1234,6 +1234,74 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testTrailingDocComment() {
+        List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
+                "BookView {\n" +
+                        "    name\n" +
+                        "\n" +
+                        "    /**\n" +
+                        "     * some documentation\n" +
+                        "     */\n" +
+                        "}"
+        );
+        assertContentEquals(
+                "[BookView {--->name}]",
+                dtoTypes.toString()
+        );
+    }
+
+    @Test
+    public void testTrailingDocCommentAtEndOfFile() {
+        List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
+                "BookView {\n" +
+                        "    name\n" +
+                        "}\n" +
+                        "/**\n" +
+                        " * some documentation\n" +
+                        " */\n"
+        );
+        assertContentEquals(
+                "[BookView {--->name}]",
+                dtoTypes.toString()
+        );
+    }
+
+    @Test
+    public void testTrailingDocCommentInTypesBlock() {
+        DtoType<BaseType, BaseProp> dtoType = MyDtoCompiler.client(
+                "ClientView {\n" +
+                        "    id\n" +
+                        "    #types {\n" +
+                        "        Person {\n" +
+                        "            firstName\n" +
+                        "        }\n" +
+                        "        /**\n" +
+                        "         * some documentation\n" +
+                        "         */\n" +
+                        "    }\n" +
+                        "}"
+        ).get(0);
+        Assertions.assertNotNull(dtoType.getPolymorphism());
+    }
+
+    @Test
+    public void testTrailingDocCommentInAliasGroup() {
+        DtoType<BaseType, BaseProp> dtoType = MyDtoCompiler.treeNode(
+                "TreeFlatView {\n" +
+                        "    flat(parent) {\n" +
+                        "        as(^ -> parent) {\n" +
+                        "            name\n" +
+                        "            /**\n" +
+                        "             * some documentation\n" +
+                        "             */\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
+        ).get(0);
+        Assertions.assertNotNull(dtoType);
+    }
+
+    @Test
     public void testInterfaceImplementation() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
                 "import com.company.project.model.common.Named\n" +


### PR DESCRIPTION
Fixes #1478

A `DocComment` (`/** ... */`) is matched on the default channel and attaches to the declaration that follows it. When a documentation comment is the last meaningful content in a block (nothing to attach to), it reaches the parser as an unexpected token and fails:

```
no viable alternative at input '/**...*/'
```

This happens when a doc comment trails at the end of a DTO body, end of file, end of a `#types` block, or end of an alias group. `BlockComment`/`LineComment` are unaffected because they go to the hidden channel.

Changes:
- `Dto.g4`: allow an optional trailing `DocComment` in the `dto`, `dtoBody`, `typesBlock`, and `aliasGroup` rules.
- Added `testTrailingDocComment`, `testTrailingDocCommentAtEndOfFile`, `testTrailingDocCommentInTypesBlock`, and `testTrailingDocCommentInAliasGroup`.