### PR TITLE
Jackson annotations bypass the use-site target check in the Kotlin DTO generator

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ jspecify = "1.0.0"
 kafka = "0.10.0.0"
 kotlinpoet = "2.2.0"
 ksp = "2.1.20-2.0.0"
+kspTest = "0.7.1"
 lombok = "1.18.38"
 mapstruct = "1.5.3.Final"
 mysql = "8.0.29"
@@ -93,6 +94,7 @@ kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotli
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
 
 ksp-symbolProcessing-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
+dev-zacsweers-kctfork-ksp = { group = "dev.zacsweers.kctfork", name = "ksp", version.ref = "kspTest" }
 
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 

--- a/project/jimmer-ksp/build.gradle.kts
+++ b/project/jimmer-ksp/build.gradle.kts
@@ -12,4 +12,16 @@ dependencies {
     implementation(libs.kotlinpoet)
     implementation(libs.kotlinpoet.ksp)
     implementation(libs.jackson2.databind)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.dev.zacsweers.kctfork.ksp) {
+        exclude(module = "symbol-processing-api")
+    }
+
+    testImplementation(projects.jimmerSqlKotlin)
+    testImplementation(libs.javax.validation.api)
+}
+
+tasks.test {
+    useJUnit()
 }

--- a/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
+++ b/project/jimmer-ksp/src/main/kotlin/org/babyfish/jimmer/ksp/dto/DtoGenerator.kt
@@ -1182,11 +1182,14 @@ class DtoGenerator private constructor(
                         if (isBuilderRequired && anno.qualifiedName == ctx.jacksonTypes.jsonDeserialize.reflectionName()) {
                             continue
                         }
+
+                        val targets = allowedTargets(anno.qualifiedName)
                         val target = if (anno.qualifiedName.startsWith("com.fasterxml.jackson.")) {
-                            AnnotationSpec.UseSiteTarget.GET
+                            targets.firstOrNull { it == AnnotationSpec.UseSiteTarget.GET } ?: targets.firstOrNull()
                         } else {
-                            allowedTargets(anno.qualifiedName).firstOrNull() ?: continue
-                        }
+                            targets.firstOrNull()
+                        } ?: continue
+
                         addAnnotation(
                             standardSpec(
                                 annotationOf(anno, ctx.resolver, target)

--- a/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
+++ b/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
@@ -1,0 +1,85 @@
+package org.babyfish.jimmer.ksp.dto
+
+import com.tschuchort.compiletesting.*
+import org.babyfish.jimmer.ksp.JimmerProcessorProvider
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DtoGeneratorTest {
+    @Test
+    @OptIn(ExperimentalCompilerApi::class)
+    fun `dto file generates a view class`() {
+        val compilation = prepare(
+            """
+                package org.example
+                
+                import org.babyfish.jimmer.sql.*
+                import java.math.BigDecimal
+                import javax.validation.constraints.NotEmpty
+                import javax.validation.constraints.Positive
+                import javax.validation.constraints.PositiveOrZero
+                
+                @Entity
+                @KeyUniqueConstraint
+                interface Book {
+                    /**
+                     * The id property
+                     */
+                    @Id
+                    @GeneratedValue(strategy = GenerationType.IDENTITY)
+                    val id: Long
+                
+                    /**
+                     * The name property, 100% immutable
+                     */
+                    @Key
+                    val name: @NotEmpty(message = "The book name cannot be empty") String
+                
+                    /**
+                     * The edition property, 100% immutable
+                     */
+                    @Key
+                    val edition: @PositiveOrZero Int
+                
+                    /**
+                     * The price property, 100% immutable
+                     */
+                    val price: @Positive BigDecimal
+                }
+            """.trimIndent(),
+            """
+                export org.example.Book
+                
+                BookView {
+                    id
+                    name
+                    edition
+                    price
+                }
+            """.trimIndent(),
+        )
+
+        val result = compilation.compile()
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+
+        val bookViewFile = compilation.kspSourcesDir.resolve("kotlin/org/example/dto/BookView.kt")
+        assertTrue(bookViewFile.exists())
+        assertContains(bookViewFile.readText(), "public open class BookView")
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    private fun prepare(entity: String, dto: String): KotlinCompilation {
+        val compilation = KotlinCompilation().apply {
+            useKsp2()
+            symbolProcessorProviders = mutableListOf(JimmerProcessorProvider())
+            inheritClassPath = true
+            sources = listOf(SourceFile.kotlin("Entity.kt", entity))
+        }
+        compilation.workingDir.resolve("src/main/dto").mkdirs()
+        compilation.workingDir.resolve("src/main/dto/Entity.dto").writeText(dto)
+        return compilation
+    }
+}

--- a/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
+++ b/project/jimmer-ksp/src/test/kotlin/org/babyfish/jimmer/ksp/dto/DtoGeneratorTest.kt
@@ -3,10 +3,7 @@ package org.babyfish.jimmer.ksp.dto
 import com.tschuchort.compiletesting.*
 import org.babyfish.jimmer.ksp.JimmerProcessorProvider
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
-import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class DtoGeneratorTest {
     @Test
@@ -68,6 +65,61 @@ class DtoGeneratorTest {
         val bookViewFile = compilation.kspSourcesDir.resolve("kotlin/org/example/dto/BookView.kt")
         assertTrue(bookViewFile.exists())
         assertContains(bookViewFile.readText(), "public open class BookView")
+    }
+
+    @Test
+    @OptIn(ExperimentalCompilerApi::class)
+    fun `jackson annotation without applicable target is not forced onto getter`() {
+        val compilation = prepare(
+            """
+                package org.example
+                
+                import org.babyfish.jimmer.sql.*
+                import javax.validation.constraints.NotEmpty
+                
+                @Entity
+                @KeyUniqueConstraint
+                interface Book {
+                    /**
+                     * The id property
+                     */
+                    @Id
+                    @GeneratedValue(strategy = GenerationType.IDENTITY)
+                    val id: Long
+                
+                    /**
+                     * The name property, 100% immutable
+                     */
+                    @Key
+                    val name: @NotEmpty(message = "The book name cannot be empty") String
+                }
+            """.trimIndent(),
+            """
+                export org.example.Book
+                
+                import com.fasterxml.jackson.annotation.JsonAutoDetect
+                import com.fasterxml.jackson.annotation.JsonIgnore
+                
+                BookView {
+                    @JsonIgnore
+                    id
+                    
+                    @JsonAutoDetect
+                    name
+                }
+            """.trimIndent(),
+        )
+
+        val result = compilation.compile()
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+
+        val bookViewFile = compilation.kspSourcesDir.resolve("kotlin/org/example/dto/BookView.kt")
+        assertTrue(bookViewFile.exists())
+
+        val bookView = bookViewFile.readText()
+        assertContains(bookView, "public open class BookView")
+        assertContains(bookView, "@get:JsonIgnore")
+        assertFalse("JsonAutoDetect" in bookView)
     }
 
     @OptIn(ExperimentalCompilerApi::class)


### PR DESCRIPTION
In `DtoGenerator.addProp` and `DtoGenerator.addAccessorDeclaration`, an annotation whose qualified name starts with `com.fasterxml.jackson.` is assigned `AnnotationSpec.UseSiteTarget.GET` without consulting `allowedTargets`. Every other annotation goes through `allowedTargets(...).firstOrNull() ?: continue`, so an empty target set means the annotation is dropped. The prefix check skips that step, and the emptiness of the set is never observed.

`@JsonAutoDetect` declares `@Target({ANNOTATION_TYPE, TYPE})`. Its target set under `allowedTargets` is empty, but it is written onto the generated property as `@get:JsonAutoDetect`:

```kotlin
@Entity
interface A {
    @Id
    val id: Long
    val name: String
}
```

```dto
AView {
    id
    @JsonAutoDetect
    name
}
```

```
This annotation is not applicable to target 'getter' and use-site target '@get'. Applicable targets: class, annotation class, file, expression
```

`allowedTargets` is now computed first for all annotations, and an empty set means `continue` as before. The Jackson prefix is reduced to a preference within a non-empty set: `GET` when available, otherwise `firstOrNull()`. In `addAccessorDeclaration` the same applies within the existing `GET`/`PROPERTY` filter.

Jackson annotations with a non-empty target set — `@JsonIgnore` and the rest — keep the site they were given before. The non-Jackson branch is unchanged. The behaviour of `allowedTargets` itself is untouched, including its returning an empty set when no `@Target` is declared. The Java generator has no such branch and is unaffected.

The first commit adds a test source set to `jimmer-ksp` with a dependency on `dev.zacsweers.kctfork:ksp`, running a real KSP compilation over sources written to a temporary directory and asserting on the generated text. The module had no test source set; generator output was reachable only through the compilation of downstream modules. The main source set and the build artifacts are unchanged.