### PR TITLE
fix(sql): support tableless types in joined inheritance

### DIFF
--- a/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/InheritanceInfo.java
+++ b/project/jimmer-core/src/main/java/org/babyfish/jimmer/meta/InheritanceInfo.java
@@ -2,6 +2,7 @@ package org.babyfish.jimmer.meta;
 
 import org.babyfish.jimmer.sql.InheritanceType;
 import org.babyfish.jimmer.sql.JoinedTableDissociateAction;
+import org.babyfish.jimmer.sql.Table;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -103,6 +104,26 @@ public final class InheritanceInfo {
         return isDeclaringTypeAvailableInTable(prop.toOriginal().getDeclaringType(), tableType);
     }
 
+    public boolean hasJoinedTable(@NotNull ImmutableType type) {
+        if (!rootType.isAssignableFrom(type)) {
+            throw new IllegalArgumentException(
+                    "The type \"" + type + "\" does not belong to the inheritance hierarchy of \"" +
+                            rootType +
+                            "\""
+            );
+        }
+        if (strategy != InheritanceType.JOINED) {
+            return false;
+        }
+        if (type == rootType) {
+            return true;
+        }
+        if (type.getJavaClass().isAnnotationPresent(Table.class)) {
+            return true;
+        }
+        return !type.getEntityProps().isEmpty();
+    }
+
     @Nullable
     public ImmutableType getTableTypeForProp(@NotNull ImmutableProp prop, @NotNull ImmutableType type) {
         if (strategy != InheritanceType.JOINED) {
@@ -112,7 +133,7 @@ public final class InheritanceInfo {
             return type;
         }
         for (ImmutableType tableType = type; tableType != null; tableType = tableType.getPrimarySuperType()) {
-            if (tableType.isEntity() && isPropAvailableInTable(prop, tableType)) {
+            if (tableType.isEntity() && hasJoinedTable(tableType) && isPropAvailableInTable(prop, tableType)) {
                 return tableType;
             }
         }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/ComposedInheritanceCrudTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/ComposedInheritanceCrudTest.kt
@@ -1,0 +1,103 @@
+package org.babyfish.jimmer.sql.kt.mutation.inheritance.joinedtable
+
+import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
+import org.babyfish.jimmer.sql.ast.mutation.SaveMode
+import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
+import org.babyfish.jimmer.sql.kt.model.inheritance.KCable
+import org.babyfish.jimmer.sql.kt.model.inheritance.KDevice
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ComposedInheritanceCrudTest : AbstractMutationTest() {
+
+    @Test
+    fun testEntityAndMappedSuperclassMultipleInheritanceCrud() {
+        jdbc(rollback = true) { con ->
+            val entities = sqlClient.entities.forConnection(con)
+
+            val insertCount = entities.save(
+                KDevice {
+                    id = 700L
+                    name = "Gateway"
+                    thingModelId = 800L
+                }
+            ) {
+                setMode(SaveMode.INSERT_ONLY)
+            }.totalAffectedRowCount
+            assertEquals(2, insertCount)
+
+            val inserted = entities.findOneById(KDevice::class, 700L)
+            assertEquals("Gateway", inserted.name)
+            assertEquals(800L, inserted.thingModelId)
+
+            val updateCount = entities.save(
+                KDevice {
+                    id = 700L
+                    name = "Gateway 2"
+                    thingModelId = 801L
+                }
+            ) {
+                setMode(SaveMode.UPDATE_ONLY)
+            }.totalAffectedRowCount
+            assertEquals(2, updateCount)
+
+            val updated = entities.findOneById(KDevice::class, 700L)
+            assertEquals("Gateway 2", updated.name)
+            assertEquals(801L, updated.thingModelId)
+
+            val deleteCount = entities.delete(KDevice::class, 700L) {
+                setMode(DeleteMode.PHYSICAL)
+            }.totalAffectedRowCount
+            assertEquals(1, deleteCount)
+            assertNull(entities.findById(KDevice::class, 700L))
+        }
+    }
+
+    @Test
+    fun testInheritanceChainCrud() {
+        jdbc(rollback = true) { con ->
+            val entities = sqlClient.entities.forConnection(con)
+
+            val insertCount = entities.save(
+                KCable {
+                    id = 701L
+                    name = "Main cable"
+                    voltage = 10
+                    length = 100
+                }
+            ) {
+                setMode(SaveMode.INSERT_ONLY)
+            }.totalAffectedRowCount
+            assertEquals(3, insertCount)
+
+            val inserted = entities.findOneById(KCable::class, 701L)
+            assertEquals("Main cable", inserted.name)
+            assertEquals(10, inserted.voltage)
+            assertEquals(100, inserted.length)
+
+            val updateCount = entities.save(
+                KCable {
+                    id = 701L
+                    name = "Main cable 2"
+                    voltage = 20
+                    length = 120
+                }
+            ) {
+                setMode(SaveMode.UPDATE_ONLY)
+            }.totalAffectedRowCount
+            assertEquals(3, updateCount)
+
+            val updated = entities.findOneById(KCable::class, 701L)
+            assertEquals("Main cable 2", updated.name)
+            assertEquals(20, updated.voltage)
+            assertEquals(120, updated.length)
+
+            val deleteCount = entities.delete(KCable::class, 701L) {
+                setMode(DeleteMode.PHYSICAL)
+            }.totalAffectedRowCount
+            assertEquals(1, deleteCount)
+            assertNull(entities.findById(KCable::class, 701L))
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/ComposedInheritanceCrudTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/ComposedInheritanceCrudTest.kt
@@ -5,8 +5,10 @@ import org.babyfish.jimmer.sql.ast.mutation.SaveMode
 import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
 import org.babyfish.jimmer.sql.kt.model.inheritance.KCable
 import org.babyfish.jimmer.sql.kt.model.inheritance.KDevice
+import org.babyfish.jimmer.sql.kt.model.inheritance.KPowerDevice
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 
 class ComposedInheritanceCrudTest : AbstractMutationTest() {
@@ -63,34 +65,33 @@ class ComposedInheritanceCrudTest : AbstractMutationTest() {
                 KCable {
                     id = 701L
                     name = "Main cable"
-                    voltage = 10
                     length = 100
                 }
             ) {
                 setMode(SaveMode.INSERT_ONLY)
             }.totalAffectedRowCount
-            assertEquals(3, insertCount)
+            assertEquals(2, insertCount)
 
             val inserted = entities.findOneById(KCable::class, 701L)
             assertEquals("Main cable", inserted.name)
-            assertEquals(10, inserted.voltage)
             assertEquals(100, inserted.length)
+
+            val insertedAsPowerDevice = entities.findOneById(KPowerDevice::class, 701L)
+            assertIs<KCable>(insertedAsPowerDevice)
 
             val updateCount = entities.save(
                 KCable {
                     id = 701L
                     name = "Main cable 2"
-                    voltage = 20
                     length = 120
                 }
             ) {
                 setMode(SaveMode.UPDATE_ONLY)
             }.totalAffectedRowCount
-            assertEquals(3, updateCount)
+            assertEquals(2, updateCount)
 
             val updated = entities.findOneById(KCable::class, 701L)
             assertEquals("Main cable 2", updated.name)
-            assertEquals(20, updated.voltage)
             assertEquals(120, updated.length)
 
             val deleteCount = entities.delete(KCable::class, 701L) {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/InheritanceMetadataTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/InheritanceMetadataTest.kt
@@ -3,6 +3,11 @@ package org.babyfish.jimmer.sql.kt.util
 import org.babyfish.jimmer.meta.ImmutableType
 import org.babyfish.jimmer.sql.Column
 import org.babyfish.jimmer.sql.InheritanceType
+import org.babyfish.jimmer.sql.kt.model.inheritance.KBaseNode
+import org.babyfish.jimmer.sql.kt.model.inheritance.KCable
+import org.babyfish.jimmer.sql.kt.model.inheritance.KDevice
+import org.babyfish.jimmer.sql.kt.model.inheritance.KPowerDevice
+import org.babyfish.jimmer.sql.kt.model.inheritance.KThingModelDevice
 import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.KClient
 import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.KOrganization
 import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.KPerson
@@ -12,6 +17,57 @@ import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 class InheritanceMetadataTest {
+
+    @Test
+    fun testInheritanceChain() {
+        val cable = KCable {
+            id = 1L
+            name = "Main cable"
+            voltage = 10
+            length = 100
+        }
+        val baseNodeType = ImmutableType.get(KBaseNode::class.java)
+        val deviceType = ImmutableType.get(KDevice::class.java)
+        val powerDeviceType = ImmutableType.get(KPowerDevice::class.java)
+        val cableType = ImmutableType.get(KCable::class.java)
+
+        assertEquals(1L, cable.id)
+        assertEquals("Main cable", cable.name)
+        assertEquals(10, cable.voltage)
+        assertEquals(100, cable.length)
+        assertSame(powerDeviceType, cableType.primarySuperType)
+        assertSame(baseNodeType, cableType.inheritanceRoot)
+        assertEquals(
+            setOf(cableType, powerDeviceType, baseNodeType),
+            cableType.allTypes
+        )
+        assertEquals(setOf(cableType), powerDeviceType.directDerivedTypes)
+        assertEquals(setOf(deviceType, cableType), baseNodeType.inheritanceInfo!!.concreteTypes.toSet())
+    }
+
+    @Test
+    fun testEntityAndMappedSuperclassMultipleInheritance() {
+        val device = KDevice {
+            id = 1L
+            name = "Gateway"
+            thingModelId = 2L
+        }
+        val baseNodeType = ImmutableType.get(KBaseNode::class.java)
+        val deviceType = ImmutableType.get(KDevice::class.java)
+        val thingModelDeviceType = ImmutableType.get(KThingModelDevice::class.java)
+
+        assertEquals(1L, device.id)
+        assertEquals("Gateway", device.name)
+        assertEquals(2L, device.thingModelId)
+        assertEquals(setOf(baseNodeType, thingModelDeviceType), deviceType.superTypes)
+        assertSame(baseNodeType, deviceType.primarySuperType)
+        assertSame(baseNodeType, deviceType.inheritanceRoot)
+        assertSame(deviceType, deviceType.getProp("thingModelId").declaringType)
+        assertEquals(
+            setOf("id", "type", "name", "thingModelId"),
+            deviceType.props.keys
+        )
+    }
 
     @Test
     fun testInheritanceInfo() {

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/InheritanceMetadataTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/util/InheritanceMetadataTest.kt
@@ -13,8 +13,10 @@ import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.KOrganization
 import org.babyfish.jimmer.sql.kt.model.inheritance.joinedtable.KPerson
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class InheritanceMetadataTest {
 
@@ -23,7 +25,6 @@ class InheritanceMetadataTest {
         val cable = KCable {
             id = 1L
             name = "Main cable"
-            voltage = 10
             length = 100
         }
         val baseNodeType = ImmutableType.get(KBaseNode::class.java)
@@ -33,10 +34,12 @@ class InheritanceMetadataTest {
 
         assertEquals(1L, cable.id)
         assertEquals("Main cable", cable.name)
-        assertEquals(10, cable.voltage)
         assertEquals(100, cable.length)
         assertSame(powerDeviceType, cableType.primarySuperType)
         assertSame(baseNodeType, cableType.inheritanceRoot)
+        assertEquals(emptySet(), powerDeviceType.entityProps.keys)
+        assertFalse(baseNodeType.inheritanceInfo!!.hasJoinedTable(powerDeviceType))
+        assertTrue(baseNodeType.inheritanceInfo!!.hasJoinedTable(cableType))
         assertEquals(
             setOf(cableType, powerDeviceType, baseNodeType),
             cableType.allTypes

--- a/project/jimmer-sql-kotlin/src/test/resources/database.sql
+++ b/project/jimmer-sql-kotlin/src/test/resources/database.sql
@@ -300,6 +300,37 @@ create table logical_joined_person(
             references logical_joined_client(id)
 );
 
+create table base_node(
+    id bigint not null,
+    node_type varchar(31) not null,
+    name varchar(100) not null,
+    constraint pk_base_node primary key(id)
+);
+
+create table device(
+    id bigint not null,
+    thing_model_id bigint not null,
+    constraint pk_device primary key(id),
+    constraint fk_device__base_node
+        foreign key(id) references base_node(id)
+);
+
+create table power_device(
+    id bigint not null,
+    voltage int not null,
+    constraint pk_power_device primary key(id),
+    constraint fk_power_device__base_node
+        foreign key(id) references base_node(id)
+);
+
+create table cable(
+    id bigint not null,
+    length int not null,
+    constraint pk_cable primary key(id),
+    constraint fk_cable__power_device
+        foreign key(id) references power_device(id)
+);
+
 insert into client(id, client_type, name, tax_code)
     values(100, 'ORG', 'Acme', 'ACME-001');
 insert into client(id, client_type, name, tax_code)

--- a/project/jimmer-sql-kotlin/src/test/resources/database.sql
+++ b/project/jimmer-sql-kotlin/src/test/resources/database.sql
@@ -315,20 +315,12 @@ create table device(
         foreign key(id) references base_node(id)
 );
 
-create table power_device(
-    id bigint not null,
-    voltage int not null,
-    constraint pk_power_device primary key(id),
-    constraint fk_power_device__base_node
-        foreign key(id) references base_node(id)
-);
-
 create table cable(
     id bigint not null,
     length int not null,
     constraint pk_cable primary key(id),
-    constraint fk_cable__power_device
-        foreign key(id) references power_device(id)
+    constraint fk_cable__base_node
+        foreign key(id) references base_node(id)
 );
 
 insert into client(id, client_type, name, tax_code)

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KBaseNode.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KBaseNode.kt
@@ -1,0 +1,25 @@
+package org.babyfish.jimmer.sql.kt.model.inheritance
+
+import org.babyfish.jimmer.sql.Column
+import org.babyfish.jimmer.sql.Discriminator
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.EntityInstantiability
+import org.babyfish.jimmer.sql.Id
+import org.babyfish.jimmer.sql.Inheritance
+import org.babyfish.jimmer.sql.InheritanceType
+import org.babyfish.jimmer.sql.Table
+
+@Entity(instantiability = EntityInstantiability.ABSTRACT)
+@Table(name = "BASE_NODE")
+@Inheritance(strategy = InheritanceType.JOINED)
+interface KBaseNode {
+
+    @Id
+    val id: Long
+
+    @Discriminator
+    @Column(name = "NODE_TYPE")
+    val type: String
+
+    val name: String
+}

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KCable.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KCable.kt
@@ -1,0 +1,13 @@
+package org.babyfish.jimmer.sql.kt.model.inheritance
+
+import org.babyfish.jimmer.sql.DiscriminatorValue
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Table
+
+@Entity
+@Table(name = "CABLE")
+@DiscriminatorValue("CABLE")
+interface KCable : KPowerDevice {
+
+    val length: Int
+}

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KDevice.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KDevice.kt
@@ -1,0 +1,10 @@
+package org.babyfish.jimmer.sql.kt.model.inheritance
+
+import org.babyfish.jimmer.sql.DiscriminatorValue
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.Table
+
+@Entity
+@Table(name = "DEVICE")
+@DiscriminatorValue("DEVICE")
+interface KDevice : KBaseNode, KThingModelDevice

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KPowerDevice.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KPowerDevice.kt
@@ -2,11 +2,6 @@ package org.babyfish.jimmer.sql.kt.model.inheritance
 
 import org.babyfish.jimmer.sql.Entity
 import org.babyfish.jimmer.sql.EntityInstantiability
-import org.babyfish.jimmer.sql.Table
 
 @Entity(instantiability = EntityInstantiability.ABSTRACT)
-@Table(name = "POWER_DEVICE")
-interface KPowerDevice : KBaseNode {
-
-    val voltage: Int
-}
+interface KPowerDevice : KBaseNode

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KPowerDevice.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KPowerDevice.kt
@@ -1,0 +1,12 @@
+package org.babyfish.jimmer.sql.kt.model.inheritance
+
+import org.babyfish.jimmer.sql.Entity
+import org.babyfish.jimmer.sql.EntityInstantiability
+import org.babyfish.jimmer.sql.Table
+
+@Entity(instantiability = EntityInstantiability.ABSTRACT)
+@Table(name = "POWER_DEVICE")
+interface KPowerDevice : KBaseNode {
+
+    val voltage: Int
+}

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KThingModelDevice.kt
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/KThingModelDevice.kt
@@ -1,0 +1,9 @@
+package org.babyfish.jimmer.sql.kt.model.inheritance
+
+import org.babyfish.jimmer.sql.MappedSuperclass
+
+@MappedSuperclass
+interface KThingModelDevice {
+
+    val thingModelId: Long
+}

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/README.md
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/README.md
@@ -1,0 +1,1 @@
+# Inheritance test models

--- a/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/README.md
+++ b/project/jimmer-sql-test/jimmer-sql-test-model-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/model/inheritance/README.md
@@ -1,1 +1,4 @@
 # Inheritance test models
+
+`KPowerDevice` is a tableless abstract type in the joined hierarchy. Its
+concrete child `KCable` owns the next physical table segment.

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/InheritanceMutationUtils.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/InheritanceMutationUtils.java
@@ -56,8 +56,9 @@ final class InheritanceMutationUtils {
 
     static List<ImmutableType> joinedTableTypes(ImmutableType rootType, ImmutableType type) {
         List<ImmutableType> tableTypes = new ArrayList<>();
+        InheritanceInfo inheritanceInfo = rootType.getInheritanceInfo();
         for (ImmutableType t = type; t != rootType; t = t.getPrimarySuperType()) {
-            if (t.isEntity()) {
+            if (t.isEntity() && inheritanceInfo.hasJoinedTable(t)) {
                 tableTypes.add(t);
             }
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -535,8 +535,9 @@ class Operator {
 
     static List<ImmutableType> joinedTableTypes(ImmutableType rootType, ImmutableType type) {
         List<ImmutableType> tableTypes = new ArrayList<>();
+        InheritanceInfo inheritanceInfo = rootType.getInheritanceInfo();
         for (ImmutableType t = type; t != rootType; t = t.getPrimarySuperType()) {
-            if (t.isEntity()) {
+            if (t.isEntity() && inheritanceInfo.hasJoinedTable(t)) {
                 tableTypes.add(t);
             }
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DatabaseValidators.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/DatabaseValidators.java
@@ -81,12 +81,12 @@ public class DatabaseValidators {
 
     private DatabaseValidationException validate() throws SQLException {
         for (ImmutableType type : entityManager.getAllTypes(microServiceName)) {
-            if (type.isEntity() && !(type instanceof AssociationType) && predicate.test(type)) {
+            if (isTableType(type) && predicate.test(type)) {
                 validateSelf(type);
             }
         }
         for (ImmutableType type : entityManager.getAllTypes(microServiceName)) {
-            if (type.isEntity() && !(type instanceof AssociationType) && predicate.test(type)) {
+            if (isTableType(type) && predicate.test(type)) {
                 validateForeignKey(type);
             }
         }
@@ -94,6 +94,16 @@ public class DatabaseValidators {
             return new DatabaseValidationException(items);
         }
         return null;
+    }
+
+    private static boolean isTableType(ImmutableType type) {
+        if (!type.isEntity() || type instanceof AssociationType) {
+            return false;
+        }
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        return inheritanceInfo == null ||
+                inheritanceInfo.getStrategy() != InheritanceType.JOINED ||
+                inheritanceInfo.hasJoinedTable(type);
     }
 
     private void validateSelf(ImmutableType type) throws SQLException {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/runtime/EntityManager.java
@@ -713,17 +713,23 @@ public class EntityManager {
                 if (!type.isEntity()) {
                     continue;
                 }
-                String tableName = DatabaseIdentifiers.comparableIdentifier(type.getTableName(strategy));
                 String microServiceName = type.getMicroServiceName();
-                Key key = new Key(microServiceName, tableName);
-                Map<List<Object>, ImmutableType> subTypeMap = typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
-                ImmutableType conflictType = subTypeMap.put(null, type);
-                if (conflictType != null) {
-                    ImmutableType rootType = sharedSingleTableRoot(conflictType, type);
-                    if (rootType == null) {
-                        tableSharedBy(key, conflictType, type, null);
-                    } else {
-                        subTypeMap.put(null, rootType);
+                InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+                if (inheritanceInfo == null ||
+                        inheritanceInfo.getStrategy() != InheritanceType.JOINED ||
+                        inheritanceInfo.hasJoinedTable(type)) {
+                    String tableName = DatabaseIdentifiers.comparableIdentifier(type.getTableName(strategy));
+                    Key key = new Key(microServiceName, tableName);
+                    Map<List<Object>, ImmutableType> subTypeMap =
+                            typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
+                    ImmutableType conflictType = subTypeMap.put(null, type);
+                    if (conflictType != null) {
+                        ImmutableType rootType = sharedSingleTableRoot(conflictType, type);
+                        if (rootType == null) {
+                            tableSharedBy(key, conflictType, type, null);
+                        } else {
+                            subTypeMap.put(null, rootType);
+                        }
                     }
                 }
                 for (ImmutableProp prop : type.getProps().values()) {
@@ -734,15 +740,16 @@ public class EntityManager {
                                 middleTable.getFilterInfo().getValues() :
                                 null;
                         String middleTableName = DatabaseIdentifiers.comparableIdentifier(middleTable.getTableName());
-                        key = new Key(microServiceName, middleTableName);
-                        subTypeMap = typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
+                        Key key = new Key(microServiceName, middleTableName);
+                        Map<List<Object>, ImmutableType> subTypeMap =
+                                typeMap.computeIfAbsent(key, it -> new LinkedHashMap<>());
                         if (filteredValues != null) {
-                            conflictType = subTypeMap.get(null);
+                            ImmutableType conflictType = subTypeMap.get(null);
                             if (conflictType != null && !(conflictType instanceof AssociationType)) {
                                 tableSharedBy(key, conflictType, associationType, null);
                             }
                         }
-                        conflictType = subTypeMap.get(filteredValues);
+                        ImmutableType conflictType = subTypeMap.get(filteredValues);
                         if (conflictType != null) {
                             tableSharedBy(key, conflictType, associationType, filteredValues);
                         }


### PR DESCRIPTION
## Need

A JOINED hierarchy can contain an abstract domain type that has no physical table segment, while a deeper subtype owns persisted fields and a table. The runtime currently treats every entity in the chain as a table and tries to execute SQL such as `insert into KPOWER_DEVICE(ID) values(?)` even when that table does not exist.

## Changes

- Treat a JOINED type as table-backed when it is the root, declares `@Table`, or owns entity properties.
- Skip tableless types consistently in save/delete stages, database validation, and table-to-type registration.
- Cover `BaseNode -> PowerDevice -> Cable`, where `PowerDevice` remains an abstract polymorphic type without a table and `Cable` owns the next table segment.
- Cover entity plus mapped-superclass multiple inheritance with `Device` and `ThingModelDevice`.
- Exercise insert, concrete and intermediate-type reads, update, physical delete, and post-delete lookup against H2.

## Verification

- `:jimmer-core:test`
- `:jimmer-sql:test`
- `:jimmer-sql-kotlin:test`
