### PR TITLE
Fix DDL length for annotated Java string properties

### DIFF
--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-addzero-ddlgenerator = "2026.07.30"
+addzero-ddlgenerator = "2026.08.26"
 addzero-ddlgenerator-archived = "2026.07.15.2"
-addzero-lsi = "2026.07.30"
+addzero-lsi = "2026.08.26"
 antlr = "4.13.0"
 buildconfig = "5.3.5"
 caffeine = "2.9.1"

--- a/project/jimmer-ddl-compiler/build.gradle.kts
+++ b/project/jimmer-ddl-compiler/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.addzero.tool.database.model)
     implementation(libs.ksp.symbolProcessing.api)
 
+    testImplementation(projects.jimmerCore)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.h2)
 }

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/AnnotatedStringDdlTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/AnnotatedStringDdlTest.kt
@@ -1,0 +1,88 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import java.nio.charset.StandardCharsets
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.StandardLocation
+import javax.tools.ToolProvider
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+import org.babyfish.jimmer.ddl.compiler.apt.JimmerDdlCompilerAptProcessor
+
+class AnnotatedStringDdlTest {
+
+    @Test
+    fun `java annotations preserve string length in mysql ddl`() {
+        val projectDir = createTempDirectory(prefix = "annotated-string-ddl-test").toFile()
+        val sourceFile = projectDir.resolve("src/main/java/demo/CallAlgRecord.java")
+        val classesDir = projectDir.resolve("build/classes")
+        val outputDir = projectDir.resolve("build/generated/jimmer-ddl/main/resources/db/migration")
+        sourceFile.parentFile.mkdirs()
+        sourceFile.writeText(
+            """
+                package demo;
+
+                import javax.validation.constraints.Pattern;
+                import javax.validation.constraints.Size;
+                import org.babyfish.jimmer.sql.Column;
+                import org.babyfish.jimmer.sql.Entity;
+                import org.babyfish.jimmer.sql.Id;
+                import org.babyfish.jimmer.sql.Table;
+
+                @Entity
+                @Table(name = "call_alg_record")
+                public interface CallAlgRecord {
+                    @Id
+                    @Size(max = 50)
+                    @Pattern(regexp = "[^\\d]+\\S+")
+                    @Column(sqlType = "varchar")
+                    String id();
+                }
+            """.trimIndent(),
+        )
+
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val compiler = ToolProvider.getSystemJavaCompiler()
+            ?: error("JDK compiler is required to run APT integration tests")
+        classesDir.mkdirs()
+        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8).use { fileManager ->
+            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(classesDir))
+            val task = compiler.getTask(
+                null,
+                fileManager,
+                diagnostics,
+                listOf(
+                    "-classpath",
+                    System.getProperty("java.class.path"),
+                    "-AjimmerDdl.enabled=true",
+                    "-AjimmerDdl.databaseType=mysql",
+                    "-AjimmerDdl.outputFormat=plain",
+                    "-AjimmerDdl.outputDir=${outputDir.absolutePath}",
+                    "-AjimmerDdl.description=annotated_string",
+                    "-AjimmerDdl.compareDatabase=false",
+                ),
+                null,
+                fileManager.getJavaFileObjects(sourceFile),
+            )
+            task.setProcessors(listOf(JimmerDdlCompilerAptProcessor()))
+            assertTrue(task.call(), diagnostics.toErrorMessage())
+        }
+
+        val sqlFile = outputDir.resolve("annotated_string.sql")
+        assertTrue(sqlFile.isFile, "APT should generate ddl file: ${sqlFile.absolutePath}")
+        assertContains(sqlFile.readText(), "`id` VARCHAR(50)")
+    }
+
+    private fun DiagnosticCollector<JavaFileObject>.toErrorMessage(): String =
+        diagnostics.joinToString(separator = "\n") { diagnostic ->
+            val source = diagnostic.source?.name.orEmpty()
+            val position = if (diagnostic.lineNumber > 0) {
+                "${diagnostic.lineNumber}:${diagnostic.columnNumber}"
+            } else {
+                "?:?"
+            }
+            "${diagnostic.kind} $source:$position ${diagnostic.getMessage(null)}"
+        }
+}


### PR DESCRIPTION
## Summary

- upgrade LSI and DDL generator artifacts to `2026.08.26`
- add a real javac/APT regression using the Java property from the issue
- verify MySQL preserves the `50` length for `@Size(max = 50)` plus `@Column(sqlType = "varchar")`

## Root cause

For annotated Java interface methods, javac's type display can include type-use annotations. The previous LSI path reused that display as the declared type name, and the DDL adapter parsed the trailing text as `String)`. That made the scalar type unknown, so the native `varchar` hint was emitted without the `@Size` length.

The released LSI artifact now derives declared names from `TypeElement`, while the DDL adapter resolves `LsiType.lsiClass` before falling back to display names.

Artifacts:

- [lsi-apt 2026.08.26](https://repo.maven.apache.org/maven2/site/addzero/lsi-apt/2026.08.26/lsi-apt-2026.08.26.jar)
- [ddlgenerator-lsi-adaptor 2026.08.26](https://repo.maven.apache.org/maven2/site/addzero/ddlgenerator-lsi-adaptor/2026.08.26/ddlgenerator-lsi-adaptor-2026.08.26.jar)

## Verification

- Java 21: `:jimmer-ddl-compiler:test --tests 'org.babyfish.jimmer.ddl.compiler.AnnotatedStringDdlTest'`
- Java 8: direct JUnit run of `AnnotatedStringDdlTest` (1 test, 0 failures)
- `:jimmer-ddl-compiler:test` (21 tests, 0 failures)
- downstream `okm-platform` compiler suite (28 tests, 0 failures) using Maven Central artifacts
- downstream config-model KSP/DDL generation twice with an unchanged checked-in schema snapshot and no new migration

Fixes #1492
