### PR TITLE
fix(dto-compiler): correct separator parsing for the DTO directory configuration

### DIFF
--- a/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/JimmerProcessor.java
+++ b/project/jimmer-apt/src/main/java/org/babyfish/jimmer/apt/JimmerProcessor.java
@@ -288,21 +288,7 @@ public class JimmerProcessor extends AbstractProcessor {
             Collection<String> defaultDirs) {
         String dtoDirs = env.getOptions().get(configurationName);
         if (dtoDirs != null && !dtoDirs.isEmpty()) {
-            Set<String> dirs = new LinkedHashSet<>();
-            for (String path : dtoDirs.trim().split("\\*[,:;]\\s*")) {
-                if (path.isEmpty() || path.equals("/")) {
-                    continue;
-                }
-                if (path.startsWith("/")) {
-                    path = path.substring(1);
-                }
-                if (path.endsWith("/")) {
-                    path = path.substring(0, path.length() - 1);
-                }
-                if (!path.isEmpty()) {
-                    dirs.add(path);
-                }
-            }
+            Set<String> dirs = DtoUtils.splitDtoDirs(dtoDirs.trim());
             for (String dir : dirs) {
                 if (!dir.startsWith(prefix)) {
                     throw new GeneratorException(

--- a/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoUtils.java
+++ b/project/jimmer-dto-compiler/src/main/java/org/babyfish/jimmer/dto/compiler/DtoUtils.java
@@ -1,8 +1,30 @@
 package org.babyfish.jimmer.dto.compiler;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.*;
 
 public class DtoUtils {
+    public static @NotNull Set<@NotNull String> splitDtoDirs(@NotNull String option) {
+        Set<String> dirs = new LinkedHashSet<>();
+
+        for (String path : option.split("\\s*[,:;](\\s*[,:;])*\\s*")) {
+            if (path.isEmpty() || path.equals("/")) {
+                continue;
+            }
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            if (path.endsWith("/")) {
+                path = path.substring(0, path.length() - 1);
+            }
+            if (!path.isEmpty()) {
+                dirs.add(path);
+            }
+        }
+
+        return dirs;
+    }
 
     public static Collection<String> standardDtoDirs(Collection<String> dtoDirs) {
         List<String> list = new ArrayList<>();

--- a/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoUtilsTest.java
+++ b/project/jimmer-dto-compiler/src/test/java/org/babyfish/jimmer/dto/compiler/DtoUtilsTest.java
@@ -73,5 +73,65 @@ public class DtoUtilsTest {
                         )
                 ).toString()
         );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2]",
+                DtoUtils.splitDtoDirs("src/main/dto,src/main/dto2").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2]",
+                DtoUtils.splitDtoDirs("src/main/dto,,src/main/dto2").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2]",
+                DtoUtils.splitDtoDirs("src/main/dto   ,  src/main/dto2").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2]",
+                DtoUtils.splitDtoDirs("src/main/dto   ;,  src/main/dto2").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2]",
+                DtoUtils.splitDtoDirs("src/main/dto   ;   :  src/main/dto2").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto, src/main/dto2, src/main/dto3]",
+                DtoUtils.splitDtoDirs("src/main/dto:src/main/dto2;src/main/dto3").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto]",
+                DtoUtils.splitDtoDirs("src/main/dto,src/main/dto").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto2, src/main/dto]",
+                DtoUtils.splitDtoDirs("src/main/dto2,src/main/dto").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto]",
+                DtoUtils.splitDtoDirs("src/main/dto").toString()
+        );
+
+        Assertions.assertEquals(
+                "[src/main/dto]",
+                DtoUtils.splitDtoDirs("/src/main/dto/").toString()
+        );
+
+        Assertions.assertEquals(
+                "[]",
+                DtoUtils.splitDtoDirs("/").toString()
+        );
+
+        Assertions.assertEquals(
+                "[]",
+                DtoUtils.splitDtoDirs("").toString()
+        );
     }
 }

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/JimmerProcessor.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/JimmerProcessor.kt
@@ -135,34 +135,25 @@ class JimmerProcessor(
         }
     }
 
-    private fun dtoDir(configurationName: String, prefix: String) : Collection<String>? =
+    private fun dtoDir(configurationName: String, prefix: String): Collection<String>? =
         environment.options[configurationName]
             ?.trim()
             ?.takeIf { it.isNotEmpty() }
             ?.let { text ->
-                text.split("\\s*[,:;]\\s*")
-                    .map {
-                        when {
-                            it == "" || it == "/" -> null
-                            it.startsWith("/") -> it.substring(1)
-                            it.endsWith("/") -> it.substring(0, it.length - 1)
-                            else -> it.takeIf { it.isNotEmpty() }
-                        }?.also { dir ->
-                            if (!dir.startsWith(prefix)) {
-                                throw GeneratorException(
-                                    "Illegal KSP configuration \"" +
+                DtoUtils.splitDtoDirs(text)
+                    .onEach { dir ->
+                        if (!dir.startsWith(prefix)) {
+                            throw GeneratorException(
+                                "Illegal KSP configuration \"" +
                                         configurationName +
                                         "\", it contains an illegal path \"" +
                                         dir +
                                         "\" which does not start with \"" +
                                         prefix +
                                         "\""
-                                )
-                            }
+                            )
                         }
                     }
-                    .filterNotNull()
-                    .toSet()
             }
             ?.let { DtoUtils.standardDtoDirs(it) }
 


### PR DESCRIPTION
The apt implementation splits on `\\*[,:;]\\s*`, which requires a literal asterisk before the separator and therefore matches nothing in a real configuration. The ksp implementation calls `String.split(String)`, the literal overload, so `\\s*[,:;]\\s*` is searched for as text. In both cases a value such as `src/main/dto,src/main/dto2` yields a single element containing the comma, which passes the prefix check and reaches `standardDtoDirs` as one path. No DTO classes are generated for either directory.

```kotlin
tasks.withType<JavaCompile> {
    options.compilerArgs.add("-Ajimmer.dto.dirs=src/main/dto,src/main/dto2")
}
```

The ksp implementation additionally normalizes paths through a `when` whose branches are mutually exclusive, so `/src/main/dto/` loses its leading slash and keeps its trailing one.

Splitting and normalization now live in a single method, called from both sides:

```java
public static @NotNull Set<@NotNull String> splitDtoDirs(@NotNull String option)
```

The separator pattern is `\\s*[,:;](\\s*[,:;])*\\s*`, so consecutive separators and the whitespace between them form one boundary. Insertion order and de-duplication are preserved by `LinkedHashSet`, as before.

The prefix check and the null handling stay at the call sites; both exception types and both messages are unchanged. `standardDtoDirs` is untouched, and its existing tests still describe its input as an already-normalized collection — the new cases are added alongside them in `DtoUtilsTest`. Delivery of the option itself, from Gradle to javac and from ksp arguments to the processor, crosses build-system boundaries and is not covered by these tests.