### PR TITLE
Pin test JVM to Java 21 for KSP2 compatibility

### DIFF
--- a/project/jimmer-ksp/build.gradle.kts
+++ b/project/jimmer-ksp/build.gradle.kts
@@ -24,4 +24,12 @@ dependencies {
 
 tasks.test {
     useJUnit()
+
+    // The intellij-core bundled in KSP2 hard-codes a feature version ceiling in
+    // JavaVersion.parse; anything above it throws IllegalArgumentException while
+    // CoreJrtFileSystem initializes. The ceiling moves up with intellij-core, so
+    // this pins a version that stays inside the current window.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }

--- a/project/settings.gradle.kts
+++ b/project/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "jimmer"
 include(
     "jimmer-bom",


### PR DESCRIPTION
**Previous behavior.** `:jimmer-ksp:test` runs on whatever JVM Gradle itself was launched with. The tests call `useKsp2()`, which invokes `KotlinSymbolProcessing` in-process. Its bundled intellij-core hard-codes a feature version ceiling in `JavaVersion.parse`, and `CoreJrtFileSystem` calls into it during initialization. On JDK 25 the parse throws `IllegalArgumentException: 25.0.4.1` and both `DtoGeneratorTest` cases fail before any DTO is generated. On JDK 21 the same tests pass. Verified across Linux, macOS and Windows: the Java version is the only variable.

**Change.** `tasks.test` now selects its launcher through a toolchain fixed at Java 21 — the highest LTS inside the ceiling that the bundled intellij-core enforces. `settings.gradle.kts` applies the foojay resolver so Gradle can provision that toolchain when it is not already present, which keeps the version requirement in the build script rather than in each contributor's environment.

**Scope.** Only `:jimmer-ksp:test` is affected; compilation and the published artifacts are untouched. The ceiling moves with the intellij-core version bundled in KSP, so 21 needs revisiting when KSP is upgraded.