### PR TITLE
fix(#1493): 修正数据库连接超时时间单位

### DIFF
--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
@@ -31,7 +31,7 @@ object JimmerDdlDatabaseSchemaReader {
             if (jdbc.password.isNotBlank()) {
                 setProperty("password", jdbc.password)
             }
-            setProperty("connectTimeout", "5")
+            setProperty("connectTimeout", "5000")
             setProperty("loginTimeout", "5")
         }
         DriverManager.getConnection(jdbc.url, properties).use { connection ->


### PR DESCRIPTION
connectTimeout单位为ms，5ms太短会导致很多数据库连接超时，改为5000ms