### PR TITLE
fix(ddl): preserve JDBC connection timeout across drivers

### DIFF
--- a/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
+++ b/project/jimmer-ddl-compiler/src/main/kotlin/org/babyfish/jimmer/ddl/compiler/JimmerDdlDatabaseSchemaReader.kt
@@ -12,6 +12,28 @@ import java.sql.ResultSet
 import java.sql.Types
 import java.util.Properties
 
+internal fun JimmerDdlCompilerSettings.jdbcConnectionProperties(): Properties {
+    return Properties().apply {
+        if (jdbc.username.isNotBlank()) {
+            setProperty("user", jdbc.username)
+        }
+        if (jdbc.password.isNotBlank()) {
+            setProperty("password", jdbc.password)
+        }
+        setProperty(
+            "connectTimeout",
+            when (databaseType) {
+                DatabaseType.MYSQL,
+                DatabaseType.OCEANBASE,
+                DatabaseType.POLARDB,
+                DatabaseType.TIDB -> "5000"
+                else -> "5"
+            }
+        )
+        setProperty("loginTimeout", "5")
+    }
+}
+
 object JimmerDdlDatabaseSchemaReader {
     fun read(
         settings: JimmerDdlCompilerSettings,
@@ -24,17 +46,7 @@ object JimmerDdlDatabaseSchemaReader {
             Class.forName(driverClassName)
         }
 
-        val properties = Properties().apply {
-            if (jdbc.username.isNotBlank()) {
-                setProperty("user", jdbc.username)
-            }
-            if (jdbc.password.isNotBlank()) {
-                setProperty("password", jdbc.password)
-            }
-            setProperty("connectTimeout", "5")
-            setProperty("loginTimeout", "5")
-        }
-        DriverManager.getConnection(jdbc.url, properties).use { connection ->
+        DriverManager.getConnection(jdbc.url, settings.jdbcConnectionProperties()).use { connection ->
             val schemaName = jdbc.schema ?: runCatching { connection.schema }.getOrNull()
             return readSchema(connection, schemaName, desiredSchema, renamedTables)
         }

--- a/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/DatabaseConnectionTimeoutTest.kt
+++ b/project/jimmer-ddl-compiler/src/test/kotlin/org/babyfish/jimmer/ddl/compiler/DatabaseConnectionTimeoutTest.kt
@@ -1,0 +1,26 @@
+package org.babyfish.jimmer.ddl.compiler
+
+import site.addzero.util.db.DatabaseType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DatabaseConnectionTimeoutTest {
+
+    @Test
+    fun `connection timeout keeps five seconds across driver units`() {
+        listOf(
+            DatabaseType.MYSQL,
+            DatabaseType.OCEANBASE,
+            DatabaseType.POLARDB,
+            DatabaseType.TIDB,
+        ).forEach { databaseType ->
+            assertEquals("5000", connectionTimeout(databaseType))
+        }
+        assertEquals("5", connectionTimeout(DatabaseType.POSTGRESQL))
+    }
+
+    private fun connectionTimeout(databaseType: DatabaseType): String? =
+        JimmerDdlCompilerSettings(databaseType = databaseType)
+            .jdbcConnectionProperties()
+            .getProperty("connectTimeout")
+}


### PR DESCRIPTION
## Problem

The DDL compiler always passes `connectTimeout=5` to JDBC drivers. MySQL Connector/J interprets that value as milliseconds, so remote database comparison gets only 5 ms. pgJDBC interprets the same property as seconds, so changing the value globally to `5000` (as proposed in #1494) would increase PostgreSQL's timeout to about 83 minutes.

## Change

- build JDBC connection properties in one internal boundary
- use `5000` for MySQL-compatible database types and keep `5` for second-based drivers
- add a deterministic regression covering MySQL, OceanBase, PolarDB, TiDB, and PostgreSQL

No LSI or DDL generator artifact changes are required; the bug is in Jimmer's JDBC connection layer.

## Verification

- regression test failed with the old MySQL value and passed after the fix
- isolated `compareDatabase=true` runs passed twice against MySQL and PostgreSQL with stable generated-file manifests
- focused test passed on the current JDK
- focused test passed with the test JVM on Corretto JDK 8
- Jimmer DDL compiler full suite: 21 tests passed
- based on `dev` `a7f8cc41f5b926fbd48fefce4f90a7c9cf6c47f2`

MySQL documents `connectTimeout` in milliseconds, while pgJDBC documents it in seconds:
- https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-networking.html
- https://jdbc.postgresql.org/documentation/use/

Fixes #1493
Supersedes #1494