### PR TITLE
fix(dto): correct depth range error message

### DIFF
--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/PropConfigBuilder.java
@@ -273,7 +273,7 @@ class PropConfigBuilder<T extends BaseType, P extends BaseProp> {
             throw ctx.exception(
                     depth.start.getLine(),
                     depth.start.getCharPositionInLine(),
-                    "The offset cannot be less than 0"
+                    "The depth cannot be less than 0"
             );
         }
         this.depth = value;


### PR DESCRIPTION
`setDepth` reports "The offset cannot be less than 0" when the `!depth`
value is negative. The message belongs to `setLimit`'s offset check; the
property being validated here is `depth`.