### PR TITLE
fix(sql): keep inherited defaults out of joined child inserts

### DIFF
--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -261,9 +261,12 @@ class Operator {
         PropertyGetter discriminatorGetter = discriminatorProp != null ?
                 PropertyGetter.propertyGetters(sqlClient, discriminatorProp).get(0) :
                 null;
+        InheritanceInfo inheritanceInfo = tableType.getInheritanceInfo();
         List<PropertyGetter> defaultGetters = new ArrayList<>();
         for (PropertyGetter getter : Shape.fullOf(sqlClient, tableType.getJavaClass()).getGetters()) {
-            if (getter.metadata().hasDefaultValue() && !batch.shape().contains(getter)) {
+            if ((inheritanceInfo == null || inheritanceInfo.isPropAvailableInTable(getter.prop(), tableType)) &&
+                    getter.metadata().hasDefaultValue() &&
+                    !batch.shape().contains(getter)) {
                 defaultGetters.add(getter);
             }
         }
@@ -1797,9 +1800,12 @@ class Operator {
 
         JSqlClientImplementor sqlClient = ctx.options.getSqlClient();
         Shape fullShape = Shape.fullOf(sqlClient, tableType.getJavaClass());
+        InheritanceInfo inheritanceInfo = tableType.getInheritanceInfo();
         List<PropertyGetter> defaultGetters = new ArrayList<>();
         for (PropertyGetter getter : fullShape.getColumnDefinitionGetters()) {
-            if (getter.metadata().hasDefaultValue() && !batch.shape().contains(getter)) {
+            if ((inheritanceInfo == null || inheritanceInfo.isPropAvailableInTable(getter.prop(), tableType)) &&
+                    getter.metadata().hasDefaultValue() &&
+                    !batch.shape().contains(getter)) {
                 defaultGetters.add(getter);
             }
         }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceLogicalDeleteTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceLogicalDeleteTest.java
@@ -1,7 +1,11 @@
 package org.babyfish.jimmer.sql.mutation.inheritance.joinedtable;
 
+import org.babyfish.jimmer.sql.ast.mutation.AffectedTable;
+import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.model.inheritance.logical.joinedtable.Client;
 import org.babyfish.jimmer.sql.model.inheritance.logical.joinedtable.Organization;
+import org.babyfish.jimmer.sql.model.inheritance.logical.joinedtable.OrganizationDraft;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -10,6 +14,47 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class JoinedInheritanceLogicalDeleteTest extends AbstractMutationTest {
+
+    @Test
+    public void testInsertDerivedType() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .getEntities()
+                        .saveCommand(
+                                OrganizationDraft.$.produce(organization -> {
+                                    organization.setId(502L);
+                                    organization.setName("Logical New Org");
+                                    organization.setTaxCode("L-NEW-001");
+                                })
+                        )
+                        .setMode(SaveMode.INSERT_ONLY),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into LOGICAL_JOINED_CLIENT(ID, CLIENT_TYPE, NAME, DELETED) " +
+                                        "values(?, ?, ?, ?)"
+                        );
+                        it.variables(502L, "ORG", "Logical New Org", false);
+                    });
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into LOGICAL_JOINED_ORGANIZATION(ID, TAX_CODE) " +
+                                        "values(?, ?)"
+                        );
+                        it.variables(502L, "L-NEW-001");
+                    });
+                    ctx.rowCount(AffectedTable.of(Client.class), 1);
+                    ctx.rowCount(AffectedTable.of(Organization.class), 1);
+                    ctx.entity(it -> {
+                        it.original("{\"id\":502,\"name\":\"Logical New Org\",\"taxCode\":\"L-NEW-001\"}");
+                        it.modified(
+                                "{\"id\":502,\"name\":\"Logical New Org\"," +
+                                        "\"deleted\":false,\"taxCode\":\"L-NEW-001\"}"
+                        );
+                    });
+                }
+        );
+    }
 
     @Test
     public void testLogicalDeleteDerivedType() {


### PR DESCRIPTION
Fixes #1489

Related feature PR: #1410
Related JOINED mutation work: #1412

## Problem

After JOINED inheritance was introduced by #1410, inserting a derived entity whose root type declares `@LogicalDeleted` can add the root logical-delete column to the child-table INSERT.

For example, saving an `Organization` derived from a logical-delete-enabled `Client` produced:

```sql
insert into LOGICAL_JOINED_ORGANIZATION(ID, TAX_CODE, DELETED) values (?, ?, ?)
```

`DELETED` belongs only to `LOGICAL_JOINED_CLIENT`, so the statement fails when the child table correctly has no such column.

The per-stage shape already excludes properties that do not belong to the current physical table. However, the insert/upsert default-value collection used the full derived shape and re-added the inherited logical-delete default to the child stage.

## Fix

Filter default-value getters through `InheritanceInfo.isPropAvailableInTable` before adding them to an INSERT or UPSERT stage. Root defaults are still written to the root table, while child-table statements contain only columns owned by that physical table.

## Verification

- Added a regression test for inserting a JOINED derived entity with logical delete on the root.
- Confirmed the test fails before the fix because the child INSERT contains `DELETED`.
- Ran `JoinedInheritanceLogicalDeleteTest`, `JoinedInheritanceMutationTest`, `MultiLevelJoinedInheritanceMutationTest`, and `JoinedInheritanceDMLTest` after the fix.

### Downstream integration

The same fix was backported onto `v0.11.2`, published to an isolated Maven-local repository as temporary version `0.11.1490`, and forced into a real downstream Kotlin/Jimmer project. Gradle dependency insight confirmed that the test runtime selected the local `jimmer-sql`, `jimmer-sql-kotlin`, and Spring starter artifacts.

With `@LogicalDeleted("1")` restored on the JOINED root while the derived table correctly had no `deleted` column:

- Unpatched `0.11.2` failed with `insert into iot_device(ID, status, device_key, deleted) values(?, ?, ?, ?)` because the derived table does not own `deleted`.
- The locally published fix inserted both root and derived rows successfully, with the root `deleted` value defaulting to `0`.
- After the root row was marked `deleted = 1`, a normal Jimmer query filtered the entity while the JOINED root and derived physical rows remained present.
- The downstream integration test class completed 5 tests with 0 failures.
