### PR TITLE
fix(dto): require associated list for !batch

### DIFF
--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
@@ -241,6 +241,13 @@ class PropConfigBuilder<T extends BaseType, P extends BaseProp> {
     }
 
     void setBatch(DtoParser.BatchContext batch) {
+        if (!baseProp.isAssociation(true) || !baseProp.isList()) {
+            throw ctx.exception(
+                    batch.start.getLine(),
+                    batch.start.getCharPositionInLine(),
+                    "Cannot be specify \"!batch\" when the property is not associated list"
+            );
+        }
         int value = Integer.parseInt(batch.IntegerLiteral().getText());
         if (value < 1) {
             throw ctx.exception(

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoCompilerTest.java
@@ -1355,6 +1355,24 @@ public class DtoCompilerTest {
     }
 
     @Test
+    public void testBatchConfigOnScalarProperty() {
+        DtoAstException ex = Assertions.assertThrows(DtoAstException.class, () -> {
+            MyDtoCompiler.book(
+                    "BookView {\n" +
+                            "    !batch(10)\n" +
+                            "    name\n" +
+                            "}\n"
+            );
+        });
+        Assertions.assertEquals(
+                "file:/User/test/Book.dto:2 : Cannot be specify \"!batch\" when the property is not associated list\n" + 
+                "    !batch(10)\n" + 
+                "    ^",
+                ex.getMessage()
+        );
+    }
+
+    @Test
     public void testZeroOffsetConfig() {
         List<DtoType<BaseType, BaseProp>> dtoTypes = MyDtoCompiler.book(
                 "BookView {\n" +


### PR DESCRIPTION
`!batch` shares the semantics of `!limit`: both configure how an
associated list is loaded. `setLimit` rejects the config when the base
property is not an associated list, but `setBatch` performs no such check.

As a result, `!batch` on a scalar property compiles silently and reaches
the generated fetcher:

```kotlin
// BookView { !batch(10) name }
newFetcher(Book::class).by {
    name {
        batch(10)
    }
}
```

`batch` has no meaning for a scalar property — there is nothing to load in
batches — so the generated code is invalid.

This applies the same guard `setLimit` uses, with the same message wording.
Added a test asserting the error for `!batch` on a scalar property.