### PR TITLE
Test module for jimmer-ksp based on kotlin-compile-testing

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ jspecify = "1.0.0"
 kafka = "0.10.0.0"
 kotlinpoet = "2.2.0"
 ksp = "2.1.20-2.0.0"
+kspTest = "0.7.1"
 lombok = "1.18.38"
 mapstruct = "1.5.3.Final"
 mysql = "8.0.29"
@@ -93,6 +94,7 @@ kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotli
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
 
 ksp-symbolProcessing-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
+dev-zacsweers-kctfork-ksp = { group = "dev.zacsweers.kctfork", name = "ksp", version.ref = "kspTest" }
 
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 

--- a/project/jimmer-ksp/build.gradle.kts
+++ b/project/jimmer-ksp/build.gradle.kts
@@ -12,4 +12,16 @@ dependencies {
     implementation(libs.kotlinpoet)
     implementation(libs.kotlinpoet.ksp)
     implementation(libs.jackson2.databind)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.dev.zacsweers.kctfork.ksp) {
+        exclude(module = "symbol-processing-api")
+    }
+
+    testImplementation(projects.jimmerSqlKotlin)
+    testImplementation(libs.javax.validation.api)
+}
+
+tasks.test {
+    useJUnit()
 }

--- a/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
+++ b/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
@@ -1,0 +1,85 @@
+package org.babyfish.jimmer.ksp.dto
+
+import com.tschuchort.compiletesting.*
+import org.babyfish.jimmer.ksp.JimmerProcessorProvider
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DtoGeneratorTest {
+    @Test
+    @OptIn(ExperimentalCompilerApi::class)
+    fun `dto file generates a view class`() {
+        val compilation = prepare(
+            """
+                package org.example
+                
+                import org.babyfish.jimmer.sql.*
+                import java.math.BigDecimal
+                import javax.validation.constraints.NotEmpty
+                import javax.validation.constraints.Positive
+                import javax.validation.constraints.PositiveOrZero
+                
+                @Entity
+                @KeyUniqueConstraint
+                interface Book {
+                    /**
+                     * The id property
+                     */
+                    @Id
+                    @GeneratedValue(strategy = GenerationType.IDENTITY)
+                    val id: Long
+                
+                    /**
+                     * The name property, 100% immutable
+                     */
+                    @Key
+                    val name: @NotEmpty(message = "The book name cannot be empty") String
+                
+                    /**
+                     * The edition property, 100% immutable
+                     */
+                    @Key
+                    val edition: @PositiveOrZero Int
+                
+                    /**
+                     * The price property, 100% immutable
+                     */
+                    val price: @Positive BigDecimal
+                }
+            """.trimIndent(),
+            """
+                export org.example.Book
+                
+                BookView {
+                    id
+                    name
+                    edition
+                    price
+                }
+            """.trimIndent(),
+        )
+
+        val result = compilation.compile()
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+
+        val bookViewFile = compilation.kspSourcesDir.resolve("kotlin/org/example/dto/BookView.kt")
+        assertTrue(bookViewFile.exists())
+        assertContains(bookViewFile.readText(), "public open class BookView")
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    private fun prepare(entity: String, dto: String): KotlinCompilation {
+        val compilation = KotlinCompilation().apply {
+            useKsp2()
+            symbolProcessorProviders = mutableListOf(JimmerProcessorProvider())
+            inheritClassPath = true
+            sources = listOf(SourceFile.kotlin("Entity.kt", entity))
+        }
+        compilation.workingDir.resolve("src/main/dto").mkdirs()
+        compilation.workingDir.resolve("src/main/dto/Entity.dto").writeText(dto)
+        return compilation
+    }
+}


### PR DESCRIPTION
jimmer-ksp has no test source set. Generator output is currently verified only by the compilation of downstream modules: generated code that is syntactically invalid fails the build, generated code that is semantically wrong compiles. There is no interception point for the latter.

This adds a test source set depending on `dev.zacsweers.kctfork:ksp`. A test writes entity sources and `.dto` files into a temporary directory, runs a real KSP compilation with `JimmerProcessorProvider`, and can assert on the exit code, the compiler messages, and the text of the generated sources under `kspSourcesDir`.

The first test covers one entity and one DTO, asserting that compilation succeeds, that `BookView.kt` is generated, and that it declares `BookView`.

Only the test source set and one test dependency are added. The main source set is unchanged and build artifacts are unaffected. No assertion tightens existing generator behavior — the textual format of current output is not pinned by any test.