### PR TITLE
Insert/upsert from typed select sources and selective save updates

### DIFF
--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClient.kt
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.kt
 import org.babyfish.jimmer.View
 import org.babyfish.jimmer.lang.NewChain
 import org.babyfish.jimmer.sql.JSqlClient
+import org.babyfish.jimmer.sql.association.Association
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
 import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
@@ -47,6 +48,20 @@ interface KSqlClient : KSaveOperations {
         block: KMutableBaseQuery<E>.() -> KConfigurableBaseQuery<B>
     ): KConfigurableBaseQuery<B>
 
+    fun <B : KNonNullBaseTable<*>> createBaseQuery(
+        block: KMutableStaticBaseQuery.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForReference(
+        prop: KProperty1<S, T?>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForList(
+        prop: KProperty1<S, List<T>>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B>
+
     fun <B : KNonNullBaseTable<*>, R : KNonNullBaseTable<*>> createBaseQuery(
         symbol: KBaseTableSymbol<B>,
         block: KMutableBaseTableQuery<B>.() -> KConfigurableBaseQuery<R>
@@ -74,6 +89,54 @@ interface KSqlClient : KSaveOperations {
     fun <E : Any, R> createUpdateReturning(
         entityType: KClass<E>,
         block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R>
+
+    fun <E : Any, B : KNonNullBaseTable<*>> createInsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<E, B>.() -> Unit
+    ): KExecutable<Int>
+
+    fun <E : Any, B : KNonNullBaseTable<*>, R> createInsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int>
+
+    fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R>
+
+    fun <E : Any, B : KNonNullBaseTable<*>> createUpsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsert<E, B>.() -> Unit
+    ): KExecutable<Int>
+
+    fun <E : Any, B : KNonNullBaseTable<*>, R> createUpsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
     ): KSelectionExecutable<R>
 
     fun <E : Any> createDelete(
@@ -104,6 +167,34 @@ interface KSqlClient : KSaveOperations {
         con: Connection? = null,
         block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
     ): List<R> = createUpdateReturning(entityType, block).execute(con)
+
+    fun <E : Any, B : KNonNullBaseTable<*>> executeInsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        con: Connection? = null,
+        block: KMutableInsert<E, B>.() -> Unit
+    ): Int = createInsert(entityType, source, block).execute(con)
+
+    fun <E : Any, B : KNonNullBaseTable<*>, R> executeInsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        con: Connection? = null,
+        block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): List<R> = createInsertReturning(entityType, source, block).execute(con)
+
+    fun <E : Any, B : KNonNullBaseTable<*>> executeUpsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        con: Connection? = null,
+        block: KMutableUpsert<E, B>.() -> Unit
+    ): Int = createUpsert(entityType, source, block).execute(con)
+
+    fun <E : Any, B : KNonNullBaseTable<*>, R> executeUpsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        con: Connection? = null,
+        block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): List<R> = createUpsertReturning(entityType, source, block).execute(con)
 
     fun <E : Any> executeDelete(
         entityType: KClass<E>,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/KSqlClientExtensions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package org.babyfish.jimmer.sql.kt
 
 import org.babyfish.jimmer.View
@@ -8,11 +10,9 @@ import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
 import org.babyfish.jimmer.sql.kt.ast.expression.constant
 import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.query.*
-import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
-import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTable
-import org.babyfish.jimmer.sql.kt.ast.table.KPropsWeakJoinFun
-import org.babyfish.jimmer.sql.kt.ast.table.KRecursiveRef
+import org.babyfish.jimmer.sql.kt.ast.table.*
 import java.sql.Connection
+import kotlin.internal.LowPriorityInOverloadResolution
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
@@ -56,6 +56,26 @@ inline fun <reified E : Any, R> KSqlClient.createUpdateReturning(
 ): KSelectionExecutable<R> =
     this.createUpdateReturning(E::class, block)
 
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createInsert(
+    source: KBaseTableSymbol<B>,
+    noinline block: KMutableInsert<E, B>.() -> Unit
+): KExecutable<Int> = this.createInsert(E::class, source, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>, R> KSqlClient.createInsertReturning(
+    source: KBaseTableSymbol<B>,
+    noinline block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+): KSelectionExecutable<R> = this.createInsertReturning(E::class, source, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createUpsert(
+    source: KBaseTableSymbol<B>,
+    noinline block: KMutableUpsert<E, B>.() -> Unit
+): KExecutable<Int> = this.createUpsert(E::class, source, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>, R> KSqlClient.createUpsertReturning(
+    source: KBaseTableSymbol<B>,
+    noinline block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
+): KSelectionExecutable<R> = this.createUpsertReturning(E::class, source, block)
+
 inline fun <reified E : Any> KSqlClient.createDelete(
     noinline block: KMutableDelete<E>.() -> Unit
 ): KExecutable<Int> =
@@ -65,6 +85,87 @@ inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuer
     noinline block: KMutableBaseQuery<E>.() -> KConfigurableBaseQuery<B>
 ): KConfigurableBaseQuery<B> =
     this.createBaseQuery(E::class, block)
+
+@JvmName("createReferenceBaseAssociationQuery")
+@LowPriorityInOverloadResolution
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuery(
+    prop: KProperty1<S, T?>,
+    block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+): KConfigurableBaseQuery<B> =
+    createBaseQueryForReference(prop, block)
+
+@JvmName("createListBaseAssociationQuery")
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuery(
+    prop: KProperty1<S, List<T>>,
+    block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+): KConfigurableBaseQuery<B> =
+    createBaseQueryForList(prop, block)
+
+@JvmName("createReferenceAssociationInsert")
+@LowPriorityInOverloadResolution
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.createInsert(
+    prop: KProperty1<S, T?>,
+    source: KBaseTableSymbol<B>,
+    block: KMutableInsert<Association<S, T>, B>.() -> Unit
+): KExecutable<Int> = createInsertForReference(prop, source, block)
+
+@JvmName("createListAssociationInsert")
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.createInsert(
+    prop: KProperty1<S, List<T>>,
+    source: KBaseTableSymbol<B>,
+    block: KMutableInsert<Association<S, T>, B>.() -> Unit
+): KExecutable<Int> = createInsertForList(prop, source, block)
+
+@JvmName("createReferenceAssociationInsertReturning")
+@LowPriorityInOverloadResolution
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> KSqlClient.createInsertReturning(
+    prop: KProperty1<S, T?>,
+    source: KBaseTableSymbol<B>,
+    block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+): KSelectionExecutable<R> =
+    createInsertReturningForReference(prop, source, block)
+
+@JvmName("createListAssociationInsertReturning")
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> KSqlClient.createInsertReturning(
+    prop: KProperty1<S, List<T>>,
+    source: KBaseTableSymbol<B>,
+    block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+): KSelectionExecutable<R> =
+    createInsertReturningForList(prop, source, block)
+
+@JvmName("executeReferenceAssociationInsert")
+@LowPriorityInOverloadResolution
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.executeInsert(
+    prop: KProperty1<S, T?>,
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    block: KMutableInsert<Association<S, T>, B>.() -> Unit
+): Int = createInsert(prop, source, block).execute(con)
+
+@JvmName("executeListAssociationInsert")
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>> KSqlClient.executeInsert(
+    prop: KProperty1<S, List<T>>,
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    block: KMutableInsert<Association<S, T>, B>.() -> Unit
+): Int = createInsert(prop, source, block).execute(con)
+
+@JvmName("executeReferenceAssociationInsertReturning")
+@LowPriorityInOverloadResolution
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> KSqlClient.executeInsertReturning(
+    prop: KProperty1<S, T?>,
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+): List<R> = createInsertReturning(prop, source, block).execute(con)
+
+@JvmName("executeListAssociationInsertReturning")
+fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> KSqlClient.executeInsertReturning(
+    prop: KProperty1<S, List<T>>,
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+): List<R> = createInsertReturning(prop, source, block).execute(con)
 
 inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.createBaseQuery(
     recursiveRef: KRecursiveRef<B>,
@@ -91,6 +192,30 @@ inline fun <reified E : Any, R> KSqlClient.executeUpdateReturning(
     noinline block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
 ): List<R> =
     this.executeUpdateReturning(E::class, con, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.executeInsert(
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    noinline block: KMutableInsert<E, B>.() -> Unit
+): Int = this.executeInsert(E::class, source, con, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>, R> KSqlClient.executeInsertReturning(
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    noinline block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+): List<R> = this.executeInsertReturning(E::class, source, con, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>> KSqlClient.executeUpsert(
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    noinline block: KMutableUpsert<E, B>.() -> Unit
+): Int = this.executeUpsert(E::class, source, con, block)
+
+inline fun <reified E : Any, B : KNonNullBaseTable<*>, R> KSqlClient.executeUpsertReturning(
+    source: KBaseTableSymbol<B>,
+    con: Connection? = null,
+    noinline block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
+): List<R> = this.executeUpsertReturning(E::class, source, con, block)
 
 inline fun <reified E : Any> KSqlClient.executeDelete(
     con: Connection? = null,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableInsert.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableInsert.kt
@@ -1,0 +1,25 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation
+
+import org.babyfish.jimmer.kt.DslScope
+import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KPropExpression
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
+
+@DslScope
+interface KMutableInsert<E : Any, B : KNonNullBaseTable<*>> {
+
+    val table: KNonNullTableEx<E>
+
+    val sourceTable: B
+
+    fun <T : Any> set(target: KPropExpression<T>, source: KExpression<out T>)
+
+    fun onConflictDoNothing()
+
+    fun onConflictDoNothing(vararg targetProps: KPropExpression<*>)
+}
+
+interface KMutableInsertReturning<E : Any, B : KNonNullBaseTable<*>> :
+    KMutableInsert<E, B>,
+    KReturningSelectable

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpsert.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KMutableUpsert.kt
@@ -1,0 +1,34 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation
+
+import org.babyfish.jimmer.kt.DslScope
+import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KPropExpression
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
+
+@DslScope
+interface KMutableUpsert<E : Any, B : KNonNullBaseTable<*>> {
+
+    val table: KNonNullTableEx<E>
+
+    val sourceTable: B
+
+    fun <T : Any> key(target: KPropExpression<T>, source: KExpression<out T>)
+
+    fun <T : Any> insert(target: KPropExpression<T>, source: KExpression<out T>)
+
+    fun <T : Any> merge(target: KPropExpression<T>, source: KExpression<out T>)
+
+    fun <T : Any> merge(
+        target: KPropExpression<T>,
+        insertSource: KExpression<out T>,
+        updateExpression: KExpression<out T>
+    )
+
+    fun updateWhere(vararg predicates: KNonNullExpression<Boolean>?)
+}
+
+interface KMutableUpsertReturning<E : Any, B : KNonNullBaseTable<*>> :
+    KMutableUpsert<E, B>,
+    KReturningSelectable

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KSaveCommandPartialDsl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/KSaveCommandPartialDsl.kt
@@ -6,10 +6,7 @@ import org.babyfish.jimmer.meta.TypedProp
 import org.babyfish.jimmer.sql.DissociateAction
 import org.babyfish.jimmer.sql.TargetTransferMode
 import org.babyfish.jimmer.sql.ast.TypeMatchMode
-import org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode
-import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
-import org.babyfish.jimmer.sql.ast.mutation.UnloadedVersionBehavior
-import org.babyfish.jimmer.sql.ast.mutation.UpsertMask
+import org.babyfish.jimmer.sql.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
 import org.babyfish.jimmer.sql.kt.ast.expression.KNullableExpression
@@ -20,6 +17,12 @@ import kotlin.reflect.KProperty1
 
 @DslScope
 interface KSaveCommandPartialDsl {
+
+    /**
+     * Configure how the `@Version` property of the root entity is saved.
+     * This configuration does not propagate to associated entities.
+     */
+    fun setVersionMode(mode: VersionMode)
 
     fun setAssociatedMode(prop: KProperty1<*, *>, mode: AssociatedSaveMode)
 
@@ -34,6 +37,13 @@ interface KSaveCommandPartialDsl {
     fun <E : Any> setKeyProps(group: String, vararg keyProps: KProperty1<E, *>)
 
     fun <E : Any> setKeyProps(group: String, vararg keyProps: TypedProp.Single<E, *>)
+
+    /**
+     * Forbid update assignments derived from entity properties during upsert.
+     * A dialect can still render a fake update assignment when required by
+     * id fetching, returning, or other save semantics.
+     */
+    fun forbidUpdate()
 
     /**
      * Set UpsertMask with updatable properties
@@ -55,7 +65,7 @@ interface KSaveCommandPartialDsl {
      *
      * @param props Properties that can be updated
      *
-     *          - its length cannot be 0
+     *          - An empty array selects no entity properties for update
      *          - all properties must belong to one entity type
      */
     fun <E : Any> setUpsertMask(vararg props: ImmutableProp)
@@ -80,7 +90,7 @@ interface KSaveCommandPartialDsl {
      *
      * @param props Properties that can be updated
      *
-     *          - its length cannot be 0
+     *          - An empty array selects no entity properties for update
      *          - all properties must belong to one entity type
      */
     fun <E : Any> setUpsertMask(vararg props: KProperty1<E, *>)
@@ -105,7 +115,7 @@ interface KSaveCommandPartialDsl {
      *
      * @param props Properties that can be updated
      *
-     *          - its length cannot be 0
+     *          - An empty array selects no entity properties for update
      *          - all properties must belong to one entity type
      */
     fun <E : Any> setUpsertMask(vararg props: TypedProp.Single<E, *>)
@@ -163,7 +173,12 @@ interface KSaveCommandPartialDsl {
     fun <E : Any> setOptimisticLock(
         type: KClass<E>,
         behavior: UnloadedVersionBehavior = UnloadedVersionBehavior.IGNORE,
-        block: (OptimisticLockContext<E>).() -> KNonNullExpression<Boolean>?
+        block: UpdateConditionContext<E>.() -> KNonNullExpression<Boolean>?
+    )
+
+    fun <E : Any> setUpdateWhere(
+        type: KClass<E>,
+        block: UpdateConditionContext<E>.() -> KNonNullExpression<Boolean>?
     )
 
     fun <E : Any> setPessimisticLock(entityType: KClass<E>, lock: Boolean = true)
@@ -239,7 +254,7 @@ interface KSaveCommandPartialDsl {
         val target: KNonNullTable<E>
     }
 
-    interface OptimisticLockContext<E : Any> : ValueExpressionContext<E> {
+    interface UpdateConditionContext<E : Any> : ValueExpressionContext<E> {
         val table: KNonNullTable<E>
     }
 }

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableInsertImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableInsertImpl.kt
@@ -1,0 +1,39 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation.impl
+
+import org.babyfish.jimmer.sql.ast.Expression
+import org.babyfish.jimmer.sql.ast.PropExpression
+import org.babyfish.jimmer.sql.ast.impl.mutation.MutableInsertImpl
+import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KPropExpression
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableInsertReturning
+import org.babyfish.jimmer.sql.kt.ast.mutation.KReturningSelectable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
+import org.babyfish.jimmer.sql.kt.ast.table.impl.KNonNullTableExImpl
+
+internal class KMutableInsertImpl<E : Any, B : KNonNullBaseTable<*>>(
+    private val javaInsert: MutableInsertImpl<*>,
+    override val sourceTable: B
+) : KMutableInsertReturning<E, B>,
+    KReturningSelectable by KReturningSelectableImpl(javaInsert) {
+
+    @Suppress("UNCHECKED_CAST")
+    override val table: KNonNullTableEx<E> =
+        KNonNullTableExImpl(javaInsert.targetTableImplementor) as KNonNullTableEx<E>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> set(target: KPropExpression<T>, source: KExpression<out T>) {
+        javaInsert.set(target as PropExpression<T>, source as Expression<T>)
+    }
+
+    override fun onConflictDoNothing() {
+        javaInsert.onConflictDoNothing()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun onConflictDoNothing(vararg targetProps: KPropExpression<*>) {
+        javaInsert.onConflictDoNothing(
+            *targetProps.map { it as PropExpression<*> }.toTypedArray()
+        )
+    }
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpsertImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KMutableUpsertImpl.kt
@@ -1,0 +1,57 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation.impl
+
+import org.babyfish.jimmer.sql.ast.Expression
+import org.babyfish.jimmer.sql.ast.Predicate
+import org.babyfish.jimmer.sql.ast.PropExpression
+import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpsertImpl
+import org.babyfish.jimmer.sql.kt.ast.expression.KExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.KPropExpression
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpsertReturning
+import org.babyfish.jimmer.sql.kt.ast.mutation.KReturningSelectable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullBaseTable
+import org.babyfish.jimmer.sql.kt.ast.table.KNonNullTableEx
+import org.babyfish.jimmer.sql.kt.ast.table.impl.KNonNullTableExImpl
+
+internal class KMutableUpsertImpl<E : Any, B : KNonNullBaseTable<*>>(
+    private val javaUpsert: MutableUpsertImpl<*>,
+    override val sourceTable: B
+) : KMutableUpsertReturning<E, B>,
+    KReturningSelectable by KReturningSelectableImpl(javaUpsert) {
+
+    @Suppress("UNCHECKED_CAST")
+    override val table: KNonNullTableEx<E> =
+        KNonNullTableExImpl(javaUpsert.targetTableImplementor) as KNonNullTableEx<E>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> key(target: KPropExpression<T>, source: KExpression<out T>) {
+        javaUpsert.key(target as PropExpression<T>, source as Expression<T>)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> insert(target: KPropExpression<T>, source: KExpression<out T>) {
+        javaUpsert.insert(target as PropExpression<T>, source as Expression<T>)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> merge(target: KPropExpression<T>, source: KExpression<out T>) {
+        javaUpsert.merge(target as PropExpression<T>, source as Expression<T>)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> merge(
+        target: KPropExpression<T>,
+        insertSource: KExpression<out T>,
+        updateExpression: KExpression<out T>
+    ) {
+        javaUpsert.merge(
+            target as PropExpression<T>,
+            insertSource as Expression<T>,
+            updateExpression as Expression<T>
+        )
+    }
+
+    override fun updateWhere(vararg predicates: KNonNullExpression<Boolean>?) {
+        javaUpsert.updateWhere(*predicates.mapNotNull { it as Predicate? }.toTypedArray())
+    }
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KReturningSelectableImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KReturningSelectableImpl.kt
@@ -1,0 +1,96 @@
+package org.babyfish.jimmer.sql.kt.ast.mutation.impl
+
+import org.babyfish.jimmer.sql.ast.Selection
+import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable
+import org.babyfish.jimmer.sql.ast.tuple.*
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
+import org.babyfish.jimmer.sql.kt.ast.mutation.KReturningSelectable
+import org.babyfish.jimmer.sql.kt.impl.KSelectionExecutableImpl
+import org.babyfish.jimmer.sql.runtime.TupleMapper
+
+internal class KReturningSelectableImpl(
+    private val javaSelectable: ReturningSelectable
+) : KReturningSelectable {
+
+    override fun <T> returning(selection: Selection<T>): KSelectionExecutable<T> =
+        KSelectionExecutableImpl(javaSelectable.returning(selection))
+
+    override fun <T1, T2> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>
+    ): KSelectionExecutable<Tuple2<T1, T2>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2))
+
+    override fun <T1, T2, T3> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>
+    ): KSelectionExecutable<Tuple3<T1, T2, T3>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3))
+
+    override fun <T1, T2, T3, T4> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>
+    ): KSelectionExecutable<Tuple4<T1, T2, T3, T4>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4))
+
+    override fun <T1, T2, T3, T4, T5> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>,
+        s5: Selection<T5>
+    ): KSelectionExecutable<Tuple5<T1, T2, T3, T4, T5>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4, s5))
+
+    override fun <T1, T2, T3, T4, T5, T6> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>,
+        s5: Selection<T5>,
+        s6: Selection<T6>
+    ): KSelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4, s5, s6))
+
+    override fun <T1, T2, T3, T4, T5, T6, T7> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>,
+        s5: Selection<T5>,
+        s6: Selection<T6>,
+        s7: Selection<T7>
+    ): KSelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4, s5, s6, s7))
+
+    override fun <T1, T2, T3, T4, T5, T6, T7, T8> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>,
+        s5: Selection<T5>,
+        s6: Selection<T6>,
+        s7: Selection<T7>,
+        s8: Selection<T8>
+    ): KSelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4, s5, s6, s7, s8))
+
+    override fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> returning(
+        s1: Selection<T1>,
+        s2: Selection<T2>,
+        s3: Selection<T3>,
+        s4: Selection<T4>,
+        s5: Selection<T5>,
+        s6: Selection<T6>,
+        s7: Selection<T7>,
+        s8: Selection<T8>,
+        s9: Selection<T9>
+    ): KSelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> =
+        KSelectionExecutableImpl(javaSelectable.returning(s1, s2, s3, s4, s5, s6, s7, s8, s9))
+
+    override fun <T> returning(mapper: TupleMapper<T>): KSelectionExecutable<T> =
+        KSelectionExecutableImpl(javaSelectable.returning(mapper))
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KSaveCommandDslImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KSaveCommandDslImpl.kt
@@ -37,6 +37,10 @@ internal class KSaveCommandDslImpl(
         javaCommand = javaCommand.setMode(mode)
     }
 
+    override fun setVersionMode(mode: VersionMode) {
+        javaCommand = javaCommand.setVersionMode(mode)
+    }
+
     override fun setAssociatedModeAll(mode: AssociatedSaveMode) {
         javaCommand = javaCommand.setAssociatedModeAll(mode)
     }
@@ -72,6 +76,10 @@ internal class KSaveCommandDslImpl(
 
     override fun <E : Any> setKeyProps(group: String, vararg keyProps: TypedProp.Single<E, *>) {
         javaCommand = javaCommand.setKeyProps(group, *keyProps)
+    }
+
+    override fun forbidUpdate() {
+        javaCommand = javaCommand.forbidUpdate()
     }
 
     override fun <E : Any> setUpsertMask(vararg props: ImmutableProp) {
@@ -148,14 +156,33 @@ internal class KSaveCommandDslImpl(
     override fun <E : Any> setOptimisticLock(
         type: KClass<E>,
         behavior: UnloadedVersionBehavior,
-        block: KSaveCommandPartialDsl.OptimisticLockContext<E>.() -> KNonNullExpression<Boolean>?
+        block: KSaveCommandPartialDsl.UpdateConditionContext<E>.() -> KNonNullExpression<Boolean>?
     ) {
         javaCommand = (javaCommand as SaveCommandImplementor).setEntityOptimisticLock(
             ImmutableType.get(type.java),
-            behavior
-        ) { table, factory ->
+            behavior,
+            updateCondition("The table provided by optimistic lock does not support join", block)
+        )
+    }
+
+    override fun <E : Any> setUpdateWhere(
+        type: KClass<E>,
+        block: KSaveCommandPartialDsl.UpdateConditionContext<E>.() -> KNonNullExpression<Boolean>?
+    ) {
+        javaCommand = (javaCommand as SaveCommandImplementor).setEntityUpdateWhere(
+            ImmutableType.get(type.java),
+            updateCondition("The table provided by save update where does not support join", block)
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <E : Any> updateCondition(
+        disabledJoinReason: String,
+        block: KSaveCommandPartialDsl.UpdateConditionContext<E>.() -> KNonNullExpression<Boolean>?
+    ): UpdateCondition<Any, Table<Any>> =
+        UpdateCondition { table, factory ->
             block(
-                object : KSaveCommandPartialDsl.OptimisticLockContext<E> {
+                object : KSaveCommandPartialDsl.UpdateConditionContext<E> {
                     override val table: KNonNullTable<E> =
                         KNonNullTableExImpl(
                             if (table is TableProxy<*>) {
@@ -163,7 +190,7 @@ internal class KSaveCommandDslImpl(
                             } else {
                                 table as TableImplementor<E>
                             },
-                            "The table provider by optimistic lock does not support join"
+                            disabledJoinReason
                         )
 
                     override fun <V : Any> newNonNull(prop: KProperty1<E, V>): KNonNullExpression<V> =
@@ -178,7 +205,6 @@ internal class KSaveCommandDslImpl(
                 }
             )?.toJavaPredicate()
         }
-    }
 
     override fun <E : Any> setPessimisticLock(entityType: KClass<E>, lock: Boolean) {
         javaCommand = javaCommand.setPessimisticLock(entityType.java, lock)

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KSimpleSaveResultImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/mutation/impl/KSimpleSaveResultImpl.kt
@@ -4,7 +4,7 @@ import org.babyfish.jimmer.View
 import org.babyfish.jimmer.sql.ast.mutation.SimpleSaveResult
 import org.babyfish.jimmer.sql.kt.ast.mutation.KSimpleSaveResult
 
-internal open class KSimpleSaveResultImpl<E: Any>(
+internal open class KSimpleSaveResultImpl<E : Any>(
     javaResult: SimpleSaveResult<E>
 ) : KMutationResultImpl(javaResult), KSimpleSaveResult<E> {
 
@@ -20,7 +20,11 @@ internal open class KSimpleSaveResultImpl<E: Any>(
     override val isModified: Boolean
         get() = (javaResult as SimpleSaveResult<E>).isModified
 
-    internal class ViewImpl<E: Any, V: View<E>>(
+    @Suppress("UNCHECKED_CAST")
+    override val isAccepted: Boolean
+        get() = (javaResult as SimpleSaveResult<E>).isAccepted
+
+    internal class ViewImpl<E : Any, V : View<E>>(
         javaResult: SimpleSaveResult.View<E, V>
     ) : KSimpleSaveResultImpl<E>(javaResult), KSimpleSaveResult.View<E, V> {
 

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableBaseQuery.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/KMutableBaseQuery.kt
@@ -47,3 +47,11 @@ interface KMutableBaseQuery<E : Any> : KMutableQuery<KNonNullTable<E>> {
                 >
     }
 }
+
+interface KMutableStaticBaseQuery {
+
+    fun <
+            T : KNonNullBaseTable<NT>,
+            NT : KNullableBaseTable
+            > select(projection: KBaseTableProjection<T, NT>): KConfigurableBaseQuery<T>
+}

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableBaseQueryImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/ast/query/impl/KMutableBaseQueryImpl.kt
@@ -225,6 +225,15 @@ internal open class KMutableBaseQueryImpl<E : Any>(
     }
 }
 
+internal class KMutableStaticBaseQueryImpl(
+    private val javaBaseQuery: MutableBaseQueryImpl
+) : KMutableStaticBaseQuery {
+
+    override fun <T : KNonNullBaseTable<NT>, NT : KNullableBaseTable> select(
+        projection: KBaseTableProjection<T, NT>
+    ): KConfigurableBaseQuery<T> = select(javaBaseQuery, projection)
+}
+
 private fun <
         T : KNonNullBaseTable<NT>,
         NT : KNullableBaseTable

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/di/AbstractKSqlClientDelegate.kt
@@ -1,13 +1,12 @@
 package org.babyfish.jimmer.sql.kt.di
 
+import org.babyfish.jimmer.sql.association.Association
 import org.babyfish.jimmer.sql.event.binlog.BinLog
 import org.babyfish.jimmer.sql.exception.DatabaseValidationException
 import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
+import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.query.*
 import org.babyfish.jimmer.sql.kt.ast.table.*
 import org.babyfish.jimmer.sql.kt.filter.KFilterDsl
@@ -39,6 +38,23 @@ abstract class AbstractKSqlClientDelegate : KSqlClientImplementor {
         block: KMutableBaseQuery<E>.() -> KConfigurableBaseQuery<B>
     ): KConfigurableBaseQuery<B> =
         sqlClient().createBaseQuery(entityType, block)
+
+    override fun <B : KNonNullBaseTable<*>> createBaseQuery(
+        block: KMutableStaticBaseQuery.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> =
+        sqlClient().createBaseQuery(block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForReference(
+        prop: KProperty1<S, T?>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> =
+        sqlClient().createBaseQueryForReference(prop, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForList(
+        prop: KProperty1<S, List<T>>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> =
+        sqlClient().createBaseQueryForList(prop, block)
 
     override fun <B : KNonNullBaseTable<*>, R : KNonNullBaseTable<*>> createBaseQuery(
         symbol: KBaseTableSymbol<B>,
@@ -73,6 +89,56 @@ abstract class AbstractKSqlClientDelegate : KSqlClientImplementor {
         block: KMutableUpdateReturning<E>.() -> KSelectionExecutable<R>
     ): KSelectionExecutable<R> =
         sqlClient().createUpdateReturning(entityType, block)
+
+    override fun <E : Any, B : KNonNullBaseTable<*>> createInsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<E, B>.() -> Unit
+    ): KExecutable<Int> = sqlClient().createInsert(entityType, source, block)
+
+    override fun <E : Any, B : KNonNullBaseTable<*>, R> createInsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> = sqlClient().createInsertReturning(entityType, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int> = sqlClient().createInsertForReference(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> =
+        sqlClient().createInsertReturningForReference(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int> = sqlClient().createInsertForList(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> =
+        sqlClient().createInsertReturningForList(prop, source, block)
+
+    override fun <E : Any, B : KNonNullBaseTable<*>> createUpsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsert<E, B>.() -> Unit
+    ): KExecutable<Int> = sqlClient().createUpsert(entityType, source, block)
+
+    override fun <E : Any, B : KNonNullBaseTable<*>, R> createUpsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> = sqlClient().createUpsertReturning(entityType, source, block)
 
     override fun <E : Any> createDelete(
         entityType: KClass<E>,

--- a/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
+++ b/project/jimmer-sql-kotlin/src/main/kotlin/org/babyfish/jimmer/sql/kt/impl/KSqlClientImpl.kt
@@ -3,9 +3,13 @@ package org.babyfish.jimmer.sql.kt.impl
 import org.babyfish.jimmer.kt.toImmutableProp
 import org.babyfish.jimmer.meta.ImmutableType
 import org.babyfish.jimmer.sql.JoinType
+import org.babyfish.jimmer.sql.association.Association
+import org.babyfish.jimmer.sql.association.meta.AssociationType
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbols
 import org.babyfish.jimmer.sql.ast.impl.mutation.MutableDeleteImpl
+import org.babyfish.jimmer.sql.ast.impl.mutation.MutableInsertImpl
 import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpdateImpl
+import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpsertImpl
 import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel
 import org.babyfish.jimmer.sql.ast.impl.query.MutableBaseQueryImpl
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRecursiveBaseQueryImpl
@@ -19,15 +23,16 @@ import org.babyfish.jimmer.sql.exception.DatabaseValidationException
 import org.babyfish.jimmer.sql.kt.*
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableDelete
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdate
-import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpdateReturning
+import org.babyfish.jimmer.sql.kt.ast.mutation.*
 import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableDeleteImpl
+import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableInsertImpl
 import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableUpdateImpl
+import org.babyfish.jimmer.sql.kt.ast.mutation.impl.KMutableUpsertImpl
 import org.babyfish.jimmer.sql.kt.ast.query.*
 import org.babyfish.jimmer.sql.kt.ast.query.impl.KMutableBaseQueryImpl
 import org.babyfish.jimmer.sql.kt.ast.query.impl.KMutableRecursiveBaseQueryImpl
 import org.babyfish.jimmer.sql.kt.ast.query.impl.KMutableRootQueryImpl
+import org.babyfish.jimmer.sql.kt.ast.query.impl.KMutableStaticBaseQueryImpl
 import org.babyfish.jimmer.sql.kt.ast.table.*
 import org.babyfish.jimmer.sql.kt.ast.table.impl.AbstractKBaseTable
 import org.babyfish.jimmer.sql.kt.ast.table.impl.createPropsWeakJoinHandle
@@ -93,6 +98,29 @@ internal class KSqlClientImpl(
         )
         return KMutableBaseQueryImpl<E>(query).block()
     }
+
+    override fun <B : KNonNullBaseTable<*>> createBaseQuery(
+        block: KMutableStaticBaseQuery.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> =
+        KMutableStaticBaseQueryImpl(MutableBaseQueryImpl(javaClient)).block()
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForReference(
+        prop: KProperty1<S, T?>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> = createBaseQuery(prop, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQueryForList(
+        prop: KProperty1<S, List<T>>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> = createBaseQuery(prop, block)
+
+    private fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createBaseQuery(
+        prop: KProperty1<S, *>,
+        block: KMutableBaseQuery<Association<S, T>>.() -> KConfigurableBaseQuery<B>
+    ): KConfigurableBaseQuery<B> =
+        KMutableBaseQueryImpl<Association<S, T>>(
+            MutableBaseQueryImpl(javaClient, AssociationType.of(prop.toImmutableProp()))
+        ).block()
 
     override fun <B : KNonNullBaseTable<*>, R : KNonNullBaseTable<*>> createBaseQuery(
         symbol: KBaseTableSymbol<B>,
@@ -162,6 +190,111 @@ internal class KSqlClientImpl(
     ): KSelectionExecutable<R> {
         val update = MutableUpdateImpl(javaClient, ImmutableType.get(entityType.java))
         return block(KMutableUpdateImpl(update))
+    }
+
+    override fun <E : Any, B : KNonNullBaseTable<*>> createInsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<E, B>.() -> Unit
+    ): KExecutable<Int> {
+        val mutation = MutableInsertImpl(
+            javaClient,
+            ImmutableType.get(entityType.java),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        block(KMutableInsertImpl(mutation, source.baseTable))
+        return KExecutableImpl(mutation)
+    }
+
+    override fun <E : Any, B : KNonNullBaseTable<*>, R> createInsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> {
+        val mutation = MutableInsertImpl(
+            javaClient,
+            ImmutableType.get(entityType.java),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        return block(KMutableInsertImpl(mutation, source.baseTable))
+    }
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int> = createInsert(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForReference(
+        prop: KProperty1<S, T?>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> = createInsertReturning(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsertForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int> = createInsert(prop, source, block)
+
+    override fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturningForList(
+        prop: KProperty1<S, List<T>>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> = createInsertReturning(prop, source, block)
+
+    private fun <S : Any, T : Any, B : KNonNullBaseTable<*>> createInsert(
+        prop: KProperty1<S, *>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsert<Association<S, T>, B>.() -> Unit
+    ): KExecutable<Int> {
+        val mutation = MutableInsertImpl(
+            javaClient,
+            AssociationType.of(prop.toImmutableProp()),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        block(KMutableInsertImpl(mutation, source.baseTable))
+        return KExecutableImpl(mutation)
+    }
+
+    private fun <S : Any, T : Any, B : KNonNullBaseTable<*>, R> createInsertReturning(
+        prop: KProperty1<S, *>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableInsertReturning<Association<S, T>, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> {
+        val mutation = MutableInsertImpl(
+            javaClient,
+            AssociationType.of(prop.toImmutableProp()),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        return block(KMutableInsertImpl(mutation, source.baseTable))
+    }
+
+    override fun <E : Any, B : KNonNullBaseTable<*>> createUpsert(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsert<E, B>.() -> Unit
+    ): KExecutable<Int> {
+        val mutation = MutableUpsertImpl(
+            javaClient,
+            ImmutableType.get(entityType.java),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        block(KMutableUpsertImpl(mutation, source.baseTable))
+        return KExecutableImpl(mutation)
+    }
+
+    override fun <E : Any, B : KNonNullBaseTable<*>, R> createUpsertReturning(
+        entityType: KClass<E>,
+        source: KBaseTableSymbol<B>,
+        block: KMutableUpsertReturning<E, B>.() -> KSelectionExecutable<R>
+    ): KSelectionExecutable<R> {
+        val mutation = MutableUpsertImpl(
+            javaClient,
+            ImmutableType.get(entityType.java),
+            (source.baseTable as AbstractKBaseTable).javaTable
+        )
+        return block(KMutableUpsertImpl(mutation, source.baseTable))
     }
 
     override fun <E : Any> createDelete(

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/InsertFromSelectApiShapeTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/InsertFromSelectApiShapeTest.kt
@@ -1,0 +1,204 @@
+package org.babyfish.jimmer.sql.kt.mutation
+
+import org.babyfish.jimmer.sql.dialect.H2Dialect
+import org.babyfish.jimmer.sql.kt.*
+import org.babyfish.jimmer.sql.kt.ast.KExecutable
+import org.babyfish.jimmer.sql.kt.ast.KSelectionExecutable
+import org.babyfish.jimmer.sql.kt.ast.expression.eq
+import org.babyfish.jimmer.sql.kt.ast.expression.nullValue
+import org.babyfish.jimmer.sql.kt.ast.expression.value
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableInsert
+import org.babyfish.jimmer.sql.kt.ast.mutation.KMutableUpsert
+import org.babyfish.jimmer.sql.kt.ast.query.baseTableSymbol
+import org.babyfish.jimmer.sql.kt.ast.table.sourceId
+import org.babyfish.jimmer.sql.kt.ast.table.targetId
+import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
+import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
+import org.babyfish.jimmer.sql.kt.model.classic.store.id
+import org.babyfish.jimmer.sql.kt.model.classic.store.name
+import org.babyfish.jimmer.sql.kt.query.tuple.AggregateTupleMapper
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InsertFromSelectApiShapeTest : AbstractMutationTest() {
+
+    @Test
+    fun testEntityFactoryReturnTypesAndDslSeparation() {
+        val client = sqlClient { setDialect(H2Dialect()) }
+        val source = source(client)
+
+        val insert: KExecutable<Int> = client.createInsert<BookStore, _>(source) {
+            set(table.id, sourceTable.storeId)
+            set(table.name, value("INSERT"))
+            onConflictDoNothing(table.id)
+        }
+        val insertByClass: KExecutable<Int> = client.createInsert(BookStore::class, source) {
+            set(table.id, sourceTable.storeId)
+            set(table.name, value("INSERT-CLASS"))
+        }
+        val insertReturning: KSelectionExecutable<Long> =
+            client.createInsertReturning<BookStore, _, Long>(source) {
+                set(table.id, sourceTable.storeId)
+                set(table.name, value("INSERT-RETURNING"))
+                returning(table.id)
+            }
+
+        val upsert: KExecutable<Int> = client.createUpsert<BookStore, _>(source) {
+            key(table.id, sourceTable.storeId)
+            merge(table.name, value("UPSERT"))
+            updateWhere(table.name eq "OLD")
+        }
+        val upsertReturning: KSelectionExecutable<Long> =
+            client.createUpsertReturning<BookStore, _, Long>(source) {
+                key(table.id, sourceTable.storeId)
+                merge(table.name, value("UPSERT-RETURNING"))
+                returning(table.id)
+            }
+
+        val executeInsertFactory: () -> Int = {
+            client.executeInsert<BookStore, _>(source) {
+                set(table.id, sourceTable.storeId)
+                set(table.name, value("EXECUTE-INSERT"))
+            }
+        }
+        val executeInsertReturningFactory: () -> List<Long> = {
+            client.executeInsertReturning<BookStore, _, Long>(source) {
+                set(table.id, sourceTable.storeId)
+                set(table.name, value("EXECUTE-INSERT-RETURNING"))
+                returning(table.id)
+            }
+        }
+        val executeUpsertFactory: () -> Int = {
+            client.executeUpsert<BookStore, _>(source) {
+                key(table.id, sourceTable.storeId)
+                merge(table.name, value("EXECUTE-UPSERT"))
+            }
+        }
+        val executeUpsertReturningFactory: () -> List<Long> = {
+            client.executeUpsertReturning<BookStore, _, Long>(source) {
+                key(table.id, sourceTable.storeId)
+                merge(table.name, value("EXECUTE-UPSERT-RETURNING"))
+                returning(table.id)
+            }
+        }
+
+        assertNotNull(insert)
+        assertNotNull(insertByClass)
+        assertNotNull(insertReturning)
+        assertNotNull(upsert)
+        assertNotNull(upsertReturning)
+        assertNotNull(executeInsertFactory)
+        assertNotNull(executeInsertReturningFactory)
+        assertNotNull(executeUpsertFactory)
+        assertNotNull(executeUpsertReturningFactory)
+
+        val insertMethods = KMutableInsert::class.java.methods.map { it.name }.toSet()
+        assertTrue("onConflictDoNothing" in insertMethods)
+        assertFalse("key" in insertMethods)
+        assertFalse("merge" in insertMethods)
+        assertFalse("updateWhere" in insertMethods)
+
+        val upsertMethods = KMutableUpsert::class.java.methods.map { it.name }.toSet()
+        assertTrue("key" in upsertMethods)
+        assertTrue("merge" in upsertMethods)
+        assertTrue("updateWhere" in upsertMethods)
+        assertFalse("onConflictDoNothing" in upsertMethods)
+    }
+
+    @Test
+    fun testAssociationOverloadShapeForListAndReference() {
+        val client = sqlClient { setDialect(H2Dialect()) }
+        val source = source(client)
+
+        val listBaseQuery = client.createBaseQuery(Book::authors) {
+            selections.add(table.sourceId)
+        }
+
+        val listInsert: KExecutable<Int> = client.createInsert(Book::authors, source) {
+            set(table.sourceId, sourceTable.storeId)
+            set(table.targetId, sourceTable.bookCount)
+        }
+        val listReturning: KSelectionExecutable<Any> =
+            client.createInsertReturning(Book::authors, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+                returning(table.sourceId)
+            }
+        val executeListInsertFactory: () -> Int = {
+            client.executeInsert(Book::authors, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+            }
+        }
+        val executeListReturningFactory: () -> List<Any> = {
+            client.executeInsertReturning(Book::authors, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+                returning(table.sourceId)
+            }
+        }
+
+        // The shared Kotlin test model has no single-valued association based on a
+        // middle table. Keep these factories uninvoked: Their purpose is to make
+        // the compiler verify the reference-property overloads and return types.
+        val referenceBaseFactory: () -> Any = {
+            client.createBaseQuery(Book::store) {
+                selections.add(table.sourceId)
+            }
+        }
+        val referenceInsertFactory: () -> KExecutable<Int> = {
+            client.createInsert(Book::store, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+            }
+        }
+        val referenceReturningFactory: () -> KSelectionExecutable<Any> = {
+            client.createInsertReturning(Book::store, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+                returning(table.sourceId)
+            }
+        }
+        val executeReferenceInsertFactory: () -> Int = {
+            client.executeInsert(Book::store, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+            }
+        }
+        val executeReferenceReturningFactory: () -> List<Any> = {
+            client.executeInsertReturning(Book::store, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+                returning(table.sourceId)
+            }
+        }
+
+        assertNotNull(listBaseQuery)
+        assertNotNull(listInsert)
+        assertNotNull(listReturning)
+        assertNotNull(executeListInsertFactory)
+        assertNotNull(executeListReturningFactory)
+        assertNotNull(referenceBaseFactory)
+        assertNotNull(referenceInsertFactory)
+        assertNotNull(referenceReturningFactory)
+        assertNotNull(executeReferenceInsertFactory)
+        assertNotNull(executeReferenceReturningFactory)
+    }
+
+    private fun source(client: org.babyfish.jimmer.sql.kt.KSqlClient) = baseTableSymbol {
+        client.createBaseQuery {
+            select(
+                AggregateTupleMapper
+                    .storeId(value(9_997L))
+                    .bookCount(value(9_996L))
+                    .minPrice(nullValue<BigDecimal>())
+                    .maxPrice(nullValue<BigDecimal>())
+                    .avgPrice(nullValue<BigDecimal>())
+            )
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/InsertFromSelectDslTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/InsertFromSelectDslTest.kt
@@ -1,0 +1,128 @@
+package org.babyfish.jimmer.sql.kt.mutation
+
+import org.babyfish.jimmer.sql.dialect.H2Dialect
+import org.babyfish.jimmer.sql.kt.ast.expression.nullValue
+import org.babyfish.jimmer.sql.kt.ast.expression.value
+import org.babyfish.jimmer.sql.kt.ast.query.baseTableSymbol
+import org.babyfish.jimmer.sql.kt.ast.table.sourceId
+import org.babyfish.jimmer.sql.kt.ast.table.targetId
+import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
+import org.babyfish.jimmer.sql.kt.createInsert
+import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.store.BookStore
+import org.babyfish.jimmer.sql.kt.model.classic.store.id
+import org.babyfish.jimmer.sql.kt.model.classic.store.name
+import org.babyfish.jimmer.sql.kt.query.tuple.AggregateTupleMapper
+import java.math.BigDecimal
+import kotlin.test.Test
+
+class InsertFromSelectDslTest : AbstractMutationTest() {
+
+    @Test
+    fun testRootlessTypedTupleInsert() {
+        val client = sqlClient {
+            setDialect(H2Dialect())
+        }
+        val source = baseTableSymbol {
+            client.createBaseQuery {
+                select(
+                    AggregateTupleMapper
+                        .storeId(value(9_999L))
+                        .bookCount(value(0L))
+                        .minPrice(nullValue<BigDecimal>())
+                        .maxPrice(nullValue<BigDecimal>())
+                        .avgPrice(nullValue<BigDecimal>())
+                )
+            }
+        }
+        executeAndExpectRowCount(
+            client.createInsert<BookStore, _>(source) {
+                set(table.id, sourceTable.storeId)
+                set(table.name, value("KOTLIN-ROOTLESS"))
+            }
+        ) {
+            statement {
+                sql(
+                    "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                            "select tb_1_.c1, ?, ? from (" +
+                            "select cast(? as bigint) as c1" +
+                            ") tb_1_"
+                )
+            }
+            rowCount(1)
+        }
+    }
+
+    @Test
+    fun testAssociationInsertDsl() {
+        val client = sqlClient {
+            setDialect(H2Dialect())
+        }
+        val source = baseTableSymbol {
+            client.createBaseQuery {
+                select(
+                    AggregateTupleMapper
+                        .storeId(value(3L))
+                        .bookCount(value(5L))
+                        .minPrice(nullValue<BigDecimal>())
+                        .maxPrice(nullValue<BigDecimal>())
+                        .avgPrice(nullValue<BigDecimal>())
+                )
+            }
+        }
+        executeAndExpectRowCount(
+            client.createInsert(Book::authors, source) {
+                set(table.sourceId, sourceTable.storeId)
+                set(table.targetId, sourceTable.bookCount)
+            }
+        ) {
+            statement {
+                sql(
+                    "insert into BOOK_AUTHOR_MAPPING(BOOK_ID, AUTHOR_ID) " +
+                            "select tb_1_.c1, tb_1_.c2 from (" +
+                            "select cast(? as bigint) as c1, cast(? as bigint) as c2" +
+                            ") tb_1_"
+                )
+            }
+            rowCount(1)
+        }
+    }
+
+    @Test
+    fun testInsertReturningDsl() {
+        val client = sqlClient {
+            setDialect(H2Dialect())
+        }
+        val source = baseTableSymbol {
+            client.createBaseQuery {
+                select(
+                    AggregateTupleMapper
+                        .storeId(value(9_998L))
+                        .bookCount(value(0L))
+                        .minPrice(nullValue<BigDecimal>())
+                        .maxPrice(nullValue<BigDecimal>())
+                        .avgPrice(nullValue<BigDecimal>())
+                )
+            }
+        }
+        connectAndExpect({ con ->
+            client.createInsertReturning(BookStore::class, source) {
+                set(table.id, sourceTable.storeId)
+                set(table.name, value("KOTLIN-RETURNING"))
+                returning(table.id)
+            }.execute(con)
+        }) {
+            statement {
+                sql(
+                    "select ID from final table (" +
+                            "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                            "select tb_1_.c1, ?, ? from (" +
+                            "select cast(? as bigint) as c1" +
+                            ") tb_1_" +
+                            ")"
+                )
+            }
+            value("[9998]")
+        }
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/ModifiedFetcherTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/ModifiedFetcherTest.kt
@@ -1,6 +1,5 @@
 package org.babyfish.jimmer.sql.kt.mutation
 
-import org.babyfish.jimmer.sql.ast.mutation.QueryReason
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode
 import org.babyfish.jimmer.sql.dialect.H2Dialect
 import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
@@ -98,16 +97,8 @@ class ModifiedFetcherTest : AbstractMutationTest() {
                         |--->values(tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, tb_2_.STORE_ID)""".trimMargin()
                 )
             }
-            statement {
-                queryReason(QueryReason.FETCHER)
-                sql(
-                    """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE 
-                        |from BOOK tb_1_ 
-                        |where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)""".trimMargin()
-                )
-            }
             value(
-                """{"id":12,"name":"GraphQL in Action","edition":3,"price":80.00}""".trimMargin()
+                """{"name":"GraphQL in Action","edition":3,"price":73.9}""".trimMargin()
             )
         }
     }
@@ -149,16 +140,9 @@ class ModifiedFetcherTest : AbstractMutationTest() {
                         |--->values(tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, tb_2_.STORE_ID)""".trimMargin()
                 )
             }
-            statement {
-                sql(
-                    """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.PRICE 
-                        |from BOOK tb_1_ 
-                        |where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)""".trimMargin()
-                )
-            }
             value(
                 """[
-                    |{"id":12,"name":"GraphQL in Action","edition":3,"price":80.00}, 
+                    |{"name":"GraphQL in Action","edition":3,"price":73.9},
                     |{"id":100,"name":"GraphQL in Action","edition":4,"price":78.9}
                     |]""".trimMargin()
             )
@@ -193,15 +177,8 @@ class ModifiedFetcherTest : AbstractMutationTest() {
                         |--->values(tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, tb_2_.STORE_ID)""".trimMargin()
                 )
             }
-            statement {
-                queryReason(QueryReason.FETCHER)
-                sql(
-                    """select tb_1_.ID from BOOK tb_1_ 
-                        |where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)""".trimMargin()
-                )
-            }
             value(
-                """{"id":12}"""
+                """{"name":"GraphQL in Action","edition":3,"price":73.9}"""
             )
         }
     }
@@ -242,16 +219,8 @@ class ModifiedFetcherTest : AbstractMutationTest() {
                         |--->values(tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, tb_2_.STORE_ID)""".trimMargin()
                 )
             }
-            statement {
-                queryReason(QueryReason.FETCHER)
-                sql(
-                    """select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION 
-                        |from BOOK tb_1_ 
-                        |where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)""".trimMargin()
-                )
-            }
             value(
-                """[{"id":12}, {"id":100}]"""
+                """[{"name":"GraphQL in Action","edition":3,"price":73.9}, {"id":100}]"""
             )
         }
     }

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/SaveUpdateWhereApiShapeTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/SaveUpdateWhereApiShapeTest.kt
@@ -1,0 +1,37 @@
+package org.babyfish.jimmer.sql.kt.mutation
+
+import org.babyfish.jimmer.sql.ast.mutation.SaveMode
+import org.babyfish.jimmer.sql.kt.ast.expression.KNonNullExpression
+import org.babyfish.jimmer.sql.kt.ast.expression.gt
+import org.babyfish.jimmer.sql.kt.ast.mutation.KSaveCommandPartialDsl
+import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
+import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import org.babyfish.jimmer.sql.kt.model.classic.book.edition
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class SaveUpdateWhereApiShapeTest : AbstractMutationTest() {
+
+    @Test
+    fun testReceiverAndExpressionTyping() {
+        val condition: KSaveCommandPartialDsl.UpdateConditionContext<Book>.() -> KNonNullExpression<Boolean>? = {
+            newNonNull(Book::edition) gt table.edition
+        }
+        val command: () -> Any = {
+            sqlClient.entities.save(
+                Book {
+                    id = 1L
+                    name = "GraphQL in Action"
+                    edition = 4
+                    price = BigDecimal("80")
+                }
+            ) {
+                setMode(SaveMode.UPSERT)
+                setUpdateWhere(Book::class, condition)
+                setOptimisticLock(Book::class, block = condition)
+            }
+        }
+        assertNotNull(command)
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/UpsertMaskApiShapeTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/UpsertMaskApiShapeTest.kt
@@ -1,0 +1,42 @@
+package org.babyfish.jimmer.sql.kt.mutation
+
+import org.babyfish.jimmer.sql.kt.common.AbstractMutationTest
+import org.babyfish.jimmer.sql.kt.model.classic.book.Book
+import java.math.BigDecimal
+import kotlin.reflect.KProperty1
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class UpsertMaskApiShapeTest : AbstractMutationTest() {
+
+    @Test
+    fun testForbidUpdateAndEmptyUpsertMask() {
+        val forbidUpdateCommand: () -> Any = {
+            sqlClient.entities.save(
+                Book {
+                    id = 1L
+                    name = "GraphQL in Action"
+                    edition = 4
+                    price = BigDecimal("80")
+                }
+            ) {
+                forbidUpdate()
+            }
+        }
+        val emptyProps: Array<KProperty1<Book, *>> = emptyArray()
+        val emptyMaskCommand: () -> Any = {
+            sqlClient.entities.save(
+                Book {
+                    id = 1L
+                    name = "GraphQL in Action"
+                    edition = 4
+                    price = BigDecimal("80")
+                }
+            ) {
+                setUpsertMask(*emptyProps)
+            }
+        }
+        assertNotNull(forbidUpdateCommand)
+        assertNotNull(emptyMaskCommand)
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/VersionModeApiShapeTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/VersionModeApiShapeTest.kt
@@ -1,0 +1,17 @@
+package org.babyfish.jimmer.sql.kt.mutation
+
+import org.babyfish.jimmer.sql.ast.mutation.VersionMode
+import org.babyfish.jimmer.sql.kt.ast.mutation.KSaveCommandPartialDsl
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class VersionModeApiShapeTest {
+
+    @Test
+    fun testVersionModeDslShape() {
+        val block: KSaveCommandPartialDsl.() -> Unit = {
+            setVersionMode(VersionMode.ASSIGNMENT)
+        }
+        assertNotNull(block)
+    }
+}

--- a/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/JoinedInheritanceMutationTest.kt
+++ b/project/jimmer-sql-kotlin/src/test/kotlin/org/babyfish/jimmer/sql/kt/mutation/inheritance/joinedtable/JoinedInheritanceMutationTest.kt
@@ -1,11 +1,11 @@
 package org.babyfish.jimmer.sql.kt.mutation.inheritance.joinedtable
 
 import org.babyfish.jimmer.sql.DissociateAction
+import org.babyfish.jimmer.sql.ast.TypeMatchMode
 import org.babyfish.jimmer.sql.ast.mutation.AssociatedSaveMode
 import org.babyfish.jimmer.sql.ast.mutation.DeleteMode
 import org.babyfish.jimmer.sql.ast.mutation.QueryReason
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode
-import org.babyfish.jimmer.sql.ast.TypeMatchMode
 import org.babyfish.jimmer.sql.dialect.H2Dialect
 import org.babyfish.jimmer.sql.exception.ExecutionException
 import org.babyfish.jimmer.sql.kt.ast.expression.eq
@@ -54,7 +54,7 @@ class JoinedInheritanceMutationTest : AbstractMutationTest() {
     }
 
     @Test
-    fun testUpdateAbstractRootWithUserOptimisticLock() {
+    fun testUpdateAbstractRootWithOptimisticLockCondition() {
         connectAndExpect({ con ->
             sqlClient.entities.forConnection(con).save(
                 KClient {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClient.java
@@ -57,9 +57,16 @@ public interface JSqlClient extends SubQueryProvider, SaveOperations {
 
     <T extends TableProxy<?>> MutableRootQuery<T> createQuery(T table);
 
+    <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
+    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createQuery(AssociationTable<SE, ST, TE, TT> table);
+
     <T extends BaseTable> MutableRootQuery<T> createQuery(T baseTable);
 
+    MutableBaseQuery createBaseQuery();
+
     MutableBaseQuery createBaseQuery(TableProxy<?> table);
+
+    MutableBaseQuery createBaseQuery(AssociationTable<?, ?, ?, ?> table);
 
     MutableBaseQuery createBaseQuery(BaseTable table);
 
@@ -79,10 +86,20 @@ public interface JSqlClient extends SubQueryProvider, SaveOperations {
 
     MutableDelete createDelete(TableProxy<?> table);
 
-    <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
-    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createAssociationQuery(
-            AssociationTable<SE, ST, TE, TT> table
-    );
+    <S extends BaseTable> MutableInsert<S> createInsert(TableProxy<?> target, S source);
+
+    <S extends BaseTable> MutableInsert<S> createInsert(AssociationTable<?, ?, ?, ?> target, S source);
+
+    <S extends BaseTable> MutableUpsert<S> createUpsert(TableProxy<?> target, S source);
+
+    /**
+     * @deprecated Use {@link #createQuery(AssociationTable)}.
+     */
+    @Deprecated
+    default <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
+    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createAssociationQuery(AssociationTable<SE, ST, TE, TT> table) {
+        return createQuery(table);
+    }
 
     Entities getEntities();
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/JSqlClientImpl.java
@@ -9,16 +9,16 @@ import org.babyfish.jimmer.sql.association.meta.AssociationProp;
 import org.babyfish.jimmer.sql.association.meta.AssociationType;
 import org.babyfish.jimmer.sql.ast.impl.EntitiesImpl;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbols;
-import org.babyfish.jimmer.sql.ast.impl.mutation.AssociationsImpl;
-import org.babyfish.jimmer.sql.ast.impl.mutation.MutableDeleteImpl;
-import org.babyfish.jimmer.sql.ast.impl.mutation.MutableUpdateImpl;
+import org.babyfish.jimmer.sql.ast.impl.mutation.*;
 import org.babyfish.jimmer.sql.ast.impl.query.*;
 import org.babyfish.jimmer.sql.ast.impl.table.JWeakJoinLambdaFactory;
 import org.babyfish.jimmer.sql.ast.impl.table.WeakJoinHandle;
 import org.babyfish.jimmer.sql.ast.impl.table.WeakJoinLambda;
 import org.babyfish.jimmer.sql.ast.impl.util.JdbcOptionValidator;
 import org.babyfish.jimmer.sql.ast.mutation.MutableDelete;
+import org.babyfish.jimmer.sql.ast.mutation.MutableInsert;
 import org.babyfish.jimmer.sql.ast.mutation.MutableUpdate;
+import org.babyfish.jimmer.sql.ast.mutation.MutableUpsert;
 import org.babyfish.jimmer.sql.ast.query.MutableBaseQuery;
 import org.babyfish.jimmer.sql.ast.query.MutableRecursiveBaseQuery;
 import org.babyfish.jimmer.sql.ast.query.MutableRootQuery;
@@ -49,7 +49,6 @@ import org.babyfish.jimmer.sql.filter.impl.FilterManager;
 import org.babyfish.jimmer.sql.filter.impl.LogicalDeletedFilterProvider;
 import org.babyfish.jimmer.sql.loader.graphql.Loaders;
 import org.babyfish.jimmer.sql.loader.graphql.impl.LoadersImpl;
-import org.babyfish.jimmer.sql.meta.GeneratorContext;
 import org.babyfish.jimmer.sql.meta.*;
 import org.babyfish.jimmer.sql.runtime.*;
 import org.babyfish.jimmer.sql.transaction.Propagation;
@@ -473,6 +472,22 @@ class JSqlClientImpl implements JSqlClientImplementor {
     }
 
     @Override
+    public <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
+    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createQuery(
+            AssociationTable<SE, ST, TE, TT> table
+    ) {
+        if (!(table instanceof TableProxy<?>)) {
+            throw new IllegalArgumentException("The argument \"table\" must be proxy");
+        }
+        return new MutableRootQueryImpl<>(
+                this,
+                (TableProxy<?>) table,
+                ExecutionPurpose.QUERY,
+                FilterLevel.DEFAULT
+        );
+    }
+
+    @Override
     public <T extends BaseTable> MutableRootQuery<T> createQuery(T baseTable) {
         return new MutableRootQueryImpl<>(
                 this,
@@ -483,8 +498,21 @@ class JSqlClientImpl implements JSqlClientImplementor {
     }
 
     @Override
+    public MutableBaseQuery createBaseQuery() {
+        return new MutableBaseQueryImpl(this);
+    }
+
+    @Override
     public MutableBaseQuery createBaseQuery(TableProxy<?> table) {
         return new MutableBaseQueryImpl(this, table);
+    }
+
+    @Override
+    public MutableBaseQuery createBaseQuery(AssociationTable<?, ?, ?, ?> table) {
+        if (!(table instanceof TableProxy<?>)) {
+            throw new IllegalArgumentException("The association table must be a table proxy");
+        }
+        return new MutableBaseQueryImpl(this, (TableProxy<?>) table);
     }
 
     @Override
@@ -533,19 +561,24 @@ class JSqlClientImpl implements JSqlClientImplementor {
     }
 
     @Override
-    public <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
-    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createAssociationQuery(
-            AssociationTable<SE, ST, TE, TT> table
+    public <S extends BaseTable> MutableInsert<S> createInsert(TableProxy<?> target, S source) {
+        return new MutableInsertImpl<>(this, target, source);
+    }
+
+    @Override
+    public <S extends BaseTable> MutableInsert<S> createInsert(
+            AssociationTable<?, ?, ?, ?> target,
+            S source
     ) {
-        if (!(table instanceof TableProxy<?>)) {
-            throw new IllegalArgumentException("The argument \"table\" must be proxy");
+        if (!(target instanceof TableProxy<?>)) {
+            throw new IllegalArgumentException("The association target must be a table proxy");
         }
-        return new MutableRootQueryImpl<>(
-                this,
-                (TableProxy<?>) table,
-                ExecutionPurpose.QUERY,
-                FilterLevel.DEFAULT
-        );
+        return new MutableInsertImpl<>(this, (TableProxy<?>) target, source);
+    }
+
+    @Override
+    public <S extends BaseTable> MutableUpsert<S> createUpsert(TableProxy<?> target, S source) {
+        return new MutableUpsertImpl<>(this, target, source);
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AbstractMutableStatementImpl.java
@@ -11,21 +11,8 @@ import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableProxies;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbol;
-import org.babyfish.jimmer.sql.ast.impl.query.ConfigurableSubQueryImpl;
-import org.babyfish.jimmer.sql.ast.impl.query.FilterableImplementor;
-import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
-import org.babyfish.jimmer.sql.ast.impl.query.MutableStatementImplementor;
-import org.babyfish.jimmer.sql.ast.impl.query.MutableSubQueryImpl;
-import org.babyfish.jimmer.sql.ast.impl.query.QueryAnalysis;
-import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderContext;
-import org.babyfish.jimmer.sql.ast.impl.query.TypedBaseQueryImplementor;
-import org.babyfish.jimmer.sql.ast.impl.table.BaseTableImpl;
-import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
-import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
-import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
-import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
-import org.babyfish.jimmer.sql.ast.impl.table.TableProxies;
-import org.babyfish.jimmer.sql.ast.impl.table.TableUtils;
+import org.babyfish.jimmer.sql.ast.impl.query.*;
+import org.babyfish.jimmer.sql.ast.impl.table.*;
 import org.babyfish.jimmer.sql.ast.impl.util.ConcattedIterator;
 import org.babyfish.jimmer.sql.ast.impl.util.FlaternIterator;
 import org.babyfish.jimmer.sql.ast.impl.util.IdentityMap;
@@ -34,11 +21,7 @@ import org.babyfish.jimmer.sql.ast.query.Filterable;
 import org.babyfish.jimmer.sql.ast.query.MutableSubQuery;
 import org.babyfish.jimmer.sql.ast.query.Order;
 import org.babyfish.jimmer.sql.ast.query.TypedSubQuery;
-import org.babyfish.jimmer.sql.ast.table.AssociationTable;
-import org.babyfish.jimmer.sql.ast.table.BaseTable;
-import org.babyfish.jimmer.sql.ast.table.Props;
-import org.babyfish.jimmer.sql.ast.table.Table;
-import org.babyfish.jimmer.sql.ast.table.TableEx;
+import org.babyfish.jimmer.sql.ast.table.*;
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
 import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
@@ -52,11 +35,7 @@ import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 public abstract class AbstractMutableStatementImpl implements FilterableImplementor, MutableStatementImplementor {
 
@@ -77,6 +56,11 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
     private int modCount;
 
     private final IdentityMap<TableImplementor<?>, List<Predicate>> filterPredicates = new IdentityMap<>();
+
+    protected AbstractMutableStatementImpl(JSqlClientImplementor sqlClient) {
+        this.sqlClient = Objects.requireNonNull(sqlClient, "sqlClient cannot be null");
+        this.type = null;
+    }
 
     public AbstractMutableStatementImpl(
             JSqlClientImplementor sqlClient,
@@ -147,6 +131,9 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
     @SuppressWarnings("unchecked")
     public <T extends TableLike<?>> T getTable() {
         TableLike<?> table = this.table;
+        if (table == null && type == null) {
+            return null;
+        }
         if (table == null) {
             this.table = table = TableProxies.wrap((TableImplementor<?>) getTableLikeImplementor());
         }
@@ -159,6 +146,9 @@ public abstract class AbstractMutableStatementImpl implements FilterableImplemen
 
     public TableLikeImplementor<?> getTableLikeImplementor() {
         TableLikeImplementor<?> tableLikeImplementor = this.tableLikeImplementor;
+        if (tableLikeImplementor == null && table == null && type == null) {
+            return null;
+        }
         if (tableLikeImplementor == null) {
             if (table instanceof BaseTable) {
                 BaseTable rawBaseTable = BaseTableProxies.unwrap((BaseTable) table);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstContext.java
@@ -46,6 +46,8 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     private Set<MergedBaseQueryImpl<?>> visitingRecursiveMergedQueries;
 
+    private MutationExpressionFrame mutationExpressionFrame;
+
     public AstContext(JSqlClientImplementor sqlClient) {
         this(sqlClient, QueryRenderMode.NORMAL);
     }
@@ -95,6 +97,25 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
 
     public void popStatement() {
         this.statementFrame = this.statementFrame.parent;
+    }
+
+    public void pushMutationExpressionMap(Map<?, ?> map) {
+        mutationExpressionFrame = new MutationExpressionFrame(map, mutationExpressionFrame);
+    }
+
+    public void popMutationExpressionMap() {
+        mutationExpressionFrame = mutationExpressionFrame.parent;
+    }
+
+    @Nullable
+    public Object getMutationExpressionReplacement(Object expression) {
+        for (MutationExpressionFrame frame = mutationExpressionFrame; frame != null; frame = frame.parent) {
+            Object replacement = frame.map.get(expression);
+            if (replacement != null) {
+                return replacement;
+            }
+        }
+        return null;
     }
 
     public void pushRenderedBaseTable(RealTable realBaseTable) {
@@ -216,7 +237,7 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
         if (table instanceof TableImplementor<?>) {
             return (TableImplementor<E>) table;
         }
-        TableImplementor<E> tableImplementor = ((TableProxy<E>)table).__unwrap();
+        TableImplementor<E> tableImplementor = ((TableProxy<E>) table).__unwrap();
         if (tableImplementor != null) {
             return tableImplementor;
         }
@@ -380,11 +401,11 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
             T resolved = (T) statementFrame.peekVpf().add((VirtualPredicate) unwrapped.value);
             return unwrapped.wrapAgain(resolved);
         }
-        if (expression instanceof Ast && ((Ast)expression).hasVirtualPredicate()) {
-            return (T) ((Ast)expression).resolveVirtualPredicate(AstContext.this);
+        if (expression instanceof Ast && ((Ast) expression).hasVirtualPredicate()) {
+            return (T) ((Ast) expression).resolveVirtualPredicate(AstContext.this);
         }
-        if (expression instanceof MutableStatementImplementor && ((MutableStatementImplementor)expression).hasVirtualPredicate()) {
-            ((MutableStatementImplementor)expression).resolveVirtualPredicate(AstContext.this);
+        if (expression instanceof MutableStatementImplementor && ((MutableStatementImplementor) expression).hasVirtualPredicate()) {
+            ((MutableStatementImplementor) expression).resolveVirtualPredicate(AstContext.this);
             return expression;
         }
         return expression;
@@ -393,7 +414,7 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
     public <T> List<T> resolveVirtualPredicates(List<T> expressions) {
         boolean changed = false;
         for (T expression : expressions) {
-            if (expression instanceof Ast && ((Ast)expression).hasVirtualPredicate()) {
+            if (expression instanceof Ast && ((Ast) expression).hasVirtualPredicate()) {
                 changed = true;
                 break;
             }
@@ -415,7 +436,7 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
     public Predicate[] resolveVirtualPredicates(Predicate[] predicates) {
         boolean changed = false;
         for (Predicate predicate : predicates) {
-            if (((Ast)predicate).hasVirtualPredicate()) {
+            if (((Ast) predicate).hasVirtualPredicate()) {
                 changed = true;
                 break;
             }
@@ -481,7 +502,7 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
                 return new Unwrapped<>(value, null);
             }
             PredicateWrapper wrapper = (PredicateWrapper) value;
-            return new Unwrapped<>((T)wrapper.unwrap(), wrapper);
+            return new Unwrapped<>((T) wrapper.unwrap(), wrapper);
         }
 
         @SuppressWarnings("unchecked")
@@ -512,7 +533,7 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
                 usingBaseQuery = true;
             } else {
                 TableLikeImplementor<?> tableLikeImplementor = statement.getTableLikeImplementor();
-                usingBaseQuery = TableUtils.hasBaseTable(tableLikeImplementor);
+                usingBaseQuery = tableLikeImplementor != null && TableUtils.hasBaseTable(tableLikeImplementor);
             }
             this.usingBaseQuery = usingBaseQuery;
         }
@@ -643,6 +664,18 @@ public class AstContext extends AbstractIdentityDataManager<RealTable, TableUsed
             this.stageType = stageType;
             this.rootAlias = rootAlias;
             this.stageAliasMap = stageAliasMap;
+        }
+    }
+
+    private static class MutationExpressionFrame {
+
+        final Map<?, ?> map;
+
+        final MutationExpressionFrame parent;
+
+        MutationExpressionFrame(Map<?, ?> map, MutationExpressionFrame parent) {
+            this.map = map;
+            this.parent = parent;
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstVisitor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/AstVisitor.java
@@ -38,7 +38,8 @@ public abstract class AstVisitor {
         return queryRenderContext;
     }
 
-    public void visitTableReference(RealTable table, @Nullable ImmutableProp prop, boolean rawId) {}
+    public void visitTableReference(RealTable table, @Nullable ImmutableProp prop, boolean rawId) {
+    }
 
     public final RealTable realTableForAnalysis(TableLikeImplementor<?> tableLikeImplementor) {
         return queryRenderContext != null ?
@@ -50,13 +51,21 @@ public abstract class AstVisitor {
         visitTableReference(table, field.getProp(), field.isRawId());
     }
 
-    public void visitTableFetcher(RealTable table, Fetcher<?> fetcher) {}
+    public void visitTableFetcher(RealTable table, Fetcher<?> fetcher) {
+    }
 
-    public void visitBaseTableExpression(BaseTableOwner baseTableOwner) {}
+    public void visitBaseTableExpression(BaseTableOwner baseTableOwner) {
+    }
 
-    public void visitSaveInputValue(ImmutableProp prop) {}
+    public void visitBaseTableExpression(BaseTableOwner baseTableOwner, Expression<?> expression) {
+        visitBaseTableExpression(baseTableOwner);
+    }
 
-    public void visitStatement(AbstractMutableStatementImpl statement) {}
+    public void visitSaveInputValue(ImmutableProp prop) {
+    }
+
+    public void visitStatement(AbstractMutableStatementImpl statement) {
+    }
 
     public boolean visitSubQuery(TypedSubQuery<?> subQuery) {
         return true;

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/PropExpressionImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/PropExpressionImpl.java
@@ -4,7 +4,9 @@ import org.babyfish.jimmer.EmbeddableDto;
 import org.babyfish.jimmer.meta.EmbeddedLevel;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.TargetLevel;
-import org.babyfish.jimmer.sql.ast.*;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.render.BatchSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.table.FetcherSelectionImpl;
@@ -186,7 +188,10 @@ public class PropExpressionImpl<T>
 
     @Override
     public void accept(@NotNull AstVisitor visitor) {
-        TableImplementor<?> tableImplementor = TableProxies.resolve(table, visitor.getAstContext());
+        AstContext ctx = visitor.getAstContext();
+        Object replacement = ctx.getMutationExpressionReplacement(table);
+        Table<?> actualTable = replacement instanceof Table<?> ? (Table<?>) replacement : table;
+        TableImplementor<?> tableImplementor = TableProxies.resolve(actualTable, ctx);
         visitor.visitTableReference(
                 visitor.realTableForAnalysis(tableImplementor),
                 prop,
@@ -218,8 +223,11 @@ public class PropExpressionImpl<T>
         if (abstractBuilder.renderValueGetter(this)) {
             return;
         }
+        Object replacement = abstractBuilder.getMutationExpressionReplacement(table);
+        Table<?> actualTable = replacement instanceof Table<?> ? (Table<?>) replacement : table;
         SqlBuilder builder = abstractBuilder.assertSimple();
-        TableImplementor<?> tableImplementor = TableProxies.resolve(table, builder.getAstContext());
+        AstContext ctx = builder.getAstContext();
+        TableImplementor<?> tableImplementor = TableProxies.resolve(actualTable, ctx);
         EmbeddedColumns.Partial partial = getPartial(builder.getAstContext().getSqlClient().getMetadataStrategy());
         if (partial != null) {
             if (ignoreBrackets || partial.size() == 1) {
@@ -372,7 +380,7 @@ public class PropExpressionImpl<T>
         @Override
         public <XE extends Expression<?>> XE get(String prop) {
             ImmutableProp deeperProp = this.deepestProp.getTargetType().getProp(prop);
-            return (XE)PropExpressionImpl.of(this, deeperProp);
+            return (XE) PropExpressionImpl.of(this, deeperProp);
         }
 
         @SuppressWarnings("unchecked")
@@ -387,7 +395,7 @@ public class PropExpressionImpl<T>
                                 "\""
                 );
             }
-            return (XE)PropExpressionImpl.of(this, prop);
+            return (XE) PropExpressionImpl.of(this, prop);
         }
 
         @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/AbstractBaseTableExpression.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/AbstractBaseTableExpression.java
@@ -1,0 +1,88 @@
+package org.babyfish.jimmer.sql.ast.impl.base;
+
+import org.babyfish.jimmer.sql.ast.impl.Ast;
+import org.babyfish.jimmer.sql.ast.impl.AstContext;
+import org.babyfish.jimmer.sql.ast.impl.AstVisitor;
+import org.babyfish.jimmer.sql.ast.impl.ExpressionImplementor;
+import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
+import org.jetbrains.annotations.NotNull;
+
+abstract class AbstractBaseTableExpression<T, E extends ExpressionImplementor<T>>
+        implements ExpressionImplementor<T>, Ast {
+
+    private final E raw;
+
+    private final BaseTableOwner baseTableOwner;
+
+    AbstractBaseTableExpression(E raw, BaseTableOwner baseTableOwner) {
+        this.raw = raw;
+        this.baseTableOwner = baseTableOwner;
+    }
+
+    final E raw() {
+        return raw;
+    }
+
+    final BaseTableOwner getBaseTableOwner() {
+        return baseTableOwner;
+    }
+
+    protected Ast rawAst() {
+        return (Ast) raw;
+    }
+
+    @Override
+    public final Class<T> getType() {
+        return raw.getType();
+    }
+
+    @Override
+    public final int precedence() {
+        return raw.precedence();
+    }
+
+    @Override
+    public final void accept(@NotNull AstVisitor visitor) {
+        AstContext ctx = visitor.getAstContext();
+        Object replacement = ctx.getMutationExpressionReplacement(this);
+        if (replacement != null) {
+            if (replacement instanceof Ast) {
+                ((Ast) replacement).accept(visitor);
+            }
+            return;
+        }
+        visitor.visitBaseTableExpression(baseTableOwner, this);
+        baseTableOwner.visitOwnerStatementChain(ctx, () -> rawAst().accept(visitor));
+    }
+
+    @Override
+    public final void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
+        renderWithMutationReplacement(builder, () -> renderWithoutReplacement(builder));
+    }
+
+    protected abstract void renderWithoutReplacement(AbstractSqlBuilder<?> builder);
+
+    protected final void renderWithMutationReplacement(
+            AbstractSqlBuilder<?> builder,
+            Runnable renderWithoutReplacement
+    ) {
+        Object replacement = builder.getMutationExpressionReplacement(this);
+        if (replacement instanceof Ast) {
+            ((Ast) replacement).renderTo(builder);
+        } else if (replacement != null) {
+            builder.sql((String) replacement);
+        } else {
+            renderWithoutReplacement.run();
+        }
+    }
+
+    @Override
+    public final boolean hasVirtualPredicate() {
+        return rawAst().hasVirtualPredicate();
+    }
+
+    @Override
+    public final Ast resolveVirtualPredicate(AstContext ctx) {
+        return rawAst().resolveVirtualPredicate(ctx);
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseSelectionAliasRenderer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseSelectionAliasRenderer.java
@@ -1,8 +1,10 @@
 package org.babyfish.jimmer.sql.ast.impl.base;
 
+import org.babyfish.jimmer.impl.util.Classes;
 import org.babyfish.jimmer.sql.ast.Expression;
 import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.ast.impl.Ast;
+import org.babyfish.jimmer.sql.ast.impl.ExpressionImplementor;
 import org.babyfish.jimmer.sql.ast.impl.query.ConfigurableBaseQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
 import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
@@ -45,9 +47,28 @@ final class BaseSelectionAliasRenderer implements BaseSelectionAliasRender {
 
         if (selection instanceof Expression<?>) {
             builder.separator();
+            ConfigurableBaseQueryImpl<?> query =
+                    ((BaseTableImplementor) realBaseTable.getTableLikeImplementor()).toSymbol().getQuery();
+            boolean rootless = query.getMutableQuery().getTableLikeImplementor() == null;
+            String castType = null;
+            if (rootless && builder.sqlClient().getDialect().isRootlessSelectionCastRequired()) {
+                castType = builder.sqlClient().getDialect().sqlType(
+                        Classes.primitiveTypeOf(((ExpressionImplementor<?>) selection).getType())
+                );
+            }
+            if (castType != null) {
+                builder.sql("cast(");
+            }
             ((Ast) selection).renderTo(builder);
+            if (castType != null) {
+                builder.sql(" as ").sql(castType).sql(")");
+            }
             if (!cte) {
-                builder.sql(" c").sql(Integer.toString(exportSelection.expressionIndex()));
+                builder.sql(
+                        rootless ?
+                                " as c" :
+                                " c"
+                ).sql(Integer.toString(exportSelection.expressionIndex()));
             }
             return;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTableExpression.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTableExpression.java
@@ -3,74 +3,43 @@ package org.babyfish.jimmer.sql.ast.impl.base;
 import org.babyfish.jimmer.sql.ast.impl.*;
 import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderContext;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.Objects;
 
-class BaseTableExpression<T> implements ExpressionImplementor<T>, Ast {
-
-    private final ExpressionImplementor<T> raw;
-
-    private final BaseTableOwner baseTableOwner;
+class BaseTableExpression<T>
+        extends AbstractBaseTableExpression<T, ExpressionImplementor<T>> {
 
     BaseTableExpression(ExpressionImplementor<T> raw, BaseTableOwner baseTableOwner) {
+        super(unwrap(raw), baseTableOwner);
+    }
+
+    private static <T> ExpressionImplementor<T> unwrap(ExpressionImplementor<T> raw) {
         if (raw instanceof BaseTableExpression<?>) {
-            raw = ((BaseTableExpression<T>)raw).raw;
+            return ((BaseTableExpression<T>) raw).raw();
         }
-        this.raw = raw;
-        this.baseTableOwner = baseTableOwner;
-    }
-
-    BaseTableOwner getBaseTableOwner() {
-        return baseTableOwner;
+        return raw;
     }
 
     @Override
-    public Class<T> getType() {
-        return raw.getType();
-    }
-
-    @Override
-    public int precedence() {
-        return raw.precedence();
-    }
-
-    @Override
-    public void accept(@NotNull AstVisitor visitor) {
-        AstContext ctx = visitor.getAstContext();
-        visitor.visitBaseTableExpression(baseTableOwner);
-        baseTableOwner.visitOwnerStatementChain(ctx, () -> ((Ast) this.raw).accept(visitor));
-    }
-
-    @Override
-    public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
-        AstContext ctx = builder.assertSimple().getAstContext();
-        ctx.pushStatement((baseTableOwner.baseTable.getQuery()).getMutableQuery());
+    protected void renderWithoutReplacement(AbstractSqlBuilder<?> builder) {
+        builder.assertSimple().getAstContext().pushStatement(
+                getBaseTableOwner().getBaseTable().getQuery().getMutableQuery()
+        );
         try {
             QueryRenderContext renderContext = builder.assertSimple().getQueryRenderContext();
             BaseQueryRead read = Objects.requireNonNull(
-                    renderContext.getBaseQueryReadSupport().expression(baseTableOwner),
-                    "No base-query export selection is available for " + baseTableOwner
+                    renderContext.getBaseQueryReadSupport().expression(getBaseTableOwner()),
+                    "No base-query export selection is available for " + getBaseTableOwner()
             );
             builder
                     .sql(builder.assertSimple().alias(read.getRealBaseTable()))
                     .sql(".c")
                     .sql(Integer.toString(read.index(0)));
         } finally {
-            ctx.popStatement();
+            builder.assertSimple().getAstContext().popStatement();
         }
-    }
-
-    @Override
-    public boolean hasVirtualPredicate() {
-        return ((Ast)this.raw).hasVirtualPredicate();
-    }
-
-    @Override
-    public Ast resolveVirtualPredicate(AstContext ctx) {
-        return ((Ast)this.raw).resolveVirtualPredicate(ctx);
     }
 
     static class Cmp<T extends Comparable<?>>

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTableOwner.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTableOwner.java
@@ -129,13 +129,8 @@ public final class BaseTableOwner {
             AbstractTypedEmbeddedPropExpression<?> embeddedPropExpression = (AbstractTypedEmbeddedPropExpression<?>) expression;
             return embeddedPropExpression.__baseTableOwner();
         }
-        if (expression instanceof BaseTableExpression<?>) {
-            BaseTableExpression<?> baseTableExpression = (BaseTableExpression<?>) expression;
-            return baseTableExpression.getBaseTableOwner();
-        }
-        if (expression instanceof BaseTablePropExpression<?>) {
-            BaseTablePropExpression<?> baseTablePropExpression = (BaseTablePropExpression<?>) expression;
-            return baseTablePropExpression.getBaseTableOwner();
+        if (expression instanceof AbstractBaseTableExpression<?, ?>) {
+            return ((AbstractBaseTableExpression<?, ?>) expression).getBaseTableOwner();
         }
         return null;
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTablePropExpression.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/base/BaseTablePropExpression.java
@@ -4,7 +4,6 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.PropExpression;
 import org.babyfish.jimmer.sql.ast.impl.Ast;
 import org.babyfish.jimmer.sql.ast.impl.AstContext;
-import org.babyfish.jimmer.sql.ast.impl.AstVisitor;
 import org.babyfish.jimmer.sql.ast.impl.PropExpressionImpl;
 import org.babyfish.jimmer.sql.ast.impl.query.QueryRenderContext;
 import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
@@ -21,62 +20,67 @@ import org.jetbrains.annotations.Nullable;
 import java.time.temporal.Temporal;
 import java.util.Date;
 
-class BaseTablePropExpression<T> implements PropExpressionImplementor<T>, Ast {
-
-    private final PropExpressionImplementor<T> raw;
-
-    private final BaseTableOwner baseTableOwner;
+class BaseTablePropExpression<T>
+        extends AbstractBaseTableExpression<T, PropExpressionImplementor<T>>
+        implements PropExpressionImplementor<T> {
 
     BaseTablePropExpression(PropExpressionImplementor<T> raw, BaseTableOwner baseTableOwner) {
-        if (raw instanceof BaseTablePropExpression<?>) {
-            raw = ((BaseTablePropExpression<T>) raw).raw;
-        }
-        this.raw = raw;
-        this.baseTableOwner = baseTableOwner;
+        super(unwrap(raw), baseTableOwner);
     }
 
-    BaseTableOwner getBaseTableOwner() {
-        return baseTableOwner;
+    private static <T> PropExpressionImplementor<T> unwrap(PropExpressionImplementor<T> raw) {
+        if (raw instanceof BaseTablePropExpression<?>) {
+            return ((BaseTablePropExpression<T>) raw).raw();
+        }
+        return raw;
+    }
+
+    @Override
+    protected Ast rawAst() {
+        return (Ast) raw().unwrap();
     }
 
     @Override
     public Table<?> getTable() {
-        return raw.getTable();
+        return raw().getTable();
     }
 
     @Override
     public ImmutableProp getProp() {
-        return raw.getProp();
+        return raw().getProp();
     }
 
     @Override
     public ImmutableProp getDeepestProp() {
-        return raw.getDeepestProp();
+        return raw().getDeepestProp();
     }
 
     @Override
     public PropExpressionImpl.@Nullable EmbeddedImpl<?> getBase() {
-        return raw.getBase();
+        return raw().getBase();
     }
 
     @Override
     public @Nullable String getPath() {
-        return raw.getPath();
+        return raw().getPath();
     }
 
     @Override
     public boolean isRawId() {
-        return raw.isRawId();
+        return raw().isRawId();
     }
 
     @Override
     public EmbeddedColumns.@Nullable Partial getPartial(MetadataStrategy strategy) {
-        return raw.getPartial(strategy);
+        return raw().getPartial(strategy);
     }
 
     @Override
     public void renderTo(@NotNull AbstractSqlBuilder<?> builder, boolean ignoreBrackets) {
-        renderTo(builder, ignoreBrackets, false);
+        renderWithMutationReplacement(
+                builder,
+                () -> renderWithoutReplacement(builder, ignoreBrackets, false)
+        );
     }
 
     @Override
@@ -85,37 +89,24 @@ class BaseTablePropExpression<T> implements PropExpressionImplementor<T>, Ast {
     }
 
     @Override
-    public Class<T> getType() {
-        return raw.getType();
+    protected void renderWithoutReplacement(AbstractSqlBuilder<?> builder) {
+        renderWithoutReplacement(builder, false, true);
     }
 
-    @Override
-    public int precedence() {
-        return raw.precedence();
-    }
-
-    @Override
-    public void accept(@NotNull AstVisitor visitor) {
-        AstContext ctx = visitor.getAstContext();
-        visitor.visitBaseTableExpression(baseTableOwner);
-        baseTableOwner.visitOwnerStatementChain(ctx, () -> ((Ast) raw.unwrap()).accept(visitor));
-    }
-
-    @Override
-    public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
-        renderTo(builder, false, true);
-    }
-
-    private void renderTo(@NotNull AbstractSqlBuilder<?> builder, boolean ignoreBrackets, boolean simpleCall) {
+    private void renderWithoutReplacement(
+            AbstractSqlBuilder<?> builder,
+            boolean ignoreBrackets,
+            boolean simpleCall
+    ) {
         AstContext ctx = builder.assertSimple().getAstContext();
         QueryRenderContext renderContext = builder.assertSimple().getQueryRenderContext();
-        ctx.pushStatement(baseTableOwner.getBaseTable().getQuery().getMutableQuery());
+        ctx.pushStatement(getBaseTableOwner().getBaseTable().getQuery().getMutableQuery());
         try {
-            RealTable realTable = TableProxies.resolve(raw.getTable(), ctx).realTable(renderContext);
+            RealTable realTable = TableProxies.resolve(raw().getTable(), ctx).realTable(renderContext);
             BaseQueryReadSupport readSupport = renderContext.getBaseQueryReadSupport();
             BaseQueryRead read = readSupport.propExpression(
-                    baseTableOwner,
-                    raw,
+                    getBaseTableOwner(),
+                    raw(),
                     realTable,
                     builder.sqlClient().getMetadataStrategy()
             );
@@ -123,14 +114,14 @@ class BaseTablePropExpression<T> implements PropExpressionImplementor<T>, Ast {
                 renderExportedRead(builder, read, ignoreBrackets);
                 return;
             }
-            readSupport.requireSelection(baseTableOwner);
+            readSupport.requireSelection(getBaseTableOwner());
         } finally {
             ctx.popStatement();
         }
         if (simpleCall) {
-            ((Ast) raw.unwrap()).renderTo(builder);
+            rawAst().renderTo(builder);
         } else {
-            raw.renderTo(builder, ignoreBrackets);
+            raw().renderTo(builder, ignoreBrackets);
         }
     }
 
@@ -159,16 +150,6 @@ class BaseTablePropExpression<T> implements PropExpressionImplementor<T>, Ast {
                 .sql(builder.assertSimple().alias(read.getRealBaseTable()))
                 .sql(".c")
                 .sql(Integer.toString(read.index(index)));
-    }
-
-    @Override
-    public boolean hasVirtualPredicate() {
-        return ((Ast) raw.unwrap()).hasVirtualPredicate();
-    }
-
-    @Override
-    public Ast resolveVirtualPredicate(AstContext ctx) {
-        return ((Ast) raw.unwrap()).resolveVirtualPredicate(ctx);
     }
 
     static class Cmp<T extends Comparable<?>>

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AbstractEntitySaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AbstractEntitySaveCommandImpl.java
@@ -1,13 +1,7 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
-import org.babyfish.jimmer.meta.ImmutableProp;
-import org.babyfish.jimmer.meta.ImmutableType;
-import org.babyfish.jimmer.meta.KeyMatcher;
-import org.babyfish.jimmer.meta.TargetLevel;
-import org.babyfish.jimmer.sql.DissociateAction;
-import org.babyfish.jimmer.sql.OneToMany;
-import org.babyfish.jimmer.sql.OneToOne;
-import org.babyfish.jimmer.sql.TargetTransferMode;
+import org.babyfish.jimmer.meta.*;
+import org.babyfish.jimmer.sql.*;
 import org.babyfish.jimmer.sql.ast.TypeMatchMode;
 import org.babyfish.jimmer.sql.ast.mutation.*;
 import org.babyfish.jimmer.sql.ast.table.Table;
@@ -101,7 +95,8 @@ abstract class AbstractEntitySaveCommandImpl
                         );
                     } else if (!prop.isColumnDefinition()) {
                         throw new IllegalArgumentException(
-                                "'" + prop  + "' of key group \"" + group + "\" cannot be key property because it is not property with column definition"
+                                "'" + prop + "' of key group \"" + group +
+                                        "\" cannot be key property because it is not property with column definition"
                         );
                     }
                     if (type == null) {
@@ -132,6 +127,57 @@ abstract class AbstractEntitySaveCommandImpl
         }
     }
 
+    static class VersionModeCfg extends Cfg {
+
+        final VersionMode mode;
+
+        VersionModeCfg(Cfg prev, VersionMode mode) {
+            super(prev);
+            this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+        }
+    }
+
+    static class ForceMatchedUpdateCfg extends Cfg {
+
+        ForceMatchedUpdateCfg(Cfg prev) {
+            super(prev);
+        }
+    }
+
+    static class ExactConflictTargetRequiredCfg extends Cfg {
+
+        ExactConflictTargetRequiredCfg(Cfg prev) {
+            super(prev);
+        }
+    }
+
+    static Cfg addForbiddenUpdateMask(Cfg cfg, ImmutableType type) {
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        if (inheritanceInfo != null && inheritanceInfo.getStrategy() == InheritanceType.JOINED) {
+            cfg = new UpsertMaskCfg(
+                    cfg,
+                    forbiddenUpdateMask(cfg, inheritanceInfo.getRootType())
+            );
+            for (ImmutableType tableType : Operator.joinedTableTypes(inheritanceInfo.getRootType(), type)) {
+                cfg = new UpsertMaskCfg(
+                        cfg,
+                        forbiddenUpdateMask(cfg, tableType)
+                );
+            }
+            return cfg;
+        }
+        return new UpsertMaskCfg(cfg, forbiddenUpdateMask(cfg, type));
+    }
+
+    private static UpsertMask<?> forbiddenUpdateMask(Cfg cfg, ImmutableType type) {
+        UpsertMaskCfg maskCfg = cfg.as(UpsertMaskCfg.class);
+        UpsertMask<?> mask = MapNode.toMap(maskCfg, it -> it.mapNode).get(type);
+        if (mask == null) {
+            mask = UpsertMask.of(type.getJavaClass());
+        }
+        return mask.forbidUpdate();
+    }
+
     static class AssignmentCfg extends Cfg {
 
         final MapNode<ImmutableProp, SaveAssignmentLambda> mapNode;
@@ -152,7 +198,6 @@ abstract class AbstractEntitySaveCommandImpl
             }
             if (!prop.isColumnDefinition() ||
                     prop.isId() ||
-                    prop.isVersion() ||
                     prop.isLogicalDeleted() ||
                     prop.isDiscriminator()) {
                 throw new IllegalArgumentException(
@@ -169,6 +214,33 @@ abstract class AbstractEntitySaveCommandImpl
                     p != null ? p.mapNode : null,
                     prop,
                     new SaveAssignmentLambda(type, expression)
+            );
+        }
+    }
+
+    static class UpdateWhereCfg extends Cfg {
+
+        final MapNode<ImmutableType, TypedUpdateCondition> mapNode;
+
+        UpdateWhereCfg(
+                Cfg prev,
+                ImmutableType type,
+                UpdateCondition<?, ?> condition
+        ) {
+            super(prev);
+            if (!type.isEntity()) {
+                throw new IllegalArgumentException(
+                        "Cannot set update where for the type \"" +
+                                type +
+                                "\" because it is not an entity"
+                );
+            }
+            Objects.requireNonNull(condition, "condition cannot be null");
+            UpdateWhereCfg p = prev.as(UpdateWhereCfg.class);
+            this.mapNode = new MapNode<>(
+                    p != null ? p.mapNode : null,
+                    type,
+                    new TypedUpdateCondition(type, condition)
             );
         }
     }
@@ -401,11 +473,11 @@ abstract class AbstractEntitySaveCommandImpl
         }
     }
 
-     static class PessimisticLockCfg extends Cfg {
+    static class PessimisticLockCfg extends Cfg {
 
-         final MapNode<ImmutableType, Boolean> mapNode;
+        final MapNode<ImmutableType, Boolean> mapNode;
 
-         final Boolean defaultValue;
+        final Boolean defaultValue;
 
         public PessimisticLockCfg(Cfg prev, boolean defaultValue) {
             super(prev);
@@ -414,38 +486,39 @@ abstract class AbstractEntitySaveCommandImpl
             this.defaultValue = defaultValue;
         }
 
-         public PessimisticLockCfg(Cfg prev, Class<?> entityType, boolean checking) {
-             super(prev);
-             ImmutableType type = ImmutableType.get(entityType);
-             PessimisticLockCfg p = prev.as(PessimisticLockCfg.class);
-             this.mapNode = new MapNode<>(p != null ? p.mapNode : null, type, checking);
-             this.defaultValue = p != null && p.defaultValue;
-         }
+        public PessimisticLockCfg(Cfg prev, Class<?> entityType, boolean checking) {
+            super(prev);
+            ImmutableType type = ImmutableType.get(entityType);
+            PessimisticLockCfg p = prev.as(PessimisticLockCfg.class);
+            this.mapNode = new MapNode<>(p != null ? p.mapNode : null, type, checking);
+            this.defaultValue = p != null && p.defaultValue;
+        }
     }
 
-    static class OptimisticLockLambdaCfg extends Cfg {
+    static class OptimisticLockConditionCfg extends Cfg {
 
         final MapNode<ImmutableType, UnloadedVersionBehavior> behaviorMapNode;
 
-        final MapNode<ImmutableType, UserOptimisticLock<Object, Table<Object>>> lamdadaMapNode;
+        final MapNode<ImmutableType, UpdateCondition<Object, Table<Object>>> conditionMapNode;
 
-        public OptimisticLockLambdaCfg(
+        public OptimisticLockConditionCfg(
                 Cfg prev,
                 ImmutableType type,
                 UnloadedVersionBehavior behavior,
-                UserOptimisticLock<Object, Table<Object>> block
+                UpdateCondition<Object, Table<Object>> condition
         ) {
             super(prev);
             if (!type.isEntity()) {
                 throw new IllegalArgumentException(
-                        "Cannot set the optimistic lock lambda for the type \"" +
+                        "Cannot set the optimistic lock condition for the type \"" +
                                 type +
                                 "\" because it is not entity"
                 );
             }
-            OptimisticLockLambdaCfg p = prev.as(OptimisticLockLambdaCfg.class);
+            Objects.requireNonNull(condition, "condition cannot be null");
+            OptimisticLockConditionCfg p = prev.as(OptimisticLockConditionCfg.class);
             this.behaviorMapNode = new MapNode<>(p != null ? p.behaviorMapNode : null, type, behavior);
-            this.lamdadaMapNode = new MapNode<>(p != null ? p.lamdadaMapNode : null, type, block);
+            this.conditionMapNode = new MapNode<>(p != null ? p.conditionMapNode : null, type, condition);
         }
     }
 
@@ -483,6 +556,14 @@ abstract class AbstractEntitySaveCommandImpl
         private final Map<ImmutableType, UpsertMask<?>> upsertMaskMap;
 
         private final Map<ImmutableProp, SaveAssignmentLambda> assignmentMap;
+
+        private final Map<ImmutableType, TypedUpdateCondition> updateWhereMap;
+
+        private final VersionMode versionMode;
+
+        private final boolean forceMatchedUpdate;
+
+        private final boolean exactConflictTargetRequired;
 
         private final Map<ImmutableProp, Boolean> autoCheckingMap;
 
@@ -524,7 +605,7 @@ abstract class AbstractEntitySaveCommandImpl
 
         private final Map<ImmutableType, UnloadedVersionBehavior> optimisticLockBehaviorMap;
 
-        private final Map<ImmutableType, UserOptimisticLock<Object, Table<Object>>> optimisticLockLambdaMap;
+        private final Map<ImmutableType, UpdateCondition<Object, Table<Object>>> optimisticLockConditionMap;
 
         private final boolean dumbBatchAcceptable;
 
@@ -550,6 +631,10 @@ abstract class AbstractEntitySaveCommandImpl
             KeyGroupsCfg keyPropsCfg = cfg.as(KeyGroupsCfg.class);
             UpsertMaskCfg upsertMaskCfg = cfg.as(UpsertMaskCfg.class);
             AssignmentCfg assignmentCfg = cfg.as(AssignmentCfg.class);
+            UpdateWhereCfg updateWhereCfg = cfg.as(UpdateWhereCfg.class);
+            VersionModeCfg versionModeCfg = cfg.as(VersionModeCfg.class);
+            ForceMatchedUpdateCfg forceMatchedUpdateCfg = cfg.as(ForceMatchedUpdateCfg.class);
+            ExactConflictTargetRequiredCfg exactConflictTargetRequiredCfg = cfg.as(ExactConflictTargetRequiredCfg.class);
             IdOnlyAutoCheckingCfg idOnlyAutoCheckingCfg = cfg.as(IdOnlyAutoCheckingCfg.class);
             IdOnlyAsReferenceCfg idOnlyAsReferenceCfg = cfg.as(IdOnlyAsReferenceCfg.class);
             KeyOnlyAsReferenceCfg keyOnlyAsReferenceCfg = cfg.as(KeyOnlyAsReferenceCfg.class);
@@ -561,7 +646,7 @@ abstract class AbstractEntitySaveCommandImpl
             AssociatedTypeChangeAllowedCfg associatedTypeChangeAllowedCfg =
                     cfg.as(AssociatedTypeChangeAllowedCfg.class);
             PessimisticLockCfg pessimisticLockCfg = cfg.as(PessimisticLockCfg.class);
-            OptimisticLockLambdaCfg optimisticLockLambdaCfg = cfg.as(OptimisticLockLambdaCfg.class);
+            OptimisticLockConditionCfg optimisticLockConditionCfg = cfg.as(OptimisticLockConditionCfg.class);
             DumbBatchAcceptableCfg dumbBatchAcceptableCfg = cfg.as(DumbBatchAcceptableCfg.class);
             SaveReturningEnabledCfg saveReturningEnabledCfg = cfg.as(SaveReturningEnabledCfg.class);
             SaveResultReadsAllPropertiesCfg saveResultReadsAllPropertiesCfg = cfg.as(SaveResultReadsAllPropertiesCfg.class);
@@ -590,11 +675,25 @@ abstract class AbstractEntitySaveCommandImpl
             this.keyMatcherMap = keyMatcherMap(MapNode.toMap(keyPropsCfg, it -> it.mapNode));
             this.upsertMaskMap = MapNode.toMap(upsertMaskCfg, it -> it.mapNode);
             this.assignmentMap = MapNode.toMap(assignmentCfg, it -> it.mapNode);
+            this.versionMode = versionModeCfg != null ? versionModeCfg.mode : VersionMode.OPTIMISTIC_LOCK;
+            if (this.versionMode != VersionMode.ASSIGNMENT) {
+                for (ImmutableProp prop : this.assignmentMap.keySet()) {
+                    if (prop.isVersion()) {
+                        throw new IllegalArgumentException(
+                                "The version property \"" + prop +
+                                        "\" can only be a save assignment target in ASSIGNMENT version mode"
+                        );
+                    }
+                }
+            }
             if (this.mode == SaveMode.INSERT_ONLY && !this.assignmentMap.isEmpty()) {
                 throw new IllegalArgumentException(
                         "Save assignment expressions cannot be used with INSERT_ONLY mode"
                 );
             }
+            this.updateWhereMap = MapNode.toMap(updateWhereCfg, it -> it.mapNode);
+            this.forceMatchedUpdate = forceMatchedUpdateCfg != null;
+            this.exactConflictTargetRequired = exactConflictTargetRequiredCfg != null;
             this.autoCheckingMap = MapNode.toMap(idOnlyAutoCheckingCfg, it -> it.mapNode);
             this.autoCheckingAll = idOnlyAutoCheckingCfg != null && idOnlyAutoCheckingCfg.defaultValue;
             this.idOnlyAsReferenceMap = MapNode.toMap(idOnlyAsReferenceCfg, it -> it.mapNode);
@@ -629,8 +728,8 @@ abstract class AbstractEntitySaveCommandImpl
             this.pessimisticLockAll = pessimisticLockCfg != null ?
                     pessimisticLockCfg.defaultValue :
                     false;
-            this.optimisticLockBehaviorMap = MapNode.toMap(optimisticLockLambdaCfg, it -> it.behaviorMapNode);
-            this.optimisticLockLambdaMap = MapNode.toMap(optimisticLockLambdaCfg, it -> it.lamdadaMapNode);
+            this.optimisticLockBehaviorMap = MapNode.toMap(optimisticLockConditionCfg, it -> it.behaviorMapNode);
+            this.optimisticLockConditionMap = MapNode.toMap(optimisticLockConditionCfg, it -> it.conditionMapNode);
             this.dumbBatchAcceptable = dumbBatchAcceptableCfg != null && dumbBatchAcceptableCfg.acceptable;
             this.saveReturningEnabled = saveReturningEnabledCfg != null ?
                     saveReturningEnabledCfg.enabled :
@@ -670,7 +769,7 @@ abstract class AbstractEntitySaveCommandImpl
 
         @SuppressWarnings("unchecked")
         public <T> T getArument() {
-            return (T)argument;
+            return (T) argument;
         }
 
         @Override
@@ -727,6 +826,31 @@ abstract class AbstractEntitySaveCommandImpl
         @Override
         public Map<ImmutableProp, SaveAssignmentLambda> getAssignments() {
             return assignmentMap;
+        }
+
+        @Override
+        public TypedUpdateCondition getUpdateWhere(ImmutableType type) {
+            return updateWhereMap.get(type);
+        }
+
+        @Override
+        public Map<ImmutableType, TypedUpdateCondition> getUpdateWheres() {
+            return updateWhereMap;
+        }
+
+        @Override
+        public VersionMode getVersionMode() {
+            return versionMode;
+        }
+
+        @Override
+        public boolean isForceMatchedUpdate() {
+            return forceMatchedUpdate;
+        }
+
+        @Override
+        public boolean isExactConflictTargetRequired() {
+            return exactConflictTargetRequired;
         }
 
         public boolean isAutoCheckingProp(ImmutableProp prop) {
@@ -841,8 +965,8 @@ abstract class AbstractEntitySaveCommandImpl
         }
 
         @Override
-        public UserOptimisticLock<Object, Table<Object>> getUserOptimisticLock(ImmutableType type) {
-            return optimisticLockLambdaMap.get(type);
+        public UpdateCondition<Object, Table<Object>> getOptimisticLockCondition(ImmutableType type) {
+            return optimisticLockConditionMap.get(type);
         }
 
         @Override
@@ -889,6 +1013,10 @@ abstract class AbstractEntitySaveCommandImpl
                     associatedMode,
                     associatedModeMap,
                     assignmentMap,
+                    updateWhereMap,
+                    versionMode,
+                    forceMatchedUpdate,
+                    exactConflictTargetRequired,
                     targetTransferModeMap,
                     targetTransferModeAll,
                     typeMatchMode,
@@ -926,6 +1054,9 @@ abstract class AbstractEntitySaveCommandImpl
                     pessimisticLockAll == other.pessimisticLockAll &&
                     saveReturningEnabled == other.saveReturningEnabled &&
                     saveResultReadsAllProperties == other.saveResultReadsAllProperties &&
+                    versionMode == other.versionMode &&
+                    forceMatchedUpdate == other.forceMatchedUpdate &&
+                    exactConflictTargetRequired == other.exactConflictTargetRequired &&
                     mode == other.mode &&
                     deleteMode == other.deleteMode &&
                     Objects.equals(argument, other.argument) &&
@@ -937,6 +1068,7 @@ abstract class AbstractEntitySaveCommandImpl
                     associatedTypeChangeAllowedTypeMap.equals(other.associatedTypeChangeAllowedTypeMap) &&
                     associatedModeMap.equals(other.associatedModeMap) &&
                     assignmentMap.equals(other.assignmentMap) &&
+                    updateWhereMap.equals(other.updateWhereMap) &&
                     keyMatcherMap.equals(other.keyMatcherMap) &&
                     autoCheckingMap.equals(other.autoCheckingMap) &&
                     dissociateActionMap.equals(other.dissociateActionMap) &&
@@ -951,6 +1083,10 @@ abstract class AbstractEntitySaveCommandImpl
                     ", associatedMode=" + associatedMode +
                     ", associatedModeMap=" + associatedModeMap +
                     ", assignmentMap=" + assignmentMap +
+                    ", updateWhereMap=" + updateWhereMap +
+                    ", versionMode=" + versionMode +
+                    ", forceMatchedUpdate=" + forceMatchedUpdate +
+                    ", exactConflictTargetRequired=" + exactConflictTargetRequired +
                     ", targetTransferableMap=" + targetTransferModeMap +
                     ", targetTransferModeAll=" + targetTransferModeAll +
                     ", typeMatchMode=" + typeMatchMode +
@@ -970,7 +1106,7 @@ abstract class AbstractEntitySaveCommandImpl
                     ", autoCheckingMap=" + autoCheckingMap +
                     ", autoCheckingAll=" + autoCheckingAll +
                     ", dissociateActionMap=" + dissociateActionMap +
-                    ", optimisticLockLambdaMap=" + optimisticLockLambdaMap +
+                    ", optimisticLockConditionMap=" + optimisticLockConditionMap +
                     '}';
         }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AbstractInsertFromSelectImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AbstractInsertFromSelectImpl.java
@@ -1,0 +1,2020 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.ImmutableObjects;
+import org.babyfish.jimmer.impl.util.Classes;
+import org.babyfish.jimmer.meta.*;
+import org.babyfish.jimmer.meta.spi.ImmutableTypeImplementor;
+import org.babyfish.jimmer.runtime.DraftSpi;
+import org.babyfish.jimmer.runtime.ImmutableSpi;
+import org.babyfish.jimmer.runtime.Internal;
+import org.babyfish.jimmer.sql.Associations;
+import org.babyfish.jimmer.sql.InheritanceType;
+import org.babyfish.jimmer.sql.KeyUniqueConstraint;
+import org.babyfish.jimmer.sql.association.meta.AssociationType;
+import org.babyfish.jimmer.sql.ast.*;
+import org.babyfish.jimmer.sql.ast.impl.*;
+import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
+import org.babyfish.jimmer.sql.ast.impl.base.BaseTableProxies;
+import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbol;
+import org.babyfish.jimmer.sql.ast.impl.query.*;
+import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
+import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
+import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
+import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
+import org.babyfish.jimmer.sql.ast.mutation.*;
+import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable;
+import org.babyfish.jimmer.sql.ast.table.BaseTable;
+import org.babyfish.jimmer.sql.ast.table.Table;
+import org.babyfish.jimmer.sql.ast.table.spi.AbstractTypedTable;
+import org.babyfish.jimmer.sql.ast.table.spi.PropExpressionImplementor;
+import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
+import org.babyfish.jimmer.sql.ast.tuple.*;
+import org.babyfish.jimmer.sql.dialect.Dialect;
+import org.babyfish.jimmer.sql.dialect.InsertFromSelectContext;
+import org.babyfish.jimmer.sql.dialect.InsertFromSelectMode;
+import org.babyfish.jimmer.sql.dialect.InsertFromSelectRenderer;
+import org.babyfish.jimmer.sql.event.TriggerType;
+import org.babyfish.jimmer.sql.exception.ExecutionException;
+import org.babyfish.jimmer.sql.meta.*;
+import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
+import org.babyfish.jimmer.sql.meta.impl.SequenceIdGenerator;
+import org.babyfish.jimmer.sql.runtime.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.sql.Connection;
+import java.util.*;
+import java.util.stream.Stream;
+
+abstract class AbstractInsertFromSelectImpl<S extends BaseTable>
+        extends AbstractMutableStatementImpl
+        implements ReturningSelectable {
+
+    enum Role {KEY, INSERT, MERGE}
+
+    final S source;
+
+    final MutableRootQueryImpl<BaseTable> sourceQuery;
+
+    final TableLikeImplementor<?> sourceTable;
+
+    final BaseTableSymbol sourceSymbol;
+
+    final TypedBaseQueryImplementor<?> sourceAst;
+
+    final StatementContext context = new StatementContext(ExecutionPurpose.UPDATE);
+
+    final LinkedHashMap<Target, Assignment> assignments = new LinkedHashMap<>();
+
+    final List<Predicate> updatePredicates = new ArrayList<>();
+
+    @Nullable
+    private Predicate discriminatorUpdatePredicate;
+
+    private boolean implicitAssignmentsAdded;
+
+    private boolean materializedIdRequired;
+
+    @Nullable
+    private Target implicitSequenceIdTarget;
+
+    private boolean materializedPlan;
+
+    private List<Expression<?>> materializedSourceExpressions = Collections.emptyList();
+
+    private final TypedQueryImplementor analysisAst = new AnalysisAst();
+
+    AbstractInsertFromSelectImpl(
+            JSqlClientImplementor sqlClient,
+            TableProxy<?> target,
+            S source
+    ) {
+        super(sqlClient, target);
+        this.source = Objects.requireNonNull(source, "source cannot be null");
+        BaseTable rawSource = BaseTableProxies.unwrap(source);
+        if (!(rawSource instanceof BaseTableSymbol)) {
+            throw new IllegalArgumentException("source must be a typed base-table symbol");
+        }
+        this.sourceSymbol = (BaseTableSymbol) rawSource;
+        ConfigurableBaseQueryImpl<?> configurableSource = sourceSymbol.getQuery();
+        MergedBaseQueryImpl<?> mergedSource = MergedBaseQueryImpl.from(configurableSource);
+        this.sourceAst = mergedSource != null ? mergedSource : configurableSource;
+        this.sourceQuery = new MutableRootQueryImpl<>(
+                sqlClient,
+                rawSource,
+                ExecutionPurpose.UPDATE,
+                FilterLevel.DEFAULT
+        );
+        this.sourceTable = sourceQuery.getTableLikeImplementor();
+        validateTargetType();
+    }
+
+    AbstractInsertFromSelectImpl(
+            JSqlClientImplementor sqlClient,
+            ImmutableType targetType,
+            S source
+    ) {
+        super(sqlClient, targetType);
+        this.source = Objects.requireNonNull(source, "source cannot be null");
+        BaseTable rawSource = BaseTableProxies.unwrap(source);
+        if (!(rawSource instanceof BaseTableSymbol)) {
+            throw new IllegalArgumentException("source must be a typed base-table symbol");
+        }
+        this.sourceSymbol = (BaseTableSymbol) rawSource;
+        ConfigurableBaseQueryImpl<?> configurableSource = sourceSymbol.getQuery();
+        MergedBaseQueryImpl<?> mergedSource = MergedBaseQueryImpl.from(configurableSource);
+        this.sourceAst = mergedSource != null ? mergedSource : configurableSource;
+        this.sourceQuery = new MutableRootQueryImpl<>(
+                sqlClient,
+                rawSource,
+                ExecutionPurpose.UPDATE,
+                FilterLevel.DEFAULT
+        );
+        this.sourceTable = sourceQuery.getTableLikeImplementor();
+        validateTargetType();
+    }
+
+    public TableImplementor<?> getTargetTableImplementor() {
+        return (TableImplementor<?>) getTableLikeImplementor();
+    }
+
+    private void validateTargetType() {
+        ImmutableType type = getType();
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        if (inheritanceInfo != null && inheritanceInfo.getStrategy() == InheritanceType.JOINED) {
+            throw new IllegalArgumentException(
+                    "Insert/upsert from select does not support joined-inheritance target type \"" +
+                            type + "\""
+            );
+        }
+    }
+
+    @Override
+    public StatementContext getContext() {
+        return context;
+    }
+
+    @Override
+    public AbstractMutableStatementImpl getParent() {
+        return null;
+    }
+
+    final <T> void addAssignment(
+            PropExpression<T> targetExpression,
+            Expression<T> insertSource,
+            @Nullable Expression<T> updateExpression,
+            Role role
+    ) {
+        validateMutable();
+        Objects.requireNonNull(insertSource, "source expression cannot be null");
+        Target target = Target.of(targetExpression, getSqlClient().getMetadataStrategy());
+        validateTarget(target);
+        Literals.bind(insertSource, targetExpression);
+        validateAssignmentType(targetExpression, insertSource);
+        if (updateExpression != null) {
+            Literals.bind(updateExpression, targetExpression);
+            validateAssignmentType(targetExpression, updateExpression);
+        }
+        Assignment assignment = new Assignment(target, insertSource, updateExpression, role);
+        if (assignments.putIfAbsent(target, assignment) != null) {
+            throw new IllegalStateException(
+                    "The target property \"" + target.prop + "\" cannot be assigned more than once"
+            );
+        }
+        validateNoOverlappingColumns(target);
+    }
+
+    private static void validateAssignmentType(
+            PropExpression<?> target,
+            Expression<?> source
+    ) {
+        Class<?> targetType = Classes.boxTypeOf(((ExpressionImplementor<?>) target).getType());
+        Class<?> sourceType = Classes.boxTypeOf(((ExpressionImplementor<?>) source).getType());
+        if (!targetType.isAssignableFrom(sourceType)) {
+            throw new IllegalArgumentException(
+                    "The source expression type \"" + sourceType.getName() +
+                            "\" is incompatible with target expression type \"" +
+                            targetType.getName() + "\""
+            );
+        }
+    }
+
+    private void validateTarget(Target target) {
+        if (!AbstractTypedTable.__refEquals(getTable(), target.table)) {
+            throw new IllegalArgumentException(
+                    "The assignment target \"" + target.expr + "\" does not belong to the mutation target"
+            );
+        }
+        if (!target.prop.isColumnDefinition()) {
+            throw new IllegalArgumentException(
+                    "The assignment target property \"" + target.prop + "\" is not backed by physical columns"
+            );
+        }
+    }
+
+    private void validateNoOverlappingColumns(Target target) {
+        Set<String> newNames = target.columnNames(getSqlClient().getMetadataStrategy());
+        for (Target oldTarget : assignments.keySet()) {
+            if (oldTarget == target) {
+                continue;
+            }
+            Set<String> names = oldTarget.columnNames(getSqlClient().getMetadataStrategy());
+            for (String name : newNames) {
+                if (names.contains(name)) {
+                    assignments.remove(target);
+                    throw new IllegalStateException(
+                            "The physical target column \"" + name + "\" cannot be assigned more than once"
+                    );
+                }
+            }
+        }
+    }
+
+    final void addUpdatePredicates(Predicate... predicates) {
+        validateMutable();
+        for (Predicate predicate : predicates) {
+            if (predicate != null) {
+                updatePredicates.add(predicate);
+            }
+        }
+    }
+
+    public Integer execute(Connection con) {
+        return getSqlClient().getConnectionManager().execute(con, this::executeCount);
+    }
+
+    private int executeCount(Connection con) {
+        SqlBuilder builder = prepareBuilder(null);
+        if (materializedPlan) {
+            return executeMaterialized(con, builder, null, null).affectedRowCount;
+        }
+        renderMutation(builder, null);
+        Tuple3<String, List<Object>, List<Integer>> sql = builder.build();
+        return getSqlClient().getExecutor().execute(
+                new Executor.Args<>(
+                        getSqlClient(),
+                        con,
+                        sql.get_1(),
+                        sql.get_2(),
+                        sql.get_3(),
+                        ExecutionPurpose.command(QueryReason.NONE),
+                        null,
+                        null,
+                        (stmt, args) -> stmt.executeUpdate()
+                )
+        );
+    }
+
+    private <R> List<R> executeReturning(
+            Connection con,
+            List<Selection<?>> selections,
+            @Nullable TupleCreator<R> tupleCreator
+    ) {
+        SqlBuilder builder = prepareBuilder(selections);
+        if (materializedPlan) {
+            return executeMaterialized(con, builder, selections, tupleCreator).rows;
+        }
+        renderMutation(builder, selections);
+        Tuple3<String, List<Object>, List<Integer>> sql = builder.build();
+        return Selectors.select(
+                getSqlClient(),
+                con,
+                sql.get_1(),
+                sql.get_2(),
+                sql.get_3(),
+                selections,
+                tupleCreator,
+                ExecutionPurpose.command(QueryReason.NONE)
+        );
+    }
+
+    private SqlBuilder prepareBuilder(@Nullable List<Selection<?>> returningSelections) {
+        validateCommand(returningSelections);
+        materializedPlan = isMaterializedExecutionRequired(returningSelections);
+        if (materializedPlan && implicitSequenceIdTarget != null) {
+            assignments.remove(implicitSequenceIdTarget);
+            implicitSequenceIdTarget = null;
+        }
+        materializedSourceExpressions = materializedPlan ?
+                collectMaterializedSourceExpressions() :
+                Collections.emptyList();
+        AstContext astContext = new AstContext(getSqlClient());
+        SqlBuilder builder = new SqlBuilder(astContext);
+        astContext.pushStatement(this);
+        try {
+            MutationQueryAnalyzer.apply(builder, analysisAst, sourceAst);
+        } finally {
+            astContext.popStatement();
+        }
+        freeze(astContext);
+        return builder;
+    }
+
+    abstract void validateSemantics();
+
+    abstract boolean isUpsert();
+
+    abstract boolean isConflictIgnored();
+
+    abstract List<Target> conflictTargets();
+
+    private void validateCommand(@Nullable List<Selection<?>> returningSelections) {
+        addImplicitAssignments();
+        if (assignments.isEmpty()) {
+            throw new IllegalStateException("At least one insert assignment is required");
+        }
+        validateSemantics();
+        if (returningSelections != null) {
+            if (returningSelections.isEmpty()) {
+                throw new IllegalArgumentException("The returning selection list cannot be empty");
+            }
+            for (Selection<?> selection : returningSelections) {
+                validateReturningSelection(selection);
+            }
+        }
+    }
+
+    private void addImplicitAssignments() {
+        if (implicitAssignmentsAdded) {
+            return;
+        }
+        implicitAssignmentsAdded = true;
+        ImmutableType type = getType();
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        if (inheritanceInfo != null && type.getDiscriminatorValue() != null) {
+            ImmutableProp prop = inheritanceInfo.getDiscriminatorProp(type);
+            Object value = inheritanceInfo.getDiscriminatorValue(type);
+            addImplicit(prop, value);
+            if (isUpsert()) {
+                PropExpression<Object> expression = ((Table<?>) getTable()).get(prop);
+                discriminatorUpdatePredicate = expression.eq(value);
+            }
+        }
+        LogicalDeletedInfo logicalDeletedInfo = type.getLogicalDeletedInfo();
+        if (logicalDeletedInfo != null) {
+            addImplicit(logicalDeletedInfo.getProp(), logicalDeletedInfo.allocateInitializedValue());
+        }
+        ImmutableProp versionProp = type.getVersionProp();
+        if (versionProp != null && assignmentByProp(versionProp) == null) {
+            addImplicit(versionProp, 0);
+        }
+        ImmutableProp idProp = type instanceof AssociationType ? null : type.getIdProp();
+        if (idProp != null && assignmentByProp(idProp) == null) {
+            IdGenerator generator = getSqlClient().getGeneratorContext().getIdGenerator(type);
+            if (generator instanceof SequenceIdGenerator) {
+                String sql = getSqlClient().getDialect().getSelectIdFromSequenceSql(
+                        ((SequenceIdGenerator) generator).getSequenceName()
+                );
+                if (sql.regionMatches(true, 0, "select ", 0, 7)) {
+                    sql = sql.substring(7);
+                }
+                int fromIndex = sql.toLowerCase(Locale.ROOT).lastIndexOf(" from ");
+                if (fromIndex != -1) {
+                    sql = sql.substring(0, fromIndex);
+                }
+                addImplicit(idProp, new NativeSqlExpression<>(idProp.getElementClass(), sql));
+                Assignment assignment = assignmentByProp(idProp);
+                if (assignment != null) {
+                    implicitSequenceIdTarget = assignment.target;
+                }
+            } else if (generator != null && !(generator instanceof IdentityIdGenerator)) {
+                materializedIdRequired = true;
+            }
+        }
+    }
+
+    private boolean isMaterializedExecutionRequired(@Nullable List<Selection<?>> returningSelections) {
+        Dialect dialect = getSqlClient().getDialect();
+        if (materializedIdRequired) {
+            return true;
+        }
+        if (getType() instanceof AssociationType) {
+            AssociationType associationType = (AssociationType) getType();
+            if (associationType.getJoinTableDeletedInfo() != null ||
+                    associationType.getJoinTableFilterInfo() != null) {
+                return true;
+            }
+        }
+        InsertFromSelectContext ctx = new NativeInsertFromSelectContext(null, returningSelections);
+        InsertFromSelectRenderer renderer = dialect.getInsertFromSelectRenderer();
+        if (getSqlClient().getTriggerType() != TriggerType.BINLOG_ONLY &&
+                !renderer.isTransactionTriggerSupported(ctx)) {
+            return true;
+        }
+        return !renderer.isSupported(ctx);
+    }
+
+    private boolean isUpdateExpressionAliasingSupported() {
+        Set<Object> availableSources = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.target.definition.size() == 1) {
+                availableSources.add(assignment.insertSource);
+            }
+        }
+        for (Expression<?> expression : collectMaterializedSourceExpressions()) {
+            if (!availableSources.contains(expression)) {
+                return false;
+            }
+        }
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.MERGE && assignment.target.definition.size() != 1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isSimpleInsertedValueUpdate() {
+        if (hasNativeUpdatePredicates()) {
+            return false;
+        }
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.MERGE &&
+                    (assignment.target.definition.size() != 1 ||
+                            assignment.updateExpression != assignment.insertSource)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasNativeUpdatePredicates() {
+        return discriminatorUpdatePredicate != null || !updatePredicates.isEmpty();
+    }
+
+    private List<Target> nativeConflictTargets() {
+        List<Target> targets = conflictTargets();
+        if (targets.isEmpty() || isIdConflict(targets)) {
+            return targets;
+        }
+        List<ImmutableProp> keyProps = new ArrayList<>(targets.size());
+        for (Target target : targets) {
+            keyProps.add(target.prop);
+        }
+        List<ImmutableProp> conflictProps = MutationKeys.keyAndLogicalDeletedProps(getType(), keyProps);
+        if (conflictProps.size() == keyProps.size() || nativeConflictPredicate() != null) {
+            return targets;
+        }
+        List<Target> nativeTargets = new ArrayList<>(targets);
+        for (ImmutableProp conflictProp : conflictProps) {
+            Assignment assignment = assignmentByProp(conflictProp);
+            if (assignment != null && !nativeTargets.contains(assignment.target)) {
+                nativeTargets.add(assignment.target);
+            }
+        }
+        return nativeTargets;
+    }
+
+    @Nullable
+    private LogicalDeletedInfo nativeConflictPredicate() {
+        List<Target> targets = conflictTargets();
+        if (targets.isEmpty() || isIdConflict(targets)) {
+            return null;
+        }
+        return MutationKeys.logicalDeletedConflictPredicate(getType());
+    }
+
+    private boolean isIdConflict(Collection<Target> targets) {
+        ImmutableProp idProp = getType() instanceof AssociationType ? null : getType().getIdProp();
+        if (idProp == null) {
+            return false;
+        }
+        Set<String> columns = new LinkedHashSet<>();
+        for (Target target : targets) {
+            columns.addAll(target.columnNames(getSqlClient().getMetadataStrategy()));
+        }
+        return columns.equals(columnNames(Collections.singleton(idProp)));
+    }
+
+    private boolean isConflictTargetUnambiguous() {
+        Set<String> selectedColumns = new LinkedHashSet<>();
+        for (Target target : conflictTargets()) {
+            selectedColumns.addAll(target.columnNames(getSqlClient().getMetadataStrategy()));
+        }
+        ImmutableProp idProp = getType() instanceof AssociationType ? null : getType().getIdProp();
+        if (idProp != null && selectedColumns.equals(columnNames(Collections.singleton(idProp)))) {
+            return getType().getKeyMatcher().toMap().isEmpty();
+        }
+        if (idProp != null && assignmentByProp(idProp) != null) {
+            return false;
+        }
+        ImmutableType keyConstraintType = keyConstraintType();
+        KeyUniqueConstraint constraint = keyUniqueConstraint(keyConstraintType);
+        if (constraint == null || !constraint.noMoreUniqueConstraints()) {
+            return false;
+        }
+        Map<String, Set<ImmutableProp>> keyGroups = keyConstraintType.getKeyMatcher().toMap();
+        return keyGroups.size() == 1 && selectedColumns.equals(columnNames(keyGroups.values().iterator().next()));
+    }
+
+    private boolean isNullableConflictTargetSupported() {
+        boolean nullable = false;
+        for (Target target : nativeConflictTargets()) {
+            if (target.prop.isNullable()) {
+                nullable = true;
+                break;
+            }
+        }
+        if (!nullable) {
+            return true;
+        }
+        KeyUniqueConstraint constraint = keyUniqueConstraint(keyConstraintType());
+        return constraint != null &&
+                constraint.isNullNotDistinct() &&
+                getSqlClient().getDialect().isUpsertWithNullableKeySupported();
+    }
+
+    private ImmutableType keyConstraintType() {
+        ImmutableType type = getType();
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        return inheritanceInfo != null ? inheritanceInfo.getRootType() : type;
+    }
+
+    @Nullable
+    private KeyUniqueConstraint keyUniqueConstraint(ImmutableType keyConstraintType) {
+        KeyUniqueConstraint constraint = getType().getJavaClass().getAnnotation(KeyUniqueConstraint.class);
+        if (constraint == null && keyConstraintType != getType()) {
+            constraint = keyConstraintType.getJavaClass().getAnnotation(KeyUniqueConstraint.class);
+        }
+        return constraint;
+    }
+
+    private List<Expression<?>> collectMaterializedSourceExpressions() {
+        AstContext ctx = new AstContext(getSqlClient());
+        List<Expression<?>> expressions = new ArrayList<>();
+        Set<Expression<?>> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<Expression<?>> loadedSources = new HashSet<>();
+        for (Assignment assignment : assignments.values()) {
+            loadedSources.add(assignment.insertSource);
+        }
+        AstVisitor visitor = new AstVisitor(ctx) {
+            @Override
+            public void visitBaseTableExpression(
+                    BaseTableOwner baseTableOwner,
+                    Expression<?> expression
+            ) {
+                if (baseTableOwner.getBaseTable() == sourceSymbol &&
+                        !loadedSources.contains(expression) &&
+                        visited.add(expression)) {
+                    expressions.add(expression);
+                }
+            }
+        };
+        ctx.pushStatement(this);
+        ctx.pushStatement(sourceQuery);
+        try {
+            for (Assignment assignment : assignments.values()) {
+                if (assignment.updateExpression != null &&
+                        assignment.updateExpression != assignment.insertSource) {
+                    ((Ast) assignment.updateExpression).accept(visitor);
+                }
+            }
+            for (Predicate predicate : updatePredicates) {
+                ((Ast) predicate).accept(visitor);
+            }
+        } finally {
+            ctx.popStatement();
+            ctx.popStatement();
+        }
+        return expressions;
+    }
+
+    private InsertFromSelectMode mutationMode() {
+        return isUpsert() ?
+                InsertFromSelectMode.UPSERT :
+                isConflictIgnored() ?
+                        InsertFromSelectMode.INSERT_IF_ABSENT :
+                        InsertFromSelectMode.INSERT;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <R> MaterializedResult<R> executeMaterialized(
+            Connection con,
+            SqlBuilder builder,
+            @Nullable List<Selection<?>> returningSelections,
+            @Nullable TupleCreator<R> tupleCreator
+    ) {
+        List<Selection<?>> sourceSelections = new ArrayList<>(assignments.size());
+        for (Assignment assignment : assignments.values()) {
+            sourceSelections.add(assignment.insertSource);
+        }
+        for (Expression<?> expression : materializedSourceExpressions) {
+            sourceSelections.add(expression);
+        }
+        renderSourceSelect(builder, sourceSelections);
+        Tuple3<String, List<Object>, List<Integer>> sql = builder.build();
+        List<Object[]> sourceRows = Selectors.select(
+                getSqlClient(),
+                con,
+                sql.get_1(),
+                sql.get_2(),
+                sql.get_3(),
+                sourceSelections,
+                args -> args,
+                ExecutionPurpose.command(QueryReason.NONE)
+        );
+        if (isUpsert()) {
+            validateDistinctMaterializedKeys(sourceRows);
+        }
+        if (getType() instanceof AssociationType) {
+            return executeMaterializedAssociation(
+                    con,
+                    sourceRows,
+                    returningSelections,
+                    tupleCreator
+            );
+        }
+        int affectedRowCount = 0;
+        List<Object> acceptedEntities = returningSelections != null ? new ArrayList<>() : null;
+        for (Object[] row : sourceRows) {
+            Object entity = createMaterializedEntity(row);
+            SimpleEntitySaveCommand<Object> command = getSqlClient()
+                    .saveCommand(entity)
+                    .setMode(
+                            isUpsert() ?
+                                    SaveMode.UPSERT :
+                                    isConflictIgnored() ?
+                                            SaveMode.INSERT_IF_ABSENT :
+                                            SaveMode.INSERT_ONLY
+                    )
+                    .setVersionMode(VersionMode.ASSIGNMENT);
+            SaveCommandImplementor implementor = (SaveCommandImplementor) command;
+            if (isUpsert() || isConflictIgnored()) {
+                implementor = (SaveCommandImplementor) implementor.setExactConflictTargetRequired();
+            }
+            if (isUpsert()) {
+                implementor = (SaveCommandImplementor) implementor.setForceMatchedUpdate();
+            }
+            command = (SimpleEntitySaveCommand<Object>) implementor;
+            if (isUpsert() || isConflictIgnored()) {
+                List<Target> conflictTargets = conflictTargets();
+                ImmutableProp idProp = getType().getIdProp();
+                Set<String> conflictColumns = new LinkedHashSet<>();
+                LinkedHashSet<ImmutableProp> keyPropSet = new LinkedHashSet<>();
+                for (Target conflictTarget : conflictTargets) {
+                    conflictColumns.addAll(
+                            conflictTarget.columnNames(getSqlClient().getMetadataStrategy())
+                    );
+                    keyPropSet.add(materializedProp(conflictTarget.prop));
+                }
+                if (idProp == null ||
+                        !conflictColumns.equals(columnNames(Collections.singleton(idProp)))) {
+                    ImmutableProp[] keyProps = keyPropSet.toArray(new ImmutableProp[0]);
+                    if (keyProps.length == 0) {
+                        throw new AssertionError("Internal bug: No materialized conflict key property");
+                    }
+                    command = command.setKeyProps(keyProps);
+                }
+            }
+            if (isUpsert()) {
+                UpsertMask mask = UpsertMask
+                        .of((Class) getType().getJavaClass())
+                        .forbidInsert()
+                        .forbidUpdate();
+                for (Assignment assignment : assignments.values()) {
+                    ImmutableProp maskProp = materializedProp(assignment.target.prop);
+                    mask = mask.addInsertableProp(maskProp);
+                    if (assignment.role == Role.MERGE) {
+                        mask = mask.addUpdatableProp(maskProp);
+                    }
+                }
+                command = command.setUpsertMask(mask);
+                command = configureMaterializedSaveCommand(command, row);
+            }
+            SimpleSaveResult<Object> result = command.execute(con);
+            affectedRowCount += result.getTotalAffectedRowCount();
+            if (acceptedEntities != null && result.isAccepted()) {
+                acceptedEntities.add(result.getModifiedEntity());
+            }
+        }
+        List<R> rows = returningSelections != null ?
+                mapEntityReturning(con, acceptedEntities, returningSelections, tupleCreator) :
+                Collections.emptyList();
+        return new MaterializedResult<>(affectedRowCount, rows);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private SimpleEntitySaveCommand<Object> configureMaterializedSaveCommand(
+            SimpleEntitySaveCommand<Object> command,
+            Object[] row
+    ) {
+        SaveCommandImplementor implementor = (SaveCommandImplementor) command;
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.MERGE &&
+                    assignment.updateExpression != null &&
+                    assignment.updateExpression != assignment.insertSource) {
+                ExpressionImplementor<?> raw = (ExpressionImplementor<?>) assignment.updateExpression;
+                implementor = (SaveCommandImplementor) implementor.setEntityAssignment(
+                        materializedProp(assignment.target.prop),
+                        (SaveAssignmentExpression) (target, values) ->
+                                new MaterializedExpression(
+                                        raw,
+                                        materializedSaveReplacements(row, target, values)
+                                )
+                );
+            }
+        }
+        if (!updatePredicates.isEmpty()) {
+            PredicateImplementor raw = (PredicateImplementor) Predicate.and(
+                    updatePredicates.toArray(new Predicate[0])
+            );
+            implementor = (SaveCommandImplementor) implementor.setEntityUpdateWhere(
+                    getType(),
+                    (UpdateCondition) (target, values) ->
+                            new MaterializedPredicate(
+                                    raw,
+                                    materializedSaveReplacements(row, target, values)
+                            )
+            );
+        }
+        return (SimpleEntitySaveCommand<Object>) implementor;
+    }
+
+    private Map<Object, Object> materializedSaveReplacements(
+            Object[] row,
+            Table<?> target,
+            ValueExpressionFactory<?> values
+    ) {
+        Map<Object, Object> replacements = materializedSourceReplacements(
+                row,
+                materializedSourceExpressions
+        );
+        replacements.put(getTable(), target);
+        for (Assignment assignment : assignments.values()) {
+            Expression<?> replacement;
+            ImmutableProp prop = materializedProp(assignment.target.prop);
+            if (assignment.target.expr.getPath() == null &&
+                    !prop.isAssociation(TargetLevel.PERSISTENT) &&
+                    !prop.isEmbedded(EmbeddedLevel.SCALAR)) {
+                replacement = values.newValue(prop);
+            } else {
+                replacement = materializedLiteral(
+                        assignment.insertSource,
+                        row[assignmentIndex(assignment)]
+                );
+            }
+            replacements.put(assignment.insertSource, replacement);
+        }
+        return replacements;
+    }
+
+    private Object createMaterializedEntity(Object[] row) {
+        return Internal.produce(getType(), null, draft -> {
+            DraftSpi spi = (DraftSpi) draft;
+            int index = 0;
+            Map<ImmutableProp, Map<String, Object>> embeddedValues = new LinkedHashMap<>();
+            for (Assignment assignment : assignments.values()) {
+                Object value = row[index++];
+                ImmutableProp prop = materializedProp(assignment.target.prop);
+                String path = assignment.target.expr.getPath();
+                if (path != null) {
+                    embeddedValues
+                            .computeIfAbsent(prop, it -> new LinkedHashMap<>())
+                            .put(path, value);
+                    continue;
+                }
+                if (prop.isAssociation(TargetLevel.ENTITY) && value != null) {
+                    value = ImmutableObjects.makeIdOnly(prop.getTargetType(), value);
+                }
+                spi.__set(prop.getId(), value);
+            }
+            for (Map.Entry<ImmutableProp, Map<String, Object>> e : embeddedValues.entrySet()) {
+                spi.__set(
+                        e.getKey().getId(),
+                        createMaterializedEmbedded(e.getKey().getTargetType(), e.getValue())
+                );
+            }
+        });
+    }
+
+    private ImmutableProp materializedProp(ImmutableProp prop) {
+        ImmutableProp actualProp = getType().getProps().get(prop.getName());
+        return actualProp != null ? actualProp : prop;
+    }
+
+    private Object createMaterializedEmbedded(
+            ImmutableType type,
+            Map<String, Object> pathValues
+    ) {
+        return Internal.produce(type, null, draft -> {
+            DraftSpi spi = (DraftSpi) draft;
+            Map<String, Map<String, Object>> nestedValues = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : pathValues.entrySet()) {
+                String path = e.getKey();
+                int dotIndex = path.indexOf('.');
+                if (dotIndex == -1) {
+                    ImmutableProp prop = type.getProp(path);
+                    spi.__set(prop.getId(), e.getValue());
+                } else {
+                    nestedValues
+                            .computeIfAbsent(path.substring(0, dotIndex), it -> new LinkedHashMap<>())
+                            .put(path.substring(dotIndex + 1), e.getValue());
+                }
+            }
+            for (Map.Entry<String, Map<String, Object>> e : nestedValues.entrySet()) {
+                ImmutableProp prop = type.getProp(e.getKey());
+                spi.__set(
+                        prop.getId(),
+                        createMaterializedEmbedded(prop.getTargetType(), e.getValue())
+                );
+            }
+        });
+    }
+
+    private Map<Object, Object> materializedSourceReplacements(
+            Object[] row,
+            List<Expression<?>> sourceExpressions
+    ) {
+        Map<Object, Object> replacements = new HashMap<>();
+        int offset = assignments.size();
+        for (int i = 0; i < sourceExpressions.size(); i++) {
+            Expression<?> sourceExpression = sourceExpressions.get(i);
+            Object value = row[offset + i];
+            Expression<?> replacement = materializedLiteral(sourceExpression, value);
+            replacements.put(sourceExpression, replacement);
+        }
+        return replacements;
+    }
+
+    private static Expression<?> materializedLiteral(Expression<?> expression, Object value) {
+        return value != null ?
+                Expression.value(value) :
+                Expression.nullValue(((ExpressionImplementor<?>) expression).getType());
+    }
+
+    private Object findMaterializedEntityById(Connection con, Object id) {
+        MutableRootQueryImpl<Table<?>> query = new MutableRootQueryImpl<>(
+                getSqlClient(),
+                (TableProxy<?>) getTable(),
+                ExecutionPurpose.MUTATE,
+                FilterLevel.IGNORE_ALL
+        );
+        Table<?> table = query.getTable();
+        query.where(table.get(getType().getIdProp()).eq(id));
+        List<?> entities = query.select(table).execute(con);
+        if (entities.isEmpty()) {
+            throw new ExecutionException(
+                    "Cannot reload the row mutated by insert/upsert-from-select, id: " + id
+            );
+        }
+        return entities.get(0);
+    }
+
+
+    private void validateDistinctMaterializedKeys(List<Object[]> rows) {
+        List<Integer> keyIndexes = new ArrayList<>();
+        int index = 0;
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.KEY) {
+                keyIndexes.add(index);
+            }
+            index++;
+        }
+        Set<List<Object>> keys = new HashSet<>();
+        for (Object[] row : rows) {
+            List<Object> key = new ArrayList<>(keyIndexes.size());
+            for (Integer keyIndex : keyIndexes) {
+                key.add(row[keyIndex]);
+            }
+            if (!keys.add(key)) {
+                throw new IllegalArgumentException(
+                        "The materialized upsert source contains duplicate key " + key
+                );
+            }
+        }
+    }
+
+    private <R> MaterializedResult<R> executeMaterializedAssociation(
+            Connection con,
+            List<Object[]> sourceRows,
+            @Nullable List<Selection<?>> returningSelections,
+            @Nullable TupleCreator<R> tupleCreator
+    ) {
+        AssociationType associationType = (AssociationType) getType();
+        Assignment sourceAssignment = assignmentByProp(associationType.getSourceProp());
+        Assignment targetAssignment = assignmentByProp(associationType.getTargetProp());
+        int sourceIndex = assignmentIndex(sourceAssignment);
+        int targetIndex = assignmentIndex(targetAssignment);
+        Associations associations = getSqlClient()
+                .getAssociations(associationType)
+                .forConnection(con);
+        int affectedRowCount = 0;
+        List<Object[]> acceptedRows = returningSelections != null ? new ArrayList<>() : null;
+        for (Object[] row : sourceRows) {
+            AssociationSaveCommandImpl command = (AssociationSaveCommandImpl) associations
+                    .saveCommand(row[sourceIndex], row[targetIndex])
+                    .ignoreConflict(isConflictIgnored())
+                    .deleteUnnecessary(false);
+            int count = isConflictIgnored() ?
+                    command.executeWithCheckingExistence(con) :
+                    command.execute(con);
+            affectedRowCount += count;
+            if (acceptedRows != null && (!isConflictIgnored() || count != 0)) {
+                acceptedRows.add(row);
+            }
+        }
+        if (returningSelections == null) {
+            return new MaterializedResult<>(affectedRowCount, Collections.emptyList());
+        }
+        List<R> rows = new ArrayList<>(acceptedRows.size());
+        for (Object[] acceptedRow : acceptedRows) {
+            Object[] values = new Object[returningSelections.size()];
+            for (int i = 0; i < values.length; i++) {
+                Target target = Target.of(
+                        (PropExpression<?>) returningSelections.get(i),
+                        getSqlClient().getMetadataStrategy()
+                );
+                values[i] = target.prop.toOriginal() == associationType.getSourceProp().toOriginal() ?
+                        acceptedRow[sourceIndex] :
+                        acceptedRow[targetIndex];
+            }
+            rows.add(toReturningRow(values, tupleCreator));
+        }
+        return new MaterializedResult<>(affectedRowCount, rows);
+    }
+
+    private int assignmentIndex(Assignment expected) {
+        int index = 0;
+        for (Assignment assignment : assignments.values()) {
+            if (assignment == expected) {
+                return index;
+            }
+            index++;
+        }
+        throw new AssertionError("Internal bug: assignment is not part of the command");
+    }
+
+    private <R> List<R> mapEntityReturning(
+            Connection con,
+            List<Object> entities,
+            List<Selection<?>> returningSelections,
+            @Nullable TupleCreator<R> tupleCreator
+    ) {
+        List<R> rows = new ArrayList<>(entities.size());
+        for (Object entity : entities) {
+            ImmutableSpi spi = (ImmutableSpi) entity;
+            for (Selection<?> selection : returningSelections) {
+                Target target = Target.of(
+                        (PropExpression<?>) selection,
+                        getSqlClient().getMetadataStrategy()
+                );
+                if (!isMaterializedTargetLoaded(spi, target)) {
+                    Object id = spi.__get(getType().getIdProp().getId());
+                    spi = (ImmutableSpi) findMaterializedEntityById(con, id);
+                    break;
+                }
+            }
+            Object[] values = new Object[returningSelections.size()];
+            for (int i = 0; i < values.length; i++) {
+                Target target = Target.of(
+                        (PropExpression<?>) returningSelections.get(i),
+                        getSqlClient().getMetadataStrategy()
+                );
+                Object value = materializedTargetValue(spi, target);
+                if (target.prop.isAssociation(TargetLevel.ENTITY) && value != null) {
+                    ImmutableSpi targetSpi = (ImmutableSpi) value;
+                    value = targetSpi.__get(target.prop.getTargetType().getIdProp().getId());
+                }
+                values[i] = value;
+            }
+            rows.add(toReturningRow(values, tupleCreator));
+        }
+        return rows;
+    }
+
+    private static boolean isMaterializedTargetLoaded(ImmutableSpi spi, Target target) {
+        if (!spi.__isLoaded(target.prop.getId())) {
+            return false;
+        }
+        Object value = spi.__get(target.prop.getId());
+        String path = target.expr.getPath();
+        if (path == null || value == null) {
+            return true;
+        }
+        ImmutableType type = target.prop.getTargetType();
+        ImmutableSpi nested = (ImmutableSpi) value;
+        for (String part : path.split("\\.")) {
+            ImmutableProp prop = type.getProp(part);
+            if (!nested.__isLoaded(prop.getId())) {
+                return false;
+            }
+            value = nested.__get(prop.getId());
+            if (value == null) {
+                return true;
+            }
+            type = prop.getTargetType();
+            if (type != null) {
+                nested = (ImmutableSpi) value;
+            }
+        }
+        return true;
+    }
+
+    private static Object materializedTargetValue(ImmutableSpi spi, Target target) {
+        Object value = spi.__get(target.prop.getId());
+        String path = target.expr.getPath();
+        if (path == null || value == null) {
+            return value;
+        }
+        ImmutableType type = target.prop.getTargetType();
+        ImmutableSpi nested = (ImmutableSpi) value;
+        for (String part : path.split("\\.")) {
+            ImmutableProp prop = type.getProp(part);
+            value = nested.__get(prop.getId());
+            if (value == null) {
+                return null;
+            }
+            type = prop.getTargetType();
+            if (type != null) {
+                nested = (ImmutableSpi) value;
+            }
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <R> R toReturningRow(Object[] values, @Nullable TupleCreator<R> tupleCreator) {
+        if (tupleCreator != null) {
+            return tupleCreator.createTuple(values);
+        }
+        switch (values.length) {
+            case 1:
+                return (R) values[0];
+            case 2:
+                return (R) new Tuple2<>(values[0], values[1]);
+            case 3:
+                return (R) new Tuple3<>(values[0], values[1], values[2]);
+            case 4:
+                return (R) new Tuple4<>(values[0], values[1], values[2], values[3]);
+            case 5:
+                return (R) new Tuple5<>(values[0], values[1], values[2], values[3], values[4]);
+            case 6:
+                return (R) new Tuple6<>(values[0], values[1], values[2], values[3], values[4], values[5]);
+            case 7:
+                return (R) new Tuple7<>(values[0], values[1], values[2], values[3], values[4], values[5], values[6]);
+            case 8:
+                return (R) new Tuple8<>(values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]);
+            case 9:
+                return (R) new Tuple9<>(values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7], values[8]);
+            default:
+                throw new AssertionError("Internal bug: Illegal returning value count " + values.length);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void addImplicit(ImmutableProp prop, Object value) {
+        if (assignmentByProp(prop) != null) {
+            return;
+        }
+        PropExpression expression = ((Table<?>) getTable()).get(prop);
+        Expression sourceExpression = value instanceof Expression<?> ?
+                (Expression<?>) value :
+                Expression.any().value(value);
+        addAssignment(expression, sourceExpression, null, Role.INSERT);
+    }
+
+    final Assignment assignmentByProp(ImmutableProp prop) {
+        ImmutableProp original = prop.toOriginal();
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.target.prop.toOriginal() == original) {
+                return assignment;
+            }
+        }
+        return null;
+    }
+
+    final List<Target> validateUniqueTargets(Collection<Target> targets, String label) {
+        if (targets.isEmpty()) {
+            throw new IllegalArgumentException(label + " cannot be empty");
+        }
+        LinkedHashSet<Target> distinctTargets = new LinkedHashSet<>();
+        for (Target target : targets) {
+            if (!distinctTargets.add(target)) {
+                throw new IllegalArgumentException(
+                        "Duplicate " + label + " property \"" + target.expr + "\""
+                );
+            }
+            if (!assignments.containsKey(target)) {
+                throw new IllegalArgumentException(
+                        "The " + label + " property \"" + target.expr + "\" has no insert assignment"
+                );
+            }
+        }
+        if (!isUnique(targets)) {
+            throw new IllegalArgumentException(
+                    "The " + label + " properties " + targets + " do not uniquely identify a target row"
+            );
+        }
+        return new ArrayList<>(targets);
+    }
+
+    private boolean isUnique(Collection<Target> targets) {
+        ImmutableType type = getType();
+        Set<String> columns = new LinkedHashSet<>();
+        for (Target target : targets) {
+            columns.addAll(target.columnNames(getSqlClient().getMetadataStrategy()));
+        }
+        ImmutableProp idProp = type instanceof AssociationType ? null : type.getIdProp();
+        if (idProp != null && columns.equals(columnNames(Collections.singleton(idProp)))) {
+            return true;
+        }
+        if (type instanceof AssociationType) {
+            return columns.equals(columnNames(Arrays.asList(
+                    type.getProp("source"),
+                    type.getProp("target")
+            )));
+        }
+        for (Set<ImmutableProp> group : type.getKeyMatcher().toMap().values()) {
+            if (columns.equals(columnNames(group))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<String> columnNames(Collection<ImmutableProp> props) {
+        Set<String> names = new LinkedHashSet<>();
+        MetadataStrategy strategy = getSqlClient().getMetadataStrategy();
+        for (ImmutableProp prop : props) {
+            Storage storage = prop.getStorage(strategy);
+            if (storage instanceof ColumnDefinition) {
+                for (String name : (ColumnDefinition) storage) {
+                    names.add(name);
+                }
+            }
+        }
+        return names;
+    }
+
+    final List<Target> inferConflictTargets() {
+        ImmutableType type = getType();
+        ImmutableProp idProp = type instanceof AssociationType ? null : type.getIdProp();
+        if (idProp != null) {
+            List<Target> idTargets = targetsForUniqueProps(Collections.singleton(idProp));
+            if (!idTargets.isEmpty()) {
+                return idTargets;
+            }
+        }
+        if (type instanceof AssociationType) {
+            List<Target> associationTargets = targetsForUniqueProps(Arrays.asList(
+                    type.getProp("source"),
+                    type.getProp("target")
+            ));
+            if (!associationTargets.isEmpty()) {
+                return associationTargets;
+            }
+        }
+        for (Set<ImmutableProp> group : type.getKeyMatcher().toMap().values()) {
+            List<Target> targets = targetsForUniqueProps(group);
+            if (!targets.isEmpty()) {
+                return targets;
+            }
+        }
+        throw new IllegalStateException(
+                "Cannot infer an eligible conflict key for target type \"" + type + "\""
+        );
+    }
+
+    private List<Target> targetsForUniqueProps(Collection<ImmutableProp> props) {
+        Set<ImmutableProp> originals = new LinkedHashSet<>();
+        for (ImmutableProp prop : props) {
+            originals.add(prop.toOriginal());
+        }
+        List<Target> targets = new ArrayList<>();
+        Set<String> assignedColumns = new LinkedHashSet<>();
+        for (Assignment assignment : assignments.values()) {
+            if (originals.contains(assignment.target.prop.toOriginal())) {
+                targets.add(assignment.target);
+                assignedColumns.addAll(
+                        assignment.target.columnNames(getSqlClient().getMetadataStrategy())
+                );
+            }
+        }
+        return assignedColumns.equals(columnNames(props)) ? targets : Collections.emptyList();
+    }
+
+    private void validateReturningSelection(Selection<?> selection) {
+        if (!(selection instanceof PropExpression<?>)) {
+            throw new IllegalArgumentException(
+                    "Insert/upsert returning supports only physical target properties"
+            );
+        }
+        Target target = Target.of(
+                (PropExpression<?>) selection,
+                getSqlClient().getMetadataStrategy()
+        );
+        validateTarget(target);
+    }
+
+    private void renderMutation(SqlBuilder builder, @Nullable List<Selection<?>> returningSelections) {
+        Dialect dialect = getSqlClient().getDialect();
+        InsertFromSelectContext ctx = new NativeInsertFromSelectContext(builder, returningSelections);
+        InsertFromSelectRenderer renderer = dialect.getInsertFromSelectRenderer();
+        if (!renderer.isSupported(ctx)) {
+            throw unsupported("native " + mutationMode().name().toLowerCase(Locale.ROOT));
+        }
+        renderer.render(ctx);
+    }
+
+    private void renderSourceSelect(SqlBuilder builder) {
+        List<Selection<?>> selections = new ArrayList<>(assignments.size());
+        for (Assignment assignment : assignments.values()) {
+            selections.add(assignment.insertSource);
+        }
+        renderSourceSelect(builder, selections);
+    }
+
+    private void renderSourceSelect(SqlBuilder builder, List<Selection<?>> selections) {
+        AstContext astContext = builder.getAstContext();
+        astContext.pushStatement(this);
+        astContext.pushStatement(sourceQuery);
+        try {
+            builder.enter(SqlBuilder.ScopeType.SELECT);
+            for (Selection<?> selection : selections) {
+                builder.separator();
+                renderExpression(builder, (Expression<?>) selection, true);
+            }
+            builder.leave();
+            builder.from();
+            sourceTable.realTable(builder.getQueryRenderContext()).renderTo(builder, false);
+        } finally {
+            astContext.popStatement();
+            astContext.popStatement();
+        }
+    }
+
+    private List<Target> assignmentTargets() {
+        List<Target> targets = new ArrayList<>(assignments.size());
+        for (Assignment assignment : assignments.values()) {
+            targets.add(assignment.target);
+        }
+        return targets;
+    }
+
+    private List<Assignment> mergeAssignments() {
+        List<Assignment> list = new ArrayList<>();
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.MERGE) {
+                list.add(assignment);
+            }
+        }
+        return list;
+    }
+
+    private Target fakeUpdateTarget() {
+        ImmutableProp prop = ((ImmutableTypeImplementor) getType()).getFakeUpdateProp();
+        if (prop == null) {
+            prop = getType().getIdProp();
+        }
+        if (prop == null) {
+            throw unsupported("fake update column selection");
+        }
+        return Target.of(((Table<?>) getTable()).get(prop), getSqlClient().getMetadataStrategy());
+    }
+
+    private void renderTargets(SqlBuilder builder, Collection<Target> targets, @Nullable String prefix) {
+        for (Target target : targets) {
+            builder.separator();
+            renderTarget(builder, target, prefix);
+        }
+    }
+
+    private void renderTarget(SqlBuilder builder, Target target, @Nullable String prefix) {
+        builder.definition(prefix, target.definition);
+    }
+
+    private void renderExpression(SqlBuilder builder, Expression<?> expression, boolean ignoreBrackets) {
+        if (expression instanceof PropExpressionImplementor<?>) {
+            ((PropExpressionImplementor<?>) expression).renderTo(builder, ignoreBrackets);
+        } else {
+            ((Ast) expression).renderTo(builder);
+        }
+    }
+
+    private void renderReturningSelections(SqlBuilder builder, List<Selection<?>> selections) {
+        builder.enter(SqlBuilder.ScopeType.COMMA);
+        for (Selection<?> selection : selections) {
+            Target target = Target.of(
+                    (PropExpression<?>) selection,
+                    getSqlClient().getMetadataStrategy()
+            );
+            builder.separator();
+            renderTarget(builder, target, null);
+        }
+        builder.leave();
+    }
+
+    private String targetAlias(SqlBuilder builder) {
+        return builder.alias(getTableLikeImplementor().realTable(builder.getQueryRenderContext()));
+    }
+
+    private final class NativeInsertFromSelectContext implements InsertFromSelectContext {
+
+        @Nullable
+        private final SqlBuilder builder;
+
+        @Nullable
+        private final List<Selection<?>> returningSelections;
+
+        private NativeInsertFromSelectContext(
+                @Nullable SqlBuilder builder,
+                @Nullable List<Selection<?>> returningSelections
+        ) {
+            this.builder = builder;
+            this.returningSelections = returningSelections;
+        }
+
+        @Override
+        public InsertFromSelectMode getMode() {
+            return mutationMode();
+        }
+
+        @Override
+        public boolean hasReturning() {
+            return returningSelections != null;
+        }
+
+        @Override
+        public boolean hasUpdateAssignments() {
+            return !mergeAssignments().isEmpty();
+        }
+
+        @Override
+        public boolean hasUpdatePredicates() {
+            return hasNativeUpdatePredicates();
+        }
+
+        @Override
+        public boolean hasConflictPredicate() {
+            return nativeConflictPredicate() != null;
+        }
+
+        @Override
+        public boolean isUpdateExpressionAliasingSupported() {
+            return AbstractInsertFromSelectImpl.this.isUpdateExpressionAliasingSupported();
+        }
+
+        @Override
+        public boolean isSimpleInsertedValueUpdate() {
+            return AbstractInsertFromSelectImpl.this.isSimpleInsertedValueUpdate();
+        }
+
+        @Override
+        public boolean isConflictTargetUnambiguous() {
+            return AbstractInsertFromSelectImpl.this.isConflictTargetUnambiguous();
+        }
+
+        @Override
+        public boolean isNullableConflictTargetSupported() {
+            return AbstractInsertFromSelectImpl.this.isNullableConflictTargetSupported();
+        }
+
+        @Override
+        public InsertFromSelectContext sql(String sql) {
+            builder().sql(sql);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext enter(AbstractSqlBuilder.ScopeType type) {
+            builder().enter(type);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext separator() {
+            builder().separator();
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext leave() {
+            builder().leave();
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendTableName() {
+            builder().sql(getType().getTableName(getSqlClient().getMetadataStrategy()));
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendTargetAlias() {
+            SqlBuilder builder = builder();
+            builder.sql(targetAlias(builder));
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendInsertColumns() {
+            renderTargets(builder(), assignmentTargets(), null);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictColumns() {
+            renderTargets(builder(), nativeConflictTargets(), null);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictPredicate(boolean targetAlias) {
+            LogicalDeletedInfo logicalDeletedInfo = nativeConflictPredicate();
+            if (logicalDeletedInfo == null) {
+                throw new IllegalStateException("No conflict predicate is available");
+            }
+            SqlBuilder builder = builder();
+            builder.logicalDeleteConflictPredicate(
+                    logicalDeletedInfo,
+                    targetAlias ? targetAlias(builder) : null
+            );
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendSourceSelect() {
+            renderSourceSelect(builder());
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendSourceTable() {
+            SqlBuilder builder = builder();
+            withSourceScope(() ->
+                    sourceTable.realTable(builder.getQueryRenderContext()).renderTo(builder, false)
+            );
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictCondition() {
+            SqlBuilder builder = builder();
+            withSourceScope(() -> {
+                String targetAlias = targetAlias(builder);
+                for (Target conflictTarget : nativeConflictTargets()) {
+                    Assignment assignment = assignments.get(conflictTarget);
+                    builder.separator();
+                    renderTarget(builder, conflictTarget, targetAlias);
+                    builder.sql(" = ");
+                    renderExpression(builder, assignment.insertSource, false);
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendInsertValues() {
+            SqlBuilder builder = builder();
+            withSourceScope(() -> {
+                for (Assignment assignment : assignments.values()) {
+                    builder.separator();
+                    renderExpression(builder, assignment.insertSource, true);
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendUpdateAssignments(
+                boolean targetAlias,
+                @Nullable String insertedValuePrefix,
+                @Nullable String insertedValueSuffix
+        ) {
+            SqlBuilder builder = builder();
+            withSourceScope(insertedValueReplacements(insertedValuePrefix, insertedValueSuffix), () -> {
+                String targetPrefix = targetAlias ? targetAlias(builder) : null;
+                for (Assignment assignment : mergeAssignments()) {
+                    builder.separator();
+                    renderTarget(builder, assignment.target, targetPrefix);
+                    builder.sql(" = ");
+                    renderExpression(builder, assignment.updateExpression, false);
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendFakeUpdateAssignment(
+                boolean leftTargetAlias,
+                boolean rightTargetAlias
+        ) {
+            SqlBuilder builder = builder();
+            Target fake = fakeUpdateTarget();
+            renderTarget(builder, fake, leftTargetAlias ? targetAlias(builder) : null);
+            builder.sql(" = ");
+            renderTarget(builder, fake, rightTargetAlias ? targetAlias(builder) : null);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendUpdatePredicates(
+                @Nullable String insertedValuePrefix,
+                @Nullable String insertedValueSuffix
+        ) {
+            SqlBuilder builder = builder();
+            withSourceScope(insertedValueReplacements(insertedValuePrefix, insertedValueSuffix), () -> {
+                if (discriminatorUpdatePredicate != null) {
+                    builder.separator();
+                    ((Ast) discriminatorUpdatePredicate).renderTo(builder);
+                }
+                for (Predicate predicate : updatePredicates) {
+                    builder.separator();
+                    ((Ast) predicate).renderTo(builder);
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendReturning() {
+            if (returningSelections == null) {
+                throw new IllegalStateException("No returning selections are available");
+            }
+            renderReturningSelections(builder(), returningSelections);
+            return this;
+        }
+
+        private SqlBuilder builder() {
+            if (builder == null) {
+                throw new IllegalStateException("The capability context cannot render SQL");
+            }
+            return builder;
+        }
+
+        private Map<Object, String> insertedValueReplacements(
+                @Nullable String prefix,
+                @Nullable String suffix
+        ) {
+            if (prefix == null) {
+                return Collections.emptyMap();
+            }
+            String actualSuffix = suffix != null ? suffix : "";
+            Map<Object, String> map = new HashMap<>();
+            for (Assignment assignment : assignments.values()) {
+                if (assignment.target.definition.size() == 1) {
+                    map.put(
+                            assignment.insertSource,
+                            prefix + assignment.target.definition.name(0) + actualSuffix
+                    );
+                }
+            }
+            return map;
+        }
+
+        private void withSourceScope(Runnable block) {
+            withSourceScope(Collections.emptyMap(), block);
+        }
+
+        private void withSourceScope(Map<Object, String> replacements, Runnable block) {
+            AstContext astContext = builder().getAstContext();
+            astContext.pushStatement(AbstractInsertFromSelectImpl.this);
+            astContext.pushStatement(sourceQuery);
+            if (!replacements.isEmpty()) {
+                astContext.pushMutationExpressionMap(replacements);
+            }
+            try {
+                block.run();
+            } finally {
+                if (!replacements.isEmpty()) {
+                    astContext.popMutationExpressionMap();
+                }
+                astContext.popStatement();
+                astContext.popStatement();
+            }
+        }
+    }
+
+    final ExecutionException unsupported(String capability) {
+        return new ExecutionException(
+                "Dialect \"" + getSqlClient().getDialect().getClass().getName() +
+                        "\" cannot preserve " + (isUpsert() ? "upsert" : "insert") +
+                        "-from-select semantics: unsupported " + capability
+        );
+    }
+
+    private void acceptForAnalysis(@NotNull AstVisitor visitor) {
+        AstContext astContext = visitor.getAstContext();
+        astContext.pushStatement(this);
+        astContext.pushStatement(sourceQuery);
+        try {
+            visitor.visitStatement(this);
+            visitor.visitStatement(sourceQuery);
+            for (Assignment assignment : assignments.values()) {
+                ((Ast) assignment.target.expr).accept(visitor);
+                ((Ast) assignment.insertSource).accept(visitor);
+                if (assignment.updateExpression != null) {
+                    ((Ast) assignment.updateExpression).accept(visitor);
+                }
+            }
+            for (Predicate predicate : updatePredicates) {
+                ((Ast) predicate).accept(visitor);
+            }
+            if (discriminatorUpdatePredicate != null) {
+                ((Ast) discriminatorUpdatePredicate).accept(visitor);
+            }
+        } finally {
+            astContext.popStatement();
+            astContext.popStatement();
+        }
+    }
+
+    @Override
+    public <R> SelectionExecutable<R> returning(Selection<R> selection) {
+        return returning0(Collections.singletonList(selection), null);
+    }
+
+    @Override
+    public <T1, T2> SelectionExecutable<Tuple2<T1, T2>> returning(Selection<T1> s1, Selection<T2> s2) {
+        return returning0(Arrays.asList(s1, s2), null);
+    }
+
+    @Override
+    public <T1, T2, T3> SelectionExecutable<Tuple3<T1, T2, T3>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4> SelectionExecutable<Tuple4<T1, T2, T3, T4>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5> SelectionExecutable<Tuple5<T1, T2, T3, T4, T5>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4,
+            Selection<T5> s5
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4, s5), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6> SelectionExecutable<Tuple6<T1, T2, T3, T4, T5, T6>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4,
+            Selection<T5> s5,
+            Selection<T6> s6
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4, s5, s6), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7> SelectionExecutable<Tuple7<T1, T2, T3, T4, T5, T6, T7>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4,
+            Selection<T5> s5,
+            Selection<T6> s6,
+            Selection<T7> s7
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4, s5, s6, s7), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8> SelectionExecutable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4,
+            Selection<T5> s5,
+            Selection<T6> s6,
+            Selection<T7> s7,
+            Selection<T8> s8
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4, s5, s6, s7, s8), null);
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    SelectionExecutable<Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> returning(
+            Selection<T1> s1,
+            Selection<T2> s2,
+            Selection<T3> s3,
+            Selection<T4> s4,
+            Selection<T5> s5,
+            Selection<T6> s6,
+            Selection<T7> s7,
+            Selection<T8> s8,
+            Selection<T9> s9
+    ) {
+        return returning0(Arrays.asList(s1, s2, s3, s4, s5, s6, s7, s8, s9), null);
+    }
+
+    @Override
+    public <R> SelectionExecutable<R> returning(TupleMapper<R> mapper) {
+        Objects.requireNonNull(mapper, "mapper cannot be null");
+        return returning0(mapper.getSelections(), mapper);
+    }
+
+    private <R> SelectionExecutable<R> returning0(
+            List<Selection<?>> selections,
+            @Nullable TupleCreator<R> tupleCreator
+    ) {
+        validateMutable();
+        List<Selection<?>> immutableSelections = Collections.unmodifiableList(new ArrayList<>(selections));
+        return new SelectionExecutable<R>() {
+            @Override
+            public List<R> execute(Connection con) {
+                return getSqlClient().getConnectionManager().execute(
+                        con,
+                        it -> executeReturning(it, immutableSelections, tupleCreator)
+                );
+            }
+
+            @Override
+            public Stream<R> stream(Connection con) {
+                return execute(con).stream();
+            }
+        };
+    }
+
+    static final class Assignment {
+
+        final Target target;
+        final Expression<?> insertSource;
+        final Expression<?> updateExpression;
+        final Role role;
+
+        Assignment(Target target, Expression<?> insertSource, Expression<?> updateExpression, Role role) {
+            this.target = target;
+            this.insertSource = insertSource;
+            this.updateExpression = updateExpression;
+            this.role = role;
+        }
+    }
+
+    private static final class MaterializedResult<R> {
+
+        final int affectedRowCount;
+
+        final List<R> rows;
+
+        MaterializedResult(int affectedRowCount, List<R> rows) {
+            this.affectedRowCount = affectedRowCount;
+            this.rows = rows;
+        }
+    }
+
+    static final class Target {
+
+        final Table<?> table;
+        final ImmutableProp prop;
+        final PropExpressionImplementor<?> expr;
+        final ColumnDefinition definition;
+
+        private Target(
+                Table<?> table,
+                ImmutableProp prop,
+                PropExpressionImplementor<?> expr,
+                ColumnDefinition definition
+        ) {
+            this.table = table;
+            this.prop = prop;
+            this.expr = expr;
+            this.definition = definition;
+        }
+
+        static Target of(PropExpression<?> expression, MetadataStrategy strategy) {
+            if (!(expression instanceof PropExpressionImplementor<?>)) {
+                throw new IllegalArgumentException("The target must be a property expression");
+            }
+            PropExpressionImplementor<?> implementor = (PropExpressionImplementor<?>) expression;
+            Table<?> targetTable = implementor.getTable();
+            Table<?> parent;
+            ImmutableProp prop;
+            if (targetTable instanceof TableImplementor<?>) {
+                parent = ((TableImplementor<?>) targetTable).getParent();
+                prop = ((TableImplementor<?>) targetTable).getJoinProp();
+            } else {
+                parent = ((TableProxy<?>) targetTable).__parent();
+                prop = ((TableProxy<?>) targetTable).__prop();
+            }
+            if (parent != null && prop != null && implementor.getProp().isId()) {
+                targetTable = parent;
+            } else {
+                prop = implementor.getProp();
+            }
+            EmbeddedColumns.Partial partial = implementor.getPartial(strategy);
+            ColumnDefinition definition = partial != null ? partial : prop.getStorage(strategy);
+            return new Target(targetTable, prop, implementor, definition);
+        }
+
+        Set<String> columnNames(MetadataStrategy strategy) {
+            Set<String> names = new LinkedHashSet<>();
+            for (String name : definition) {
+                names.add(name);
+            }
+            return names;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Target && expr.equals(((Target) o).expr);
+        }
+
+        @Override
+        public int hashCode() {
+            return expr.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return expr.toString();
+        }
+    }
+
+    private static final class NativeSqlExpression<T> implements ExpressionImplementor<T>, Ast {
+
+        private final Class<T> type;
+        private final String sql;
+
+        @SuppressWarnings("unchecked")
+        NativeSqlExpression(Class<?> type, String sql) {
+            this.type = (Class<T>) type;
+            this.sql = sql;
+        }
+
+        @Override
+        public Class<T> getType() {
+            return type;
+        }
+
+        @Override
+        public int precedence() {
+            return 0;
+        }
+
+        @Override
+        public void accept(@NotNull AstVisitor visitor) {
+        }
+
+        @Override
+        public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
+            builder.sql(sql);
+        }
+
+        @Override
+        public boolean hasVirtualPredicate() {
+            return false;
+        }
+
+        @Override
+        public Ast resolveVirtualPredicate(AstContext ctx) {
+            return this;
+        }
+    }
+
+    private static class MaterializedExpression<T> extends AbstractExpression<T> {
+
+        private final ExpressionImplementor<T> raw;
+
+        private final Map<Object, Object> replacements;
+
+        private MaterializedExpression(
+                ExpressionImplementor<T> raw,
+                Map<Object, Object> replacements
+        ) {
+            this.raw = raw;
+            this.replacements = replacements;
+        }
+
+        @Override
+        public Class<T> getType() {
+            return raw.getType();
+        }
+
+        @Override
+        public int precedence() {
+            return raw.precedence();
+        }
+
+        @Override
+        public void accept(@NotNull AstVisitor visitor) {
+            AstContext ctx = visitor.getAstContext();
+            ctx.pushMutationExpressionMap(replacements);
+            try {
+                ((Ast) raw).accept(visitor);
+            } finally {
+                ctx.popMutationExpressionMap();
+            }
+        }
+
+        @Override
+        public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
+            builder.pushMutationExpressionMap(replacements);
+            try {
+                ((Ast) raw).renderTo(builder);
+            } finally {
+                builder.popMutationExpressionMap();
+            }
+        }
+
+        @Override
+        protected boolean determineHasVirtualPredicate() {
+            return false;
+        }
+
+        @Override
+        protected Ast onResolveVirtualPredicate(AstContext ctx) {
+            return this;
+        }
+    }
+
+    private static final class MaterializedPredicate extends AbstractPredicate {
+
+        private final PredicateImplementor raw;
+
+        private final Map<Object, Object> replacements;
+
+        private MaterializedPredicate(
+                PredicateImplementor raw,
+                Map<Object, Object> replacements
+        ) {
+            this.raw = raw;
+            this.replacements = replacements;
+        }
+
+        @Override
+        public int precedence() {
+            return raw.precedence();
+        }
+
+        @Override
+        public void accept(@NotNull AstVisitor visitor) {
+            AstContext ctx = visitor.getAstContext();
+            ctx.pushMutationExpressionMap(replacements);
+            try {
+                ((Ast) raw).accept(visitor);
+            } finally {
+                ctx.popMutationExpressionMap();
+            }
+        }
+
+        @Override
+        public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
+            builder.pushMutationExpressionMap(replacements);
+            try {
+                ((Ast) raw).renderTo(builder);
+            } finally {
+                builder.popMutationExpressionMap();
+            }
+        }
+
+        @Override
+        protected boolean determineHasVirtualPredicate() {
+            return false;
+        }
+
+        @Override
+        protected Ast onResolveVirtualPredicate(AstContext ctx) {
+            return this;
+        }
+    }
+
+    private final class AnalysisAst implements TypedQueryImplementor {
+
+        @Override
+        public List<Selection<?>> getSelections() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public JSqlClientImplementor getSqlClient() {
+            return AbstractInsertFromSelectImpl.this.getSqlClient();
+        }
+
+        @Override
+        public void accept(@NotNull AstVisitor visitor) {
+            acceptForAnalysis(visitor);
+        }
+
+        @Override
+        public void renderTo(@NotNull AbstractSqlBuilder<?> builder) {
+            renderMutation(builder.assertSimple(), null);
+        }
+
+        @Override
+        public boolean hasVirtualPredicate() {
+            return false;
+        }
+
+        @Override
+        public Ast resolveVirtualPredicate(AstContext ctx) {
+            return this;
+        }
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationExecutable.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationExecutable.java
@@ -5,9 +5,10 @@ import org.babyfish.jimmer.sql.association.meta.AssociationType;
 import org.babyfish.jimmer.sql.ast.Executable;
 import org.babyfish.jimmer.sql.ast.mutation.AffectedTable;
 import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
-import org.babyfish.jimmer.sql.dialect.Dialect;
 import org.babyfish.jimmer.sql.event.TriggerType;
-import org.babyfish.jimmer.sql.runtime.*;
+import org.babyfish.jimmer.sql.runtime.Executor;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.babyfish.jimmer.sql.runtime.MutationPath;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
@@ -161,13 +162,20 @@ class AssociationExecutable implements Executable<Integer> {
 
     @Override
     public Integer execute(Connection con) {
+        return execute(con, false);
+    }
+
+    Integer execute(Connection con, boolean forceCheckingExistence) {
         return sqlClient
                 .getConnectionManager()
-                .execute(con == null ? this.con : con, this::executeImpl);
+                .execute(
+                        con == null ? this.con : con,
+                        actualCon -> executeImpl(actualCon, forceCheckingExistence)
+                );
     }
 
     @SuppressWarnings("unchecked")
-    private Integer executeImpl(Connection con) {
+    private Integer executeImpl(Connection con, boolean forceCheckingExistence) {
         if (sqlClient.isTargetTransferable()) {
             Executor.validateMutationConnection(con);
         }
@@ -227,7 +235,7 @@ class AssociationExecutable implements Executable<Integer> {
                 operator.disconnectExcept(IdPairs.retain(idPairs));
             }
             if (checkExistence) {
-                operator.merge(idPairs);
+                operator.merge(idPairs, forceCheckingExistence);
             } else {
                 operator.append(idPairs);
             }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationSaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/AssociationSaveCommandImpl.java
@@ -42,4 +42,8 @@ class AssociationSaveCommandImpl implements AssociationSaveCommand {
     private Integer executeImpl(Connection con) {
         return executable.execute(con);
     }
+
+    int executeWithCheckingExistence(Connection con) {
+        return executable.execute(con, true);
+    }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/BatchEntitySaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/BatchEntitySaveCommandImpl.java
@@ -84,6 +84,11 @@ public class BatchEntitySaveCommandImpl<E>
     }
 
     @Override
+    public BatchEntitySaveCommand<E> setVersionMode(VersionMode mode) {
+        return new BatchEntitySaveCommandImpl<>(new VersionModeCfg(cfg, mode));
+    }
+
+    @Override
     public BatchEntitySaveCommand<E> setAssociatedModeAll(AssociatedSaveMode mode) {
         return new BatchEntitySaveCommandImpl<>(new AssociatedModeCfg(cfg, mode));
     }
@@ -99,8 +104,33 @@ public class BatchEntitySaveCommandImpl<E>
     }
 
     @Override
+    public BatchEntitySaveCommand<E> forbidUpdate() {
+        RootCfg rootCfg = cfg.as(RootCfg.class);
+        assert rootCfg != null;
+        Cfg newCfg = cfg;
+        Set<ImmutableType> types = new LinkedHashSet<>();
+        for (Object entity : (Iterable<?>) rootCfg.argument) {
+            types.add(((ImmutableSpi) entity).__type());
+        }
+        for (ImmutableType type : types) {
+            newCfg = addForbiddenUpdateMask(newCfg, type);
+        }
+        return new BatchEntitySaveCommandImpl<>(newCfg);
+    }
+
+    @Override
     public BatchEntitySaveCommand<E> setUpsertMask(UpsertMask<?> mask) {
         return new BatchEntitySaveCommandImpl<>(new UpsertMaskCfg(cfg, mask));
+    }
+
+    @Override
+    public BatchEntitySaveCommand<E> setForceMatchedUpdate() {
+        return new BatchEntitySaveCommandImpl<>(new ForceMatchedUpdateCfg(cfg));
+    }
+
+    @Override
+    public BatchEntitySaveCommand<E> setExactConflictTargetRequired() {
+        return new BatchEntitySaveCommandImpl<>(new ExactConflictTargetRequiredCfg(cfg));
     }
 
     @Override
@@ -122,6 +152,24 @@ public class BatchEntitySaveCommandImpl<E>
         return new BatchEntitySaveCommandImpl<>(
                 new AssignmentCfg(cfg, prop, prop.getDeclaringType(), expression)
         );
+    }
+
+    @Override
+    public <X, T extends Table<X>> BatchEntitySaveCommand<E> setUpdateWhere(
+            Class<T> tableType,
+            UpdateCondition<X, T> condition
+    ) {
+        return new BatchEntitySaveCommandImpl<>(
+                new UpdateWhereCfg(cfg, ImmutableType.get(tableType), condition)
+        );
+    }
+
+    @Override
+    public BatchEntitySaveCommand<E> setEntityUpdateWhere(
+            ImmutableType type,
+            UpdateCondition<?, ?> condition
+    ) {
+        return new BatchEntitySaveCommandImpl<>(new UpdateWhereCfg(cfg, type, condition));
     }
 
     @Override
@@ -151,7 +199,7 @@ public class BatchEntitySaveCommandImpl<E>
 
     @Override
     public BatchEntitySaveCommand<E> setKeyOnlyAsReference(ImmutableProp prop, boolean asReference) {
-        return new BatchEntitySaveCommandImpl<>(new KeyOnlyAsReferenceCfg(cfg, prop,asReference));
+        return new BatchEntitySaveCommandImpl<>(new KeyOnlyAsReferenceCfg(cfg, prop, asReference));
     }
 
     @Override
@@ -184,14 +232,14 @@ public class BatchEntitySaveCommandImpl<E>
     public <T extends Table<E>> BatchEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     ) {
         return new BatchEntitySaveCommandImpl<>(
-                new OptimisticLockLambdaCfg(
+                new OptimisticLockConditionCfg(
                         cfg,
                         ImmutableType.get(tableType),
                         behavior,
-                        (UserOptimisticLock<Object, Table<Object>>) block
+                        (UpdateCondition<Object, Table<Object>>) condition
                 )
         );
     }
@@ -200,14 +248,14 @@ public class BatchEntitySaveCommandImpl<E>
     public BatchEntitySaveCommand<E> setEntityOptimisticLock(
             ImmutableType type,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<Object, Table<Object>> block
+            UpdateCondition<Object, Table<Object>> condition
     ) {
         return new BatchEntitySaveCommandImpl<>(
-                new OptimisticLockLambdaCfg(
+                new OptimisticLockConditionCfg(
                         cfg,
                         type,
                         behavior,
-                        block
+                        condition
                 )
         );
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Deleter.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Deleter.java
@@ -1111,7 +1111,7 @@ public class Deleter {
             }
 
             @Override
-            public UserOptimisticLock<?, ?> getUserOptimisticLock(ImmutableType type) {
+            public UpdateCondition<?, ?> getOptimisticLockCondition(ImmutableType type) {
                 return null;
             }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/EntityIdPairsImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/EntityIdPairsImpl.java
@@ -5,9 +5,12 @@ import org.babyfish.jimmer.meta.PropId;
 import org.babyfish.jimmer.meta.TargetLevel;
 import org.babyfish.jimmer.runtime.ImmutableSpi;
 import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 public class EntityIdPairsImpl implements IdPairs.Retain {
 
@@ -21,11 +24,21 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
 
     private final boolean isList;
 
+    private final Predicate<ImmutableSpi> targetFilter;
+
     private List<Tuple2<Object, Object>> tuples;
 
     private List<Tuple2<Object, Collection<Object>>> entries;
 
     public EntityIdPairsImpl(Collection<? extends ImmutableSpi> rows, ImmutableProp prop) {
+        this(rows, prop, it -> true);
+    }
+
+    public EntityIdPairsImpl(
+            Collection<? extends ImmutableSpi> rows,
+            ImmutableProp prop,
+            Predicate<ImmutableSpi> targetFilter
+    ) {
         if (!prop.isAssociation(TargetLevel.ENTITY)) {
             throw new IllegalArgumentException(
                     "The property \"" +
@@ -38,6 +51,7 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
         this.sourceIdPropId = prop.getDeclaringType().getIdProp().getId();
         this.targetIdProId = prop.getTargetType().getIdProp().getId();
         this.isList = prop.isReferenceList(TargetLevel.ENTITY);
+        this.targetFilter = targetFilter;
     }
 
     @SuppressWarnings("unchecked")
@@ -50,12 +64,14 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
                 Object sourceId = row.__get(sourceIdPropId);
                 Object associatedValue = row.__get(propId);
                 if (isList) {
-                    for (ImmutableSpi e : ((Collection<ImmutableSpi>)associatedValue)) {
-                        Object targetId = e.__get(targetIdProId);
-                        tuples.add(new Tuple2<>(sourceId, targetId));
+                    for (ImmutableSpi e : ((Collection<ImmutableSpi>) associatedValue)) {
+                        if (targetFilter.test(e)) {
+                            Object targetId = e.__get(targetIdProId);
+                            tuples.add(new Tuple2<>(sourceId, targetId));
+                        }
                     }
-                } else if (associatedValue != null) {
-                    Object targetId = ((ImmutableSpi)associatedValue).__get(targetIdProId);
+                } else if (associatedValue != null && targetFilter.test((ImmutableSpi) associatedValue)) {
+                    Object targetId = ((ImmutableSpi) associatedValue).__get(targetIdProId);
                     tuples.add(new Tuple2<>(sourceId, targetId));
                 }
             }
@@ -74,21 +90,37 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
                 Object sourceId = row.__get(sourceIdPropId);
                 Object value = row.__get(propId);
                 Collection<Object> targetIds;
+                boolean includeEntry = true;
                 if (value == null) {
                     targetIds = Collections.emptyList();
                 } else if (isList) {
                     List<ImmutableSpi> list = (List<ImmutableSpi>) value;
-                    if (list.isEmpty()) {
+                    List<Object> acceptedTargetIds = new ArrayList<>(list.size());
+                    for (ImmutableSpi target : list) {
+                        if (targetFilter.test(target)) {
+                            acceptedTargetIds.add(target.__get(targetIdProId));
+                        }
+                    }
+                    if (acceptedTargetIds.isEmpty()) {
                         targetIds = Collections.emptyList();
-                    } else if (list.size() == 1) {
-                        targetIds = Collections.singletonList(list.get(0).__get(targetIdProId));
+                        includeEntry = list.isEmpty();
+                    } else if (acceptedTargetIds.size() == 1) {
+                        targetIds = Collections.singletonList(acceptedTargetIds.get(0));
                     } else {
-                        targetIds = new MultipleTargetIdCollection(list, targetIdProId);
+                        targetIds = Collections.unmodifiableList(acceptedTargetIds);
                     }
                 } else {
-                    targetIds = Collections.singletonList(((ImmutableSpi) value).__get(targetIdProId));
+                    ImmutableSpi target = (ImmutableSpi) value;
+                    if (targetFilter.test(target)) {
+                        targetIds = Collections.singletonList(target.__get(targetIdProId));
+                    } else {
+                        targetIds = Collections.emptyList();
+                        includeEntry = false;
+                    }
                 }
-                entries.add(new Tuple2<>(sourceId, targetIds));
+                if (includeEntry) {
+                    entries.add(new Tuple2<>(sourceId, targetIds));
+                }
             }
             this.entries = entries = Collections.unmodifiableList(entries);
         }
@@ -97,7 +129,7 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
 
     @Override
     public boolean isEmpty() {
-        return rows.isEmpty();
+        return entries().isEmpty();
     }
 
     @Override
@@ -105,75 +137,4 @@ public class EntityIdPairsImpl implements IdPairs.Retain {
         return "EntityIdPairs" + entries();
     }
 
-    private static class MultipleTargetIdCollection extends AbstractCollection<Object> {
-
-        private final List<ImmutableSpi> associatedRows;
-
-        private final PropId targetIdPropId;
-
-        private MultipleTargetIdCollection(List<ImmutableSpi> associatedRows, PropId targetIdPropId) {
-            this.associatedRows = associatedRows;
-            this.targetIdPropId = targetIdPropId;
-        }
-
-        @Override
-        public int size() {
-            return associatedRows.size();
-        }
-
-        @Override
-        public boolean add(Object o) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean addAll(@NotNull Collection<?> c) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean remove(Object o) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean removeAll(@NotNull Collection<?> c) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean retainAll(@NotNull Collection<?> c) {
-            throw new UnsupportedOperationException();
-        }
-
-        @NotNull
-        @Override
-        public Iterator<Object> iterator() {
-            return new Itr();
-        }
-
-        private class Itr implements Iterator<Object> {
-
-            private final Iterator<ImmutableSpi> baseItr;
-
-            Itr() {
-                this.baseItr = associatedRows.iterator();
-            }
-
-            @Override
-            public boolean hasNext() {
-                return baseItr.hasNext();
-            }
-
-            @Override
-            public Object next() {
-                return baseItr.next().__get(targetIdPropId);
-            }
-        }
-    }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/IdPairs.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/IdPairs.java
@@ -6,6 +6,7 @@ import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 interface IdPairs {
 
@@ -17,6 +18,14 @@ interface IdPairs {
 
     static Retain retain(Collection<? extends ImmutableSpi> rows, ImmutableProp prop) {
         return new EntityIdPairsImpl(rows, prop);
+    }
+
+    static Retain retain(
+            Collection<? extends ImmutableSpi> rows,
+            ImmutableProp prop,
+            Predicate<ImmutableSpi> targetFilter
+    ) {
+        return new EntityIdPairsImpl(rows, prop, targetFilter);
     }
 
     static Retain retain(IdPairs idPairs) {
@@ -50,6 +59,6 @@ interface IdPairs {
         return new TupleIdPairsImpl(Arrays.asList(tuples));
     }
 
-    interface Retain extends IdPairs {}
+    interface Retain extends IdPairs {
+    }
 }
-

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MiddleTableOperator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MiddleTableOperator.java
@@ -32,12 +32,12 @@ class MiddleTableOperator extends AbstractAssociationOperator {
 
     private static final int[] EMPTY_ROW_COUNTS = new int[0];
 
-    private static final int[] SINGLE_ERROR_ROW_COUNTS = new int[] {-1};
+    private static final int[] SINGLE_ERROR_ROW_COUNTS = new int[]{-1};
 
     private final MutationPath path;
 
     private final ExceptionTranslator<Exception> exceptionTranslator;
-    
+
     private final MutationTrigger trigger;
 
     final Map<AffectedTable, Integer> affectedRowCount;
@@ -62,7 +62,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
 
     MiddleTableOperator(SaveContext ctx, boolean isSourceLogicalDeleted) {
         this(
-                ctx.options.getSqlClient(), 
+                ctx.options.getSqlClient(),
                 ctx.con,
                 ctx.options.isBatchForbidden(),
                 ctx.options.getExceptionTranslator(),
@@ -201,7 +201,11 @@ class MiddleTableOperator extends AbstractAssociationOperator {
     }
 
     public final void merge(IdPairs idPairs) {
-        if (queryReason == QueryReason.NONE) {
+        merge(idPairs, false);
+    }
+
+    final void merge(IdPairs idPairs, boolean forceCheckingExistence) {
+        if (!forceCheckingExistence && queryReason == QueryReason.NONE) {
             int[] rowCounts = connectIfNecessary(idPairs);
             int index = 0;
             MutationTrigger trigger = this.trigger;
@@ -216,7 +220,9 @@ class MiddleTableOperator extends AbstractAssociationOperator {
         }
         Set<Tuple2<Object, Object>> existingIdTuples = findByTuples(
                 idPairs.tuples(),
-                queryReason
+                queryReason != QueryReason.NONE ?
+                        queryReason :
+                        QueryReason.NO_MORE_UNIQUE_CONSTRAINTS_REQUIRED
         );
         List<Tuple2<Object, Object>> insertingIdTuples =
                 new ArrayList<>(idPairs.tuples().size() - existingIdTuples.size());
@@ -548,7 +554,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
             int rowCount = execute(
                     builder,
                     args.deletedIds != null ?
-                            args.deletedIds:
+                            args.deletedIds :
                             args.retainedIdPairs.entries(),
                     null
             );
@@ -718,7 +724,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
         builder.sql("exists ").enter(AbstractSqlBuilder.ScopeType.SUB_QUERY);
         builder.sql("select * from ")
                 .sql(path.getParent().getType()
-                .getTableName(sqlClient.getMetadataStrategy()))
+                        .getTableName(sqlClient.getMetadataStrategy()))
                 .sql(" tb_2_");
         builder.enter(AbstractSqlBuilder.ScopeType.WHERE);
         int size = sourceGetters.size();
@@ -1085,7 +1091,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
             builder.sql(middleTable.getFilterInfo().getColumnName());
         }
     }
-    
+
     private void fireInsert(Object sourceId, Object targetId) {
         ImmutableProp prop = path.getProp();
         if (prop != null) {
@@ -1115,7 +1121,7 @@ class MiddleTableOperator extends AbstractAssociationOperator {
         }
         int[] affectedRowCounts;
         if (ex instanceof BatchUpdateException) {
-            affectedRowCounts = ((BatchUpdateException)ex).getUpdateCounts();
+            affectedRowCounts = ((BatchUpdateException) ex).getUpdateCounts();
         } else {
             affectedRowCounts = SINGLE_ERROR_ROW_COUNTS;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableInsertImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableInsertImpl.java
@@ -1,0 +1,109 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.mutation.MutableInsert;
+import org.babyfish.jimmer.sql.ast.table.BaseTable;
+import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class MutableInsertImpl<S extends BaseTable>
+        extends AbstractInsertFromSelectImpl<S>
+        implements MutableInsert<S> {
+
+    private boolean conflictIgnored;
+
+    private boolean inferConflictTargets;
+
+    private List<Target> explicitConflictTargets;
+
+    private List<Target> resolvedConflictTargets;
+
+    public MutableInsertImpl(JSqlClientImplementor sqlClient, TableProxy<?> target, S source) {
+        super(sqlClient, target, source);
+    }
+
+    public MutableInsertImpl(JSqlClientImplementor sqlClient, ImmutableType targetType, S source) {
+        super(sqlClient, targetType, source);
+    }
+
+    @Override
+    public <T> MutableInsert<S> set(PropExpression<T> target, Expression<T> source) {
+        addAssignment(target, source, null, Role.INSERT);
+        return this;
+    }
+
+    @Override
+    public MutableInsert<S> onConflictDoNothing() {
+        validateMutable();
+        conflictIgnored = true;
+        inferConflictTargets = true;
+        explicitConflictTargets = null;
+        resolvedConflictTargets = null;
+        return this;
+    }
+
+    @Override
+    public MutableInsert<S> onConflictDoNothing(PropExpression<?>... targetProps) {
+        validateMutable();
+        if (targetProps == null || targetProps.length == 0) {
+            throw new IllegalArgumentException(
+                    "Explicit conflict properties cannot be empty; use onConflictDoNothing() for inference"
+            );
+        }
+        List<Target> targets = new ArrayList<>(targetProps.length);
+        for (PropExpression<?> targetProp : targetProps) {
+            Target target = Target.of(targetProp, getSqlClient().getMetadataStrategy());
+            validateTargetForConflict(target);
+            targets.add(target);
+        }
+        conflictIgnored = true;
+        inferConflictTargets = false;
+        explicitConflictTargets = targets;
+        resolvedConflictTargets = null;
+        return this;
+    }
+
+    private void validateTargetForConflict(Target target) {
+        if (!org.babyfish.jimmer.sql.ast.table.spi.AbstractTypedTable.__refEquals(getTable(), target.table)) {
+            throw new IllegalArgumentException(
+                    "Conflict property \"" + target.prop + "\" does not belong to the mutation target"
+            );
+        }
+        if (!target.prop.isColumnDefinition()) {
+            throw new IllegalArgumentException(
+                    "Conflict property \"" + target.prop + "\" is not backed by physical columns"
+            );
+        }
+    }
+
+    @Override
+    void validateSemantics() {
+        if (!conflictIgnored) {
+            return;
+        }
+        resolvedConflictTargets = inferConflictTargets ?
+                inferConflictTargets() :
+                validateUniqueTargets(explicitConflictTargets, "conflict target");
+    }
+
+    @Override
+    boolean isUpsert() {
+        return false;
+    }
+
+    @Override
+    boolean isConflictIgnored() {
+        return conflictIgnored;
+    }
+
+    @Override
+    List<Target> conflictTargets() {
+        return resolvedConflictTargets != null ? resolvedConflictTargets : Collections.emptyList();
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpsertImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutableUpsertImpl.java
@@ -1,0 +1,91 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.Predicate;
+import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.mutation.MutableUpsert;
+import org.babyfish.jimmer.sql.ast.table.BaseTable;
+import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MutableUpsertImpl<S extends BaseTable>
+        extends AbstractInsertFromSelectImpl<S>
+        implements MutableUpsert<S> {
+
+    private List<Target> keyTargets;
+
+    public MutableUpsertImpl(JSqlClientImplementor sqlClient, TableProxy<?> target, S source) {
+        super(sqlClient, target, source);
+    }
+
+    public MutableUpsertImpl(JSqlClientImplementor sqlClient, ImmutableType targetType, S source) {
+        super(sqlClient, targetType, source);
+    }
+
+    @Override
+    public <T> MutableUpsert<S> key(PropExpression<T> target, Expression<T> source) {
+        addAssignment(target, source, null, Role.KEY);
+        return this;
+    }
+
+    @Override
+    public <T> MutableUpsert<S> insert(PropExpression<T> target, Expression<T> source) {
+        addAssignment(target, source, null, Role.INSERT);
+        return this;
+    }
+
+    @Override
+    public <T> MutableUpsert<S> merge(PropExpression<T> target, Expression<T> source) {
+        addAssignment(target, source, source, Role.MERGE);
+        return this;
+    }
+
+    @Override
+    public <T> MutableUpsert<S> merge(
+            PropExpression<T> target,
+            Expression<T> insertSource,
+            Expression<T> updateExpression
+    ) {
+        addAssignment(target, insertSource, updateExpression, Role.MERGE);
+        return this;
+    }
+
+    @Override
+    public MutableUpsert<S> updateWhere(Predicate... predicates) {
+        addUpdatePredicates(predicates);
+        return this;
+    }
+
+    @Override
+    void validateSemantics() {
+        List<Target> targets = new ArrayList<>();
+        for (Assignment assignment : assignments.values()) {
+            if (assignment.role == Role.KEY) {
+                targets.add(assignment.target);
+            }
+        }
+        if (targets.isEmpty()) {
+            throw new IllegalStateException("At least one key assignment is required for upsert");
+        }
+        keyTargets = validateUniqueTargets(targets, "upsert key");
+    }
+
+    @Override
+    boolean isUpsert() {
+        return true;
+    }
+
+    @Override
+    boolean isConflictIgnored() {
+        return false;
+    }
+
+    @Override
+    List<Target> conflictTargets() {
+        return keyTargets;
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationKeys.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/MutationKeys.java
@@ -3,6 +3,7 @@ package org.babyfish.jimmer.sql.ast.impl.mutation;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.LogicalDeletedInfo;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,7 +11,8 @@ import java.util.List;
 
 class MutationKeys {
 
-    private MutationKeys() {}
+    private MutationKeys() {
+    }
 
     static List<ImmutableProp> keyAndLogicalDeletedProps(
             ImmutableType type,
@@ -22,6 +24,14 @@ class MutationKeys {
             addProp(props, logicalDeletedInfo.getProp());
         }
         return props;
+    }
+
+    @Nullable
+    static LogicalDeletedInfo logicalDeletedConflictPredicate(ImmutableType type) {
+        LogicalDeletedInfo logicalDeletedInfo = type.getLogicalDeletedInfo();
+        return logicalDeletedInfo != null && logicalDeletedInfo.getType() == boolean.class ?
+                logicalDeletedInfo :
+                null;
     }
 
     private static void addProp(List<ImmutableProp> props, ImmutableProp prop) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Operator.java
@@ -489,11 +489,15 @@ class Operator {
         return inheritanceInfo.getDiscriminatorProp();
     }
 
-    private ImmutableProp discriminatorGuardProp(@Nullable InheritanceInfo inheritanceInfo, ImmutableType type) {
+    static @Nullable ImmutableProp discriminatorGuardProp(
+            SaveOptions options,
+            @Nullable InheritanceInfo inheritanceInfo,
+            ImmutableType type
+    ) {
         if (inheritanceInfo == null) {
             return null;
         }
-        TypeMatchMode resolvedMode = TypeMatchModes.resolve(type, ctx.options.getTypeMatchMode(type));
+        TypeMatchMode resolvedMode = TypeMatchModes.resolve(type, options.getTypeMatchMode(type));
         if (resolvedMode == TypeMatchMode.POLYMORPHIC) {
             if (inheritanceInfo.getRootType() == type) {
                 return null;
@@ -683,7 +687,7 @@ class Operator {
                 batch,
                 ctx.path.getType(),
                 typeChangeAllowed ? discriminatorProp(inheritanceInfo) : null,
-                typeChangeAllowed ? null : discriminatorGuardProp(inheritanceInfo, type),
+                typeChangeAllowed ? null : discriminatorGuardProp(ctx.options, inheritanceInfo, type),
                 typeChangeAllowed ? redundantSingleTableGetters(inheritanceInfo, type) : Collections.emptyList(),
                 ownerAcceptanceRequired,
                 false
@@ -970,11 +974,14 @@ class Operator {
     }
 
     private boolean isOptimisticLockActive(Shape rootShape) {
-        if (ctx.options.getUserOptimisticLock(ctx.path.getType()) != null) {
-            userLockOptimisticPredicate();
-            return true;
+        if (ctx.options.getOptimisticLockCondition(ctx.path.getType()) != null) {
+            return optimisticLockPredicate() != null || optimisticLockVersionGetter(rootShape) != null;
         }
-        return rootShape.getVersionGetter() != null;
+        return optimisticLockVersionGetter(rootShape) != null;
+    }
+
+    private @Nullable PropertyGetter optimisticLockVersionGetter(Shape shape) {
+        return ctx.options.getVersionMode() == VersionMode.ASSIGNMENT ? null : shape.getVersionGetter();
     }
 
     private boolean hasMissingTypeChangeRow(Batch<DraftSpi> rootBatch, Set<Object> acceptedIds) {
@@ -1217,9 +1224,12 @@ class Operator {
                             "when id property is embeddable"
             );
         }
-        Predicate userOptimisticLockPredicate = userLockOptimisticPredicate();
-        PropertyGetter versionGetter = shape.getVersionGetter();
-        boolean hasOptimisticLock = userOptimisticLockPredicate != null || versionGetter != null;
+        Predicate optimisticLockPredicate = optimisticLockPredicate();
+        Predicate updateWherePredicate = ctx.updateWhereEnabled ?
+                ctx.updateWherePredicate :
+                null;
+        PropertyGetter versionGetter = optimisticLockVersionGetter(shape);
+        boolean hasOptimisticLock = optimisticLockPredicate != null || versionGetter != null;
         if (hasOptimisticLock && keyProps != null) {
             throw new IllegalArgumentException(
                     "Cannot update batch whose shape does not have id " +
@@ -1266,7 +1276,9 @@ class Operator {
             if (prop.isId()) {
                 continue;
             }
-            if (prop.isVersion() && userOptimisticLockPredicate == null) {
+            if (prop.isVersion() &&
+                    optimisticLockPredicate == null &&
+                    ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK) {
                 continue;
             }
             if (!prop.isColumnDefinition()) {
@@ -1316,6 +1328,7 @@ class Operator {
             }
         }
         MutationTrigger trigger = fireTrigger ? ctx.trigger : null;
+        ImmutableProp unchangedVersionProp = unchangedVersionProp(updatedGetters);
         EntityCollection<DraftSpi> entities = changedProps != null ?
                 new EntityList<>(batch.entities().size()) :
                 null;
@@ -1332,7 +1345,8 @@ class Operator {
                         Collections.emptyMap();
                 for (DraftSpi draft : batch.entities()) {
                     ImmutableSpi oldRow = subMap.get(Keys.keyOf(draft, keyProps));
-                    if (hasCustomAssignments || isChanged(changedProps, oldRow, draft)) {
+                    restoreUnchangedVersion(draft, oldRow, unchangedVersionProp);
+                    if (hasCustomAssignments || fakeUpdate || isChanged(changedProps, oldRow, draft)) {
                         if (pendingTriggerData != null) {
                             pendingTriggerData.add(new Object[]{oldRow, draft});
                         }
@@ -1347,7 +1361,8 @@ class Operator {
                     ImmutableSpi oldRow = originalIdObjMap != null ?
                             originalIdObjMap.get(draft.__get(idPropId)) :
                             null;
-                    if (hasCustomAssignments || isChanged(changedProps, oldRow, draft) || hasOptimisticLock) {
+                    restoreUnchangedVersion(draft, oldRow, unchangedVersionProp);
+                    if (hasCustomAssignments || fakeUpdate || isChanged(changedProps, oldRow, draft) || hasOptimisticLock) {
                         if (pendingTriggerData != null) {
                             pendingTriggerData.add(new Object[]{oldRow, draft});
                         }
@@ -1374,7 +1389,8 @@ class Operator {
                 nullGetters,
                 null,
                 keyProps,
-                userOptimisticLockPredicate,
+                updateWherePredicate,
+                optimisticLockPredicate,
                 versionGetter,
                 fakeUpdate,
                 forceOneByOne
@@ -1398,7 +1414,8 @@ class Operator {
                     discriminatorGuardProp,
                     discriminatorGuardValue,
                     nullGetters,
-                    userOptimisticLockPredicate,
+                    updateWherePredicate,
+                    optimisticLockPredicate,
                     versionGetter,
                     fakeUpdate
             );
@@ -1413,7 +1430,7 @@ class Operator {
             );
             unloadCustomAssignmentTargets(entities, rowCounts, assignments);
         }
-        if (versionGetter != null || userOptimisticLockPredicate != null) {
+        if (versionGetter != null || optimisticLockPredicate != null) {
             int index = 0;
             for (DraftSpi row : entities) {
                 if (rowCounts[index++] == 0) {
@@ -1432,6 +1449,9 @@ class Operator {
     }
 
     private boolean isVersionUpdateRequired(@Nullable PropertyGetter versionGetter) {
+        if (ctx.options.getVersionMode() == VersionMode.ASSIGNMENT) {
+            return false;
+        }
         if (versionGetter != null) {
             return true;
         }
@@ -1511,17 +1531,29 @@ class Operator {
                 (inheritanceInfo.getRootType() != type || typeChangeAllowed)) {
             return upsertJoined(batch, inheritanceInfo, ignoreUpdate);
         }
+        ImmutableProp discriminatorGuardProp = typeChangeAllowed ?
+                null :
+                discriminatorGuardProp(ctx.options, inheritanceInfo, type);
         int[] rowCounts = upsert(
                 batch,
                 ctx.path.getType(),
                 discriminatorProp(inheritanceInfo),
                 typeChangeAllowed,
-                typeChangeAllowed ? null : discriminatorGuardProp(inheritanceInfo, type),
+                discriminatorGuardProp,
                 typeChangeAllowed ? redundantSingleTableGetters(inheritanceInfo, type) : Collections.emptyList(),
                 ignoreUpdate,
-                false
+                ctx.options.isForceMatchedUpdate() && !ignoreUpdate
         );
         if (ownerAcceptanceRequired) {
+            // An unconditional upsert accepts every row. Some drivers can report 0 for a matched
+            // self-assignment, so the physical changed-row count is not an acceptance signal here.
+            if (!ignoreUpdate &&
+                    !ctx.updateWhereEnabled &&
+                    discriminatorGuardProp == null &&
+                    ctx.options.getOptimisticLockCondition(type) == null &&
+                    (ctx.options.getVersionMode() == VersionMode.ASSIGNMENT || batch.shape().getVersionGetter() == null)) {
+                return MutationRows.UNKNOWN;
+            }
             return MutationRows.accepted(acceptedOriginalEntities(batch, rowCounts));
         }
         return MutationRows.UNKNOWN;
@@ -1693,6 +1725,7 @@ class Operator {
                 null,
                 null,
                 null,
+                null,
                 false,
                 false
         );
@@ -1835,7 +1868,8 @@ class Operator {
                     implicitKeyProps
             );
             LogicalDeletedInfo logicalDeletedInfo = batch.shape().getType().getLogicalDeletedInfo();
-            boolean filteredLogicalDeletedKey = isFilteredLogicalDeletedKey(batch.shape().getType());
+            boolean filteredLogicalDeletedKey =
+                    MutationKeys.logicalDeletedConflictPredicate(batch.shape().getType()) != null;
             conflictProps = MutationKeys.keyAndLogicalDeletedProps(batch.shape().getType(), keyProps);
             conflictGetters = new ArrayList<>();
             for (PropertyGetter getter : fullShape.getGetters()) {
@@ -1870,14 +1904,18 @@ class Operator {
         }
         List<SaveAssignment> assignments = SaveAssignments.of(ctx, batch.shape(), tableType, updatedGetters);
         if (!forceMatchedUpdate &&
+                !ctx.updateWhereEnabled &&
                 ctx.options.isIdOnlyAsReference(ctx.path.getProp()) &&
                 batch.shape().isIdOnly() &&
                 assignments.isEmpty()) {
             return EMPTY_ROW_COUNTS;
         }
 
-        Predicate userOptimisticLockPredicate = userLockOptimisticPredicate();
-        PropertyGetter versionGetter = batch.shape().getVersionGetter();
+        Predicate optimisticLockPredicate = optimisticLockPredicate();
+        Predicate updateWherePredicate = ctx.updateWhereEnabled ?
+                ctx.updateWherePredicate :
+                null;
+        PropertyGetter versionGetter = optimisticLockVersionGetter(batch.shape());
 
         SaveReturning returning = SaveReturning.forUpsert(
                 ctx,
@@ -1894,13 +1932,15 @@ class Operator {
                 conflictPredicate,
                 assignments,
                 ignoreUpdate,
-                userOptimisticLockPredicate,
+                updateWherePredicate,
+                optimisticLockPredicate,
                 versionGetter,
-                forceMatchedUpdate,
+                forceMatchedUpdate || updateWherePredicate != null,
                 forceOneByOne
         );
         if (returning != null) {
             int[] rowCounts = returning.executeUpsert(batch.entities());
+            unloadUnchangedVersion(batch.entities(), updatedGetters);
             AffectedRows.add(ctx.affectedRowCountMap, tableType, rowCount(rowCounts));
             return rowCounts;
         }
@@ -1923,9 +1963,10 @@ class Operator {
                 conflictPredicate,
                 assignments,
                 ignoreUpdate,
-                userOptimisticLockPredicate,
+                updateWherePredicate,
+                optimisticLockPredicate,
                 versionGetter,
-                forceMatchedUpdate
+                forceMatchedUpdate || updateWherePredicate != null
         );
         sqlClient.getDialect().upsert(upsertContext);
         int[] rowCounts = executeAndGetRowCounts(
@@ -1937,8 +1978,49 @@ class Operator {
                 forceOneByOne
         );
         unloadCustomAssignmentTargets(batch.entities(), rowCounts, assignments);
+        unloadUnchangedVersion(batch.entities(), updatedGetters);
         AffectedRows.add(ctx.affectedRowCountMap, tableType, rowCount(rowCounts));
         return rowCounts;
+    }
+
+    private @Nullable ImmutableProp unchangedVersionProp(List<PropertyGetter> updatedGetters) {
+        if (ctx.options.getVersionMode() != VersionMode.ASSIGNMENT) {
+            return null;
+        }
+        ImmutableProp versionProp = ctx.path.getType().getVersionProp();
+        if (versionProp == null) {
+            return null;
+        }
+        for (PropertyGetter getter : updatedGetters) {
+            if (getter.prop().toOriginal() == versionProp.toOriginal()) {
+                return null;
+            }
+        }
+        return versionProp;
+    }
+
+    private static void restoreUnchangedVersion(
+            DraftSpi draft,
+            @Nullable ImmutableSpi oldRow,
+            @Nullable ImmutableProp versionProp
+    ) {
+        if (versionProp != null && oldRow != null && oldRow.__isLoaded(versionProp.getId())) {
+            draft.__set(versionProp.getId(), oldRow.__get(versionProp.getId()));
+        }
+    }
+
+    private void unloadUnchangedVersion(
+            EntityCollection<DraftSpi> entities,
+            List<PropertyGetter> updatedGetters
+    ) {
+        ImmutableProp versionProp = unchangedVersionProp(updatedGetters);
+        if (versionProp == null) {
+            return;
+        }
+        PropId versionPropId = versionProp.getId();
+        for (DraftSpi draft : entities) {
+            draft.__unload(versionPropId);
+        }
     }
 
     private static void unloadCustomAssignmentTargets(
@@ -2094,11 +2176,6 @@ class Operator {
         }
     }
 
-    private boolean isFilteredLogicalDeletedKey(ImmutableType type) {
-        LogicalDeletedInfo logicalDeletedInfo = type.getLogicalDeletedInfo();
-        return logicalDeletedInfo != null && logicalDeletedInfo.getType() == boolean.class;
-    }
-
     private void validate(Shape shape, boolean insertOnly) {
         validate(shape, insertOnly, Collections.emptySet());
     }
@@ -2140,11 +2217,11 @@ class Operator {
     }
 
     @SuppressWarnings("unchecked")
-    private Predicate userLockOptimisticPredicate() {
+    private @Nullable Predicate optimisticLockPredicate() {
 
-        UserOptimisticLock<Object, Table<Object>> userOptimisticLock =
-                (UserOptimisticLock<Object, Table<Object>>) ctx.options.getUserOptimisticLock(ctx.path.getType());
-        if (userOptimisticLock == null) {
+        UpdateCondition<Object, Table<Object>> optimisticLockCondition =
+                (UpdateCondition<Object, Table<Object>>) ctx.options.getOptimisticLockCondition(ctx.path.getType());
+        if (optimisticLockCondition == null) {
             return null;
         }
         MutableRootQueryImpl<?> fakeQuery = new MutableRootQueryImpl<>(
@@ -2162,15 +2239,17 @@ class Operator {
         } else {
             table = ((TableProxy<?>) table).__disableJoin(GENERAL_OPTIMISTIC_DISABLED_JOIN_REASON);
         }
-        Predicate predicate = userOptimisticLock.predicate(
+        Predicate predicate = optimisticLockCondition.predicate(
                 (Table<Object>) table,
                 ValueExpressionFactories.<Object>of()
         );
-        validateUserOptimisticLockPredicate(predicate);
+        if (predicate != null) {
+            validateOptimisticLockCondition(predicate);
+        }
         return predicate;
     }
 
-    private void validateUserOptimisticLockPredicate(Predicate predicate) {
+    private void validateOptimisticLockCondition(Predicate predicate) {
         InheritanceInfo inheritanceInfo = ctx.path.getType().getInheritanceInfo();
         if (inheritanceInfo == null || inheritanceInfo.getStrategy() != InheritanceType.JOINED) {
             return;
@@ -2443,7 +2522,7 @@ class Operator {
             }
         }
 
-        PropertyGetter versionGetter = shape.getVersionGetter();
+        PropertyGetter versionGetter = optimisticLockVersionGetter(shape);
         if (updatable && versionGetter != null) {
             PropId versionPropId = versionGetter.prop().getId();
             Integer version = (Integer) item.getEntity().__get(versionPropId);
@@ -2653,7 +2732,9 @@ class Operator {
 
         private final List<PropertyGetter> nullGetters;
 
-        private final Predicate userOptimisticLockPredicate;
+        private final Predicate optimisticLockPredicate;
+
+        private final Predicate updateWherePredicate;
 
         private final PropertyGetter versionGetter;
 
@@ -2670,7 +2751,8 @@ class Operator {
                 @Nullable ImmutableProp discriminatorGuardProp,
                 @Nullable Object discriminatorGuardValue,
                 List<PropertyGetter> nullGetters,
-                Predicate userOptimisticLockPredicate,
+                Predicate updateWherePredicate,
+                Predicate optimisticLockPredicate,
                 PropertyGetter versionGetter,
                 boolean fakeUpdate
         ) {
@@ -2697,7 +2779,8 @@ class Operator {
             }
             this.discriminatorGuardValue = discriminatorGuardValue;
             this.nullGetters = nullGetters;
-            this.userOptimisticLockPredicate = userOptimisticLockPredicate;
+            this.updateWherePredicate = updateWherePredicate;
+            this.optimisticLockPredicate = optimisticLockPredicate;
             this.versionGetter = versionGetter;
             this.fakeUpdate = fakeUpdate;
         }
@@ -2791,7 +2874,8 @@ class Operator {
             PropertyGetter actualVersionGetter = versionGetter;
             if (actualVersionGetter == null) {
                 ImmutableProp versionProp = ctx.path.getType().getVersionProp();
-                if (versionProp != null &&
+                if (ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK &&
+                        versionProp != null &&
                         ctx.options.getUnloadedVersionBehavior(ctx.path.getType()) == UnloadedVersionBehavior.INCREASE
                 ) {
                     actualVersionGetter = PropertyGetter
@@ -2852,10 +2936,18 @@ class Operator {
                         .sql(" = ")
                         .variable(versionGetter);
             }
-            if (userOptimisticLockPredicate != null) {
+            if (updateWherePredicate != null) {
                 builder.separator();
                 AbstractExpression.renderChild(
-                        (Ast) userOptimisticLockPredicate,
+                        (Ast) updateWherePredicate,
+                        ExpressionPrecedences.AND,
+                        builder
+                );
+            }
+            if (optimisticLockPredicate != null) {
+                builder.separator();
+                AbstractExpression.renderChild(
+                        (Ast) optimisticLockPredicate,
                         ExpressionPrecedences.AND,
                         builder
                 );
@@ -2915,7 +3007,9 @@ class Operator {
 
         private final boolean fakeUpdate;
 
-        private final Predicate userOptimisticLockPredicate;
+        private final Predicate optimisticLockPredicate;
+
+        private final Predicate updateWherePredicate;
 
         private final PropertyGetter versionGetter;
 
@@ -2935,7 +3029,8 @@ class Operator {
                 LogicalDeletedInfo conflictPredicate,
                 List<SaveAssignment> assignments,
                 boolean updateIgnored,
-                Predicate userOptimisticLockPredicate,
+                Predicate updateWherePredicate,
+                Predicate optimisticLockPredicate,
                 PropertyGetter versionGetter,
                 boolean fakeUpdate
         ) {
@@ -2943,7 +3038,7 @@ class Operator {
                 throw new IllegalArgumentException("Generated id prop cannot be embeddable");
             }
             if (generatedIdProp != null && (
-                    userOptimisticLockPredicate != null || versionGetter != null)
+                    optimisticLockPredicate != null || versionGetter != null)
             ) {
                 throw new IllegalArgumentException(
                         "Optimistic lock is not support by upsert statement which can generate id"
@@ -2972,7 +3067,8 @@ class Operator {
             this.assignments = assignments;
             this.updateIgnored = updateIgnored;
             this.fakeUpdate = fakeUpdate;
-            this.userOptimisticLockPredicate = userOptimisticLockPredicate;
+            this.updateWherePredicate = updateWherePredicate;
+            this.optimisticLockPredicate = optimisticLockPredicate;
             this.versionGetter = versionGetter;
         }
 
@@ -2986,7 +3082,8 @@ class Operator {
 
         @Override
         public boolean hasUpdateCondition() {
-            return userOptimisticLockPredicate != null ||
+            return optimisticLockPredicate != null ||
+                    updateWherePredicate != null ||
                     versionGetter != null ||
                     discriminatorGuardGetter != null;
         }
@@ -3251,12 +3348,30 @@ class Operator {
                 String sourceSuffix
         ) {
             boolean hasPrevious = false;
-            if (userOptimisticLockPredicate != null) {
+            if (updateWherePredicate != null) {
                 builder.pushValueGetterRender(targetPrefix, targetSuffix);
-                builder.pushSaveInputValueRender(null, "");
+                builder.pushSaveInputValueRender(sourcePrefix, sourceSuffix);
                 try {
                     AbstractExpression.renderChild(
-                            (Ast) userOptimisticLockPredicate,
+                            (Ast) updateWherePredicate,
+                            ExpressionPrecedences.AND,
+                            builder
+                    );
+                } finally {
+                    builder.popSaveInputValueRender();
+                    builder.popValueGetterRender();
+                }
+                hasPrevious = true;
+            }
+            if (optimisticLockPredicate != null) {
+                if (hasPrevious) {
+                    builder.sql(" and ");
+                }
+                builder.pushValueGetterRender(targetPrefix, targetSuffix);
+                builder.pushSaveInputValueRender(sourcePrefix, sourceSuffix);
+                try {
+                    AbstractExpression.renderChild(
+                            (Ast) optimisticLockPredicate,
                             ExpressionPrecedences.AND,
                             builder
                     );
@@ -3327,7 +3442,8 @@ class Operator {
             PropertyGetter getter = assignment.target;
             if (assignment.value == null &&
                     getter.metadata().getValueProp().isVersion() &&
-                    ctx.options.getUserOptimisticLock(ctx.path.getType()) == null) {
+                    ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK &&
+                    ctx.options.getOptimisticLockCondition(ctx.path.getType()) == null) {
                 builder.sql(inputPrefix)
                         .sql(getter)
                         .sql(inputSuffix)

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/PreHandler.java
@@ -14,10 +14,7 @@ import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
 import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
 import org.babyfish.jimmer.sql.ast.impl.util.ConcattedIterator;
 import org.babyfish.jimmer.sql.ast.impl.value.PropertyGetter;
-import org.babyfish.jimmer.sql.ast.mutation.QueryReason;
-import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
-import org.babyfish.jimmer.sql.ast.mutation.UnloadedVersionBehavior;
-import org.babyfish.jimmer.sql.ast.mutation.UserOptimisticLock;
+import org.babyfish.jimmer.sql.ast.mutation.*;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.exception.ExecutionException;
 import org.babyfish.jimmer.sql.fetcher.Fetcher;
@@ -188,7 +185,8 @@ abstract class AbstractPreHandler implements PreHandler {
             ctx.throwLongRemoteAssociation();
         }
         if (draft.__isLoaded(draft.__type().getIdProp().getId())) {
-            if (ctx.options.isIdOnlyAsReference(prop) &&
+            if (!ctx.options.isForceMatchedUpdate() &&
+                    ctx.options.isIdOnlyAsReference(prop) &&
                     !ctx.options.hasAssignment(draft.__type()) &&
                     ctx.options.getUnloadedVersionBehavior(draft.__type()) == UnloadedVersionBehavior.IGNORE &&
                     !hasNonIdValues.get()
@@ -326,9 +324,13 @@ abstract class AbstractPreHandler implements PreHandler {
         if (oldFetcher == null) {
             ImmutableType type = ctx.path.getType();
             FetcherImplementor<ImmutableSpi> fetcherImplementor =
-                    new FetcherImpl<>((Class<ImmutableSpi>)ctx.path.getType().getJavaClass());
+                    new FetcherImpl<>((Class<ImmutableSpi>) ctx.path.getType().getJavaClass());
             for (ImmutableProp keyProp : keyMatcher.getAllProps()) {
                 fetcherImplementor = fetcherImplementor.add(keyProp.getName(), IdOnlyFetchType.RAW);
+            }
+            ImmutableProp versionProp = type.getVersionProp();
+            if (versionProp != null && ctx.options.getVersionMode() == VersionMode.ASSIGNMENT) {
+                fetcherImplementor = fetcherImplementor.add(versionProp.getName(), IdOnlyFetchType.RAW);
             }
             DraftInterceptor<?, ?> interceptor = ctx.options.getSqlClient().getDraftInterceptor(type);
             if (interceptor != null) {
@@ -360,6 +362,39 @@ abstract class AbstractPreHandler implements PreHandler {
         JSqlClientImplementor sqlClient = ctx.options.getSqlClient();
         SaveMode saveMode = ctx.options.getMode();
         boolean clearMode = saveMode == SaveMode.INSERT_ONLY || saveMode == SaveMode.UPDATE_ONLY;
+        if (!clearMode &&
+                ctx.options.isExactConflictTargetRequired() &&
+                !sqlClient.getDialect().isUpsertWithMultipleUniqueConstraintSupported() &&
+                (saveMode == SaveMode.INSERT_IF_ABSENT || !isGuaranteedSingleConflictTarget(drafts))) {
+            return QueryReason.NO_MORE_UNIQUE_CONSTRAINTS_REQUIRED;
+        }
+        if (ctx.updateWhereEnabled) {
+            boolean optimisticLock = ctx.options.getOptimisticLockCondition(ctx.path.getType()) != null;
+            ImmutableProp versionProp = ctx.path.getType().getVersionProp();
+            if (!optimisticLock && versionProp != null && ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK) {
+                PropId versionPropId = versionProp.getId();
+                for (DraftSpi draft : drafts) {
+                    if (draft.__isLoaded(versionPropId)) {
+                        optimisticLock = true;
+                        break;
+                    }
+                }
+            }
+            if (optimisticLock) {
+                return QueryReason.UPDATE_WHERE;
+            }
+            if (saveMode != SaveMode.UPDATE_ONLY &&
+                    !clearMode &&
+                    !sqlClient.getDialect().isUpsertWithUpdateWhereSupported()) {
+                return QueryReason.UPDATE_WHERE;
+            }
+        }
+        if (!clearMode &&
+                saveMode != SaveMode.INSERT_IF_ABSENT &&
+                hasSingleTableDiscriminatorGuard(drafts) &&
+                !sqlClient.getDialect().isUpsertWithUpdateWhereSupported()) {
+            return QueryReason.UPDATE_WHERE;
+        }
         if (!clearMode && !sqlClient.getDialect().isUpsertSupported()) {
             return QueryReason.UPSERT_NOT_SUPPORTED;
         }
@@ -387,9 +422,10 @@ abstract class AbstractPreHandler implements PreHandler {
         if (!clearMode) {
             if (saveMode != SaveMode.INSERT_IF_ABSENT &&
                     !sqlClient.getDialect().isUpsertWithOptimisticLockSupported()) {
-                UserOptimisticLock<?, ?> userLock = ctx.options.getUserOptimisticLock(ctx.path.getType());
-                boolean useOptimisticLock = userLock != null;
-                if (!useOptimisticLock) {
+                UpdateCondition<?, ?> optimisticLockCondition =
+                        ctx.options.getOptimisticLockCondition(ctx.path.getType());
+                boolean useOptimisticLock = optimisticLockCondition != null;
+                if (!useOptimisticLock && ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK) {
                     ImmutableProp versionProp = ctx.path.getType().getVersionProp();
                     if (versionProp != null) {
                         PropId versionPropId = versionProp.getId();
@@ -402,7 +438,7 @@ abstract class AbstractPreHandler implements PreHandler {
                     }
                 }
                 if (useOptimisticLock) {
-                    if (userLock != null) {
+                    if (optimisticLockCondition != null) {
                         return QueryReason.OPTIMISTIC_LOCK;
                     }
                     if (!(this instanceof UpdatePreHandler)) {
@@ -471,6 +507,81 @@ abstract class AbstractPreHandler implements PreHandler {
             }
         }
         return QueryReason.NONE;
+    }
+
+    private boolean isGuaranteedSingleConflictTarget(Collection<DraftSpi> drafts) {
+        ImmutableType type = ctx.path.getType();
+        ImmutableProp idProp = type.getIdProp();
+        if (idProp != null) {
+            PropId idPropId = idProp.getId();
+            for (DraftSpi draft : drafts) {
+                if (draft.__isLoaded(idPropId)) {
+                    return false;
+                }
+            }
+        }
+        ImmutableType keyConstraintType = type;
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        if (inheritanceInfo != null) {
+            keyConstraintType = inheritanceInfo.getRootType();
+        }
+        KeyUniqueConstraint constraint = type.getJavaClass().getAnnotation(KeyUniqueConstraint.class);
+        if (constraint == null && keyConstraintType != type) {
+            constraint = keyConstraintType.getJavaClass().getAnnotation(KeyUniqueConstraint.class);
+        }
+        if (constraint == null || !constraint.noMoreUniqueConstraints()) {
+            return false;
+        }
+        Map<String, Set<ImmutableProp>> modelGroups = keyConstraintType.getKeyMatcher().toMap();
+        if (modelGroups.size() != 1) {
+            return false;
+        }
+        Set<ImmutableProp> selectedProps = keyMatcher.toMap().get("");
+        return selectedProps != null && sameProps(selectedProps, modelGroups.values().iterator().next());
+    }
+
+    private static boolean sameProps(Set<ImmutableProp> a, Set<ImmutableProp> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        Set<ImmutableProp> originalProps = new HashSet<>();
+        for (ImmutableProp prop : a) {
+            originalProps.add(prop.toOriginal());
+        }
+        for (ImmutableProp prop : b) {
+            if (!originalProps.remove(prop.toOriginal())) {
+                return false;
+            }
+        }
+        return originalProps.isEmpty();
+    }
+
+    private boolean hasSingleTableDiscriminatorGuard(Collection<DraftSpi> drafts) {
+        for (DraftSpi draft : drafts) {
+            ImmutableType type = draft.__type();
+            InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+            if (inheritanceInfo != null &&
+                    inheritanceInfo.getStrategy() == InheritanceType.SINGLE_TABLE &&
+                    !ctx.options.isTypeChangeAllowed(type) &&
+                    Operator.discriminatorGuardProp(ctx.options, inheritanceInfo, type) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    final void markPreselectedAccepted(DraftSpi draft) {
+        ImmutableType type = draft.__type();
+        if (ctx.options.getOptimisticLockCondition(type) != null) {
+            return;
+        }
+        ImmutableProp versionProp = type.getVersionProp();
+        if (versionProp != null &&
+                ctx.options.getVersionMode() == VersionMode.OPTIMISTIC_LOCK &&
+                draft.__isLoaded(versionProp.getId())) {
+            return;
+        }
+        ctx.markPreselectedAccepted(draft);
     }
 
     private boolean isExplicitJoinedTypeChange(Collection<DraftSpi> drafts) {
@@ -615,7 +726,8 @@ abstract class AbstractPreHandler implements PreHandler {
 
     // Notes: This method can only be overridden by InsertPreHandler
     // Otherwise, it is bug!
-    void assignDefaultValues(DraftSpi draft) {}
+    void assignDefaultValues(DraftSpi draft) {
+    }
 
     final void resolve() {
         if (!resolved) {
@@ -956,7 +1068,12 @@ class UpdatePreHandler extends AbstractPreHandler {
                     Object id = draft.__get(idPropId);
                     ImmutableSpi original = idMap.get(id);
                     if (original != null) {
-                        items.add(newItem(draft, original));
+                        if (!ctx.updateWhereEnabled || SaveUpdateConditions.isAllowed(ctx, draft)) {
+                            markPreselectedAccepted(draft);
+                            items.add(newItem(draft, original));
+                        } else {
+                            itr.remove();
+                        }
                     } else if (ctx.options.isTypeChangeAllowed(draft.__type()) &&
                             isExistingDifferentTypeById(queryReason, draft)) {
                         items.add(newItem(draft, null));
@@ -980,8 +1097,14 @@ class UpdatePreHandler extends AbstractPreHandler {
                     Map<Object, ImmutableSpi> subMap = keyMap.getOrDefault(group, Collections.emptyMap());
                     ImmutableSpi original = subMap.get(key);
                     if (original != null) {
-                        items.add(newItem(draft, original));
+                        DraftInterceptor.Item<Object, DraftSpi> item = newItem(draft, original);
                         draft.__set(idPropId, original.__get(idPropId));
+                        if (!ctx.updateWhereEnabled || SaveUpdateConditions.isAllowed(ctx, draft)) {
+                            markPreselectedAccepted(draft);
+                            items.add(item);
+                        } else {
+                            itr.remove();
+                        }
                     } else {
                         itr.remove();
                     }
@@ -1042,7 +1165,7 @@ class UpsertPreHandler extends AbstractPreHandler {
         List<DraftSpi> updatedWithoutKeyList = null;
 
         List<DraftInterceptor.Item<Object, DraftSpi>> items = new ArrayList<>(
-                (draftsWithNothing != null ? draftsWithNothing.size() : 0)+
+                (draftsWithNothing != null ? draftsWithNothing.size() : 0) +
                         draftsWithId.size() +
                         draftsWithKey.size()
         );
@@ -1074,8 +1197,11 @@ class UpsertPreHandler extends AbstractPreHandler {
                             items.add(newItem(draft, null));
                         }
                     } else if (!ignoreUpdate) {
-                        updatedList.add(draft);
-                        items.add(newItem(draft, original));
+                        if (!ctx.updateWhereEnabled || SaveUpdateConditions.isAllowed(ctx, draft)) {
+                            markPreselectedAccepted(draft);
+                            updatedList.add(draft);
+                            items.add(newItem(draft, original));
+                        }
                     }
                 }
             } else {
@@ -1104,12 +1230,17 @@ class UpsertPreHandler extends AbstractPreHandler {
                         itr.remove();
                         items.add(newItem(draft, null));
                     } else {
-                        if (!ignoreUpdate) {
-                            updatedWithoutKeyList.add(draft);
-                            items.add(newItem(draft, original));
-                        }
+                        DraftInterceptor.Item<Object, DraftSpi> item =
+                                !ignoreUpdate ? newItem(draft, original) : null;
                         if (!ignoreUpdate || ctx.isIdRetrievingRequired()) {
                             draft.__set(idPropId, original.__get(idPropId));
+                        }
+                        if (!ignoreUpdate) {
+                            if (!ctx.updateWhereEnabled || SaveUpdateConditions.isAllowed(ctx, draft)) {
+                                markPreselectedAccepted(draft);
+                                updatedWithoutKeyList.add(draft);
+                                items.add(item);
+                            }
                         }
                     }
                 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveCommandImplementor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveCommandImplementor.java
@@ -5,19 +5,28 @@ import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.sql.ast.mutation.AbstractEntitySaveCommand;
 import org.babyfish.jimmer.sql.ast.mutation.SaveAssignmentExpression;
 import org.babyfish.jimmer.sql.ast.mutation.UnloadedVersionBehavior;
-import org.babyfish.jimmer.sql.ast.mutation.UserOptimisticLock;
+import org.babyfish.jimmer.sql.ast.mutation.UpdateCondition;
 import org.babyfish.jimmer.sql.ast.table.Table;
 
 public interface SaveCommandImplementor extends AbstractEntitySaveCommand {
 
+    AbstractEntitySaveCommand setForceMatchedUpdate();
+
+    AbstractEntitySaveCommand setExactConflictTargetRequired();
+
     AbstractEntitySaveCommand setEntityOptimisticLock(
             ImmutableType type,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<Object, Table<Object>> block
+            UpdateCondition<Object, Table<Object>> condition
     );
 
     AbstractEntitySaveCommand setEntityAssignment(
             ImmutableProp prop,
             SaveAssignmentExpression<?, ?, ?> expression
+    );
+
+    AbstractEntitySaveCommand setEntityUpdateWhere(
+            ImmutableType type,
+            UpdateCondition<?, ?> condition
     );
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveContext.java
@@ -5,6 +5,7 @@ import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.TargetLevel;
 import org.babyfish.jimmer.runtime.DraftSpi;
 import org.babyfish.jimmer.sql.OneToMany;
+import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.mutation.AffectedTable;
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
 import org.babyfish.jimmer.sql.exception.SaveException;
@@ -40,7 +41,15 @@ class SaveContext extends MutationContext {
 
     private final SaveResultCoverage saveResultCoverage;
 
-    private final Set<DraftSpi> saveReturningNotAcceptedDrafts;
+    private final Set<DraftSpi> rejectedDrafts;
+
+    private final Set<DraftSpi> unavailableAssociationTargets;
+
+    private final Set<DraftSpi> preselectedAcceptedDrafts;
+
+    boolean updateWhereEnabled;
+
+    Predicate updateWherePredicate;
 
     SaveContext(
             SaveOptions options,
@@ -75,7 +84,9 @@ class SaveContext extends MutationContext {
         this.backReferenceFrozen = false;
         this.affectedRowCountMap = affectedRowCountMap;
         this.saveResultCoverage = new SaveResultCoverage();
-        this.saveReturningNotAcceptedDrafts = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.rejectedDrafts = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.unavailableAssociationTargets = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.preselectedAcceptedDrafts = Collections.newSetFromMap(new IdentityHashMap<>());
     }
 
     private SaveContext(SaveContext parent, ImmutableProp prop, ImmutableProp backProp) {
@@ -131,7 +142,9 @@ class SaveContext extends MutationContext {
         }
         this.affectedRowCountMap = parent.affectedRowCountMap;
         this.saveResultCoverage = parent.saveResultCoverage;
-        this.saveReturningNotAcceptedDrafts = parent.saveReturningNotAcceptedDrafts;
+        this.rejectedDrafts = parent.rejectedDrafts;
+        this.unavailableAssociationTargets = parent.unavailableAssociationTargets;
+        this.preselectedAcceptedDrafts = parent.preselectedAcceptedDrafts;
     }
 
     private SaveContext(SaveContext base, JSqlClientImplementor sqlClient) {
@@ -144,7 +157,11 @@ class SaveContext extends MutationContext {
         this.backReferenceProp = base.backReferenceProp;
         this.backReferenceFrozen = base.backReferenceFrozen;
         this.saveResultCoverage = base.saveResultCoverage;
-        this.saveReturningNotAcceptedDrafts = base.saveReturningNotAcceptedDrafts;
+        this.rejectedDrafts = base.rejectedDrafts;
+        this.unavailableAssociationTargets = base.unavailableAssociationTargets;
+        this.preselectedAcceptedDrafts = base.preselectedAcceptedDrafts;
+        this.updateWhereEnabled = base.updateWhereEnabled;
+        this.updateWherePredicate = base.updateWherePredicate;
     }
 
     public Object allocateId() {
@@ -248,10 +265,34 @@ class SaveContext extends MutationContext {
     }
 
     public void markSaveReturningNotAccepted(DraftSpi draft) {
-        saveReturningNotAcceptedDrafts.add(draft);
+        rejectedDrafts.add(draft);
     }
 
     public boolean isSaveReturningNotAccepted(DraftSpi draft) {
-        return saveReturningNotAcceptedDrafts.contains(draft);
+        return rejectedDrafts.contains(draft);
+    }
+
+    public void markRejected(DraftSpi draft) {
+        rejectedDrafts.add(draft);
+    }
+
+    public boolean isRejected(DraftSpi draft) {
+        return rejectedDrafts.contains(draft);
+    }
+
+    public void markAssociationTargetUnavailable(DraftSpi draft) {
+        unavailableAssociationTargets.add(draft);
+    }
+
+    public boolean isAssociationTargetUnavailable(DraftSpi draft) {
+        return unavailableAssociationTargets.contains(draft);
+    }
+
+    public void markPreselectedAccepted(DraftSpi draft) {
+        preselectedAcceptedDrafts.add(draft);
+    }
+
+    public boolean isPreselectedAccepted(DraftSpi draft) {
+        return preselectedAcceptedDrafts.contains(draft);
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveOptions.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveOptions.java
@@ -40,6 +40,27 @@ public interface SaveOptions {
         return Collections.emptyMap();
     }
 
+    @Nullable
+    default TypedUpdateCondition getUpdateWhere(ImmutableType type) {
+        return null;
+    }
+
+    default Map<ImmutableType, TypedUpdateCondition> getUpdateWheres() {
+        return Collections.emptyMap();
+    }
+
+    default VersionMode getVersionMode() {
+        return VersionMode.OPTIMISTIC_LOCK;
+    }
+
+    default boolean isForceMatchedUpdate() {
+        return false;
+    }
+
+    default boolean isExactConflictTargetRequired() {
+        return false;
+    }
+
     default boolean hasAssignment(ImmutableType type) {
         for (SaveAssignmentLambda assignment : getAssignments().values()) {
             if (assignment.type.isAssignableFrom(type)) {
@@ -77,7 +98,7 @@ public interface SaveOptions {
 
     UnloadedVersionBehavior getUnloadedVersionBehavior(ImmutableType type);
 
-    UserOptimisticLock<?, ?> getUserOptimisticLock(ImmutableType type);
+    UpdateCondition<?, ?> getOptimisticLockCondition(ImmutableType type);
 
     boolean isAutoCheckingProp(ImmutableProp prop);
 
@@ -173,6 +194,31 @@ abstract class AbstractSaveOptionsWrapper implements SaveOptions {
     }
 
     @Override
+    public @Nullable TypedUpdateCondition getUpdateWhere(ImmutableType type) {
+        return raw.getUpdateWhere(type);
+    }
+
+    @Override
+    public Map<ImmutableType, TypedUpdateCondition> getUpdateWheres() {
+        return raw.getUpdateWheres();
+    }
+
+    @Override
+    public VersionMode getVersionMode() {
+        return raw.getVersionMode();
+    }
+
+    @Override
+    public boolean isForceMatchedUpdate() {
+        return raw.isForceMatchedUpdate();
+    }
+
+    @Override
+    public boolean isExactConflictTargetRequired() {
+        return raw.isExactConflictTargetRequired();
+    }
+
+    @Override
     public boolean isTargetTransferable(ImmutableProp prop) {
         return raw.isTargetTransferable(prop);
     }
@@ -233,8 +279,8 @@ abstract class AbstractSaveOptionsWrapper implements SaveOptions {
     }
 
     @Override
-    public UserOptimisticLock<?, ?> getUserOptimisticLock(ImmutableType type) {
-        return raw.getUserOptimisticLock(type);
+    public UpdateCondition<?, ?> getOptimisticLockCondition(ImmutableType type) {
+        return raw.getOptimisticLockCondition(type);
     }
 
     @Override
@@ -351,5 +397,20 @@ class SaveOptionsForAssociatedProp extends AbstractSaveOptionsWrapper {
     @Override
     public boolean isTypeChangeAllowed(ImmutableType type) {
         return super.isAssociatedTypeChangeAllowed(prop, type);
+    }
+
+    @Override
+    public VersionMode getVersionMode() {
+        return VersionMode.OPTIMISTIC_LOCK;
+    }
+
+    @Override
+    public boolean isForceMatchedUpdate() {
+        return false;
+    }
+
+    @Override
+    public boolean isExactConflictTargetRequired() {
+        return false;
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveResultMaterializer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveResultMaterializer.java
@@ -79,7 +79,7 @@ class SaveResultMaterializer {
         PropId idPropId = ctx.path.getType().getIdProp().getId();
         SaveShapeMatcher inputShapeMatcher = SaveShapeMatcher.forSaveInput(ctx.options);
         for (DraftSpi draft : drafts) {
-            if (ctx.isSaveReturningNotAccepted(draft)) {
+            if (!fillIdIfNecessary && ctx.isSaveReturningNotAccepted(draft)) {
                 // Returning row-count 0 rows must remain unmaterialized.
                 ++index;
                 continue;

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturning.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturning.java
@@ -136,7 +136,8 @@ class SaveReturning {
             List<PropertyGetter> nullGetters,
             @Nullable SaveReturningUpdateCondition updateCondition,
             @Nullable Set<ImmutableProp> keyProps,
-            @Nullable Predicate userOptimisticLockPredicate,
+            @Nullable Predicate updateWherePredicate,
+            @Nullable Predicate optimisticLockPredicate,
             @Nullable PropertyGetter versionGetter,
             boolean fakeUpdate,
             boolean forceOneByOne
@@ -152,7 +153,8 @@ class SaveReturning {
                 nullGetters,
                 updateCondition,
                 keyProps,
-                userOptimisticLockPredicate,
+                updateWherePredicate,
+                optimisticLockPredicate,
                 versionGetter,
                 fakeUpdate,
                 forceOneByOne
@@ -174,7 +176,8 @@ class SaveReturning {
             @Nullable LogicalDeletedInfo conflictPredicate,
             List<SaveAssignment> assignments,
             boolean ignoreUpdate,
-            @Nullable Predicate userOptimisticLockPredicate,
+            @Nullable Predicate updateWherePredicate,
+            @Nullable Predicate optimisticLockPredicate,
             @Nullable PropertyGetter versionGetter,
             boolean fakeUpdate,
             boolean forceOneByOne
@@ -194,7 +197,8 @@ class SaveReturning {
                 conflictPredicate,
                 assignments,
                 ignoreUpdate,
-                userOptimisticLockPredicate,
+                updateWherePredicate,
+                optimisticLockPredicate,
                 versionGetter,
                 fakeUpdate,
                 forceOneByOne

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturningFactory.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturningFactory.java
@@ -119,13 +119,17 @@ class SaveReturningFactory {
             List<PropertyGetter> nullGetters,
             @Nullable SaveReturningUpdateCondition updateCondition,
             @Nullable Set<ImmutableProp> keyProps,
-            @Nullable Predicate userOptimisticLockPredicate,
+            @Nullable Predicate updateWherePredicate,
+            @Nullable Predicate optimisticLockPredicate,
             @Nullable PropertyGetter versionGetter,
             boolean fakeUpdate,
             boolean forceOneByOne
     ) {
         JSqlClientImplementor sqlClient = ctx.options.getSqlClient();
         if (!sqlClient.getDialect().isUpdateByValuesReturningSupported()) {
+            return null;
+        }
+        if (updateWherePredicate != null) {
             return null;
         }
         List<PropertyGetter> customTargetGetters = customTargetGetters(assignments);
@@ -136,7 +140,8 @@ class SaveReturningFactory {
                 shape,
                 entities,
                 false,
-                customTargetGetters
+                customTargetGetters,
+                false
         );
         if (basic == null ||
                 fakeUpdate ||
@@ -243,18 +248,18 @@ class SaveReturningFactory {
                     discriminatorGuardValue
             );
         }
-        if (userOptimisticLockPredicate != null) {
-            SaveReturningUpdateCondition userOptimisticLockCondition =
-                    SaveReturningUpdateCondition.userOptimisticLock(
+        if (optimisticLockPredicate != null) {
+            SaveReturningUpdateCondition optimisticLockCondition =
+                    SaveReturningUpdateCondition.fromPredicate(
                             sqlClient,
-                            userOptimisticLockPredicate
+                            optimisticLockPredicate
                     );
-            if (userOptimisticLockCondition == null) {
+            if (optimisticLockCondition == null) {
                 return null;
             }
             updateCondition = SaveReturningUpdateCondition.and(
                     updateCondition,
-                    userOptimisticLockCondition
+                    optimisticLockCondition
             );
         }
         if (updateCondition != null) {
@@ -312,7 +317,8 @@ class SaveReturningFactory {
             @Nullable LogicalDeletedInfo conflictPredicate,
             List<SaveAssignment> assignments,
             boolean ignoreUpdate,
-            @Nullable Predicate userOptimisticLockPredicate,
+            @Nullable Predicate updateWherePredicate,
+            @Nullable Predicate optimisticLockPredicate,
             @Nullable PropertyGetter versionGetter,
             boolean fakeUpdate,
             boolean forceOneByOne
@@ -327,7 +333,8 @@ class SaveReturningFactory {
                 batch.shape(),
                 batch.entities(),
                 generatedIdProp != null,
-                requiredReturningGetters
+                requiredReturningGetters,
+                updateWherePredicate != null
         );
         if (basic == null ||
                 versionGetter != null ||
@@ -342,7 +349,7 @@ class SaveReturningFactory {
                         Collections.emptyList() :
                         upsertKnownSourceGetters(insertedGetters, assignments, ignoreUpdate)
         );
-        if (returningFetcherProps.isEmpty() && generatedIdProp == null) {
+        if (returningFetcherProps.isEmpty() && generatedIdProp == null && updateWherePredicate == null) {
             return null;
         }
         if (generatedIdProp != null && generatedIdProp.isEmbedded(EmbeddedLevel.SCALAR)) {
@@ -400,17 +407,30 @@ class SaveReturningFactory {
             }
         }
         SaveReturningUpdateCondition updateCondition = null;
-        if (userOptimisticLockPredicate != null) {
-            if (!sqlClient.getDialect().isUpsertWithOptimisticLockSupported()) {
+        if (updateWherePredicate != null) {
+            if (!sqlClient.getDialect().isUpsertWithUpdateWhereSupported()) {
                 return null;
             }
-            updateCondition = SaveReturningUpdateCondition.userOptimisticLock(
+            updateCondition = SaveReturningUpdateCondition.fromPredicate(
                     sqlClient,
-                    userOptimisticLockPredicate
+                    updateWherePredicate
             );
             if (updateCondition == null || !updateCondition.isSourceValueReady(sourceValues)) {
                 return null;
             }
+        }
+        if (optimisticLockPredicate != null) {
+            if (!sqlClient.getDialect().isUpsertWithOptimisticLockSupported()) {
+                return null;
+            }
+            SaveReturningUpdateCondition optimisticLockCondition = SaveReturningUpdateCondition.fromPredicate(
+                    sqlClient,
+                    optimisticLockPredicate
+            );
+            if (optimisticLockCondition == null || !optimisticLockCondition.isSourceValueReady(sourceValues)) {
+                return null;
+            }
+            updateCondition = SaveReturningUpdateCondition.and(updateCondition, optimisticLockCondition);
         }
         SaveReturningColumns returning = returningColumns(
                 sqlClient,
@@ -454,19 +474,24 @@ class SaveReturningFactory {
             Shape shape,
             EntityCollection<DraftSpi> entities,
             boolean idWillBeLoadedByDml,
-            List<PropertyGetter> requiredReturningGetters
+            List<PropertyGetter> requiredReturningGetters,
+            boolean acceptanceRequired
     ) {
-        if (!ctx.options.isSaveReturningEnabled()) {
+        if (!ctx.options.isSaveReturningEnabled() && !acceptanceRequired) {
             return null;
         }
-        if (ctx.path.getParent() != null || ctx.trigger != null || ctx.fetcher == null) {
+        if (ctx.path.getParent() != null || ctx.trigger != null ||
+                ctx.fetcher == null && !acceptanceRequired) {
             return null;
         }
         JSqlClientImplementor sqlClient = ctx.options.getSqlClient();
         LogicalDeletedBehavior logicalDeletedBehavior = sqlClient.getFilters().getBehavior(shape.getType());
         LogicalDeletedInfo logicalDeletedInfo = logicalDeletedInfo(shape.getType(), logicalDeletedBehavior);
-        Fetcher<?> fetcher = ctx.fetcher;
-        if (!isFetchRequired(ctx, fetcher, entities, idWillBeLoadedByDml) &&
+        Fetcher<?> fetcher = ctx.fetcher != null ?
+                ctx.fetcher :
+                new org.babyfish.jimmer.sql.fetcher.impl.FetcherImpl<>(shape.getType().getJavaClass());
+        if (!acceptanceRequired &&
+                !isFetchRequired(ctx, fetcher, entities, idWillBeLoadedByDml) &&
                 !isReturningRequiredByFetcher(
                         fetcher,
                         shape.getType(),

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturningUpdateCondition.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveReturningUpdateCondition.java
@@ -72,7 +72,7 @@ interface SaveReturningUpdateCondition {
         return new LogicalDeletedGuard(logicalDeletedInfo);
     }
 
-    static @Nullable SaveReturningUpdateCondition userOptimisticLock(
+    static @Nullable SaveReturningUpdateCondition fromPredicate(
             JSqlClientImplementor sqlClient,
             Predicate predicate
     ) {
@@ -104,7 +104,7 @@ interface SaveReturningUpdateCondition {
         if (!valid[0]) {
             return null;
         }
-        return new UserOptimisticLock(predicate, newValueGetters);
+        return new PredicateCondition(predicate, newValueGetters);
     }
 
     static @Nullable PropertyGetter singleColumnGetter(
@@ -284,13 +284,13 @@ interface SaveReturningUpdateCondition {
         }
     }
 
-    class UserOptimisticLock implements SaveReturningUpdateCondition {
+    class PredicateCondition implements SaveReturningUpdateCondition {
 
         private final Predicate predicate;
 
         private final List<PropertyGetter> newValueGetters;
 
-        private UserOptimisticLock(Predicate predicate, List<PropertyGetter> newValueGetters) {
+        private PredicateCondition(Predicate predicate, List<PropertyGetter> newValueGetters) {
             this.predicate = predicate;
             this.newValueGetters = newValueGetters;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveUpdateConditions.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveUpdateConditions.java
@@ -1,0 +1,258 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.ImmutableObjects;
+import org.babyfish.jimmer.impl.util.Classes;
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.meta.InheritanceInfo;
+import org.babyfish.jimmer.runtime.DraftSpi;
+import org.babyfish.jimmer.sql.InheritanceType;
+import org.babyfish.jimmer.sql.ast.*;
+import org.babyfish.jimmer.sql.ast.impl.*;
+import org.babyfish.jimmer.sql.ast.impl.query.FilterLevel;
+import org.babyfish.jimmer.sql.ast.impl.query.MutableRootQueryImpl;
+import org.babyfish.jimmer.sql.ast.impl.query.Queries;
+import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
+import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
+import org.babyfish.jimmer.sql.ast.impl.value.PropertyGetter;
+import org.babyfish.jimmer.sql.ast.mutation.QueryReason;
+import org.babyfish.jimmer.sql.ast.mutation.UpdateCondition;
+import org.babyfish.jimmer.sql.ast.mutation.ValueExpressionFactory;
+import org.babyfish.jimmer.sql.ast.table.Table;
+import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
+import org.babyfish.jimmer.sql.ast.table.spi.UntypedJoinDisabledTableProxy;
+import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class SaveUpdateConditions {
+
+    private static final String DISABLED_JOIN_REASON =
+            "Joining is disabled for save update-where predicates";
+
+    private SaveUpdateConditions() {
+    }
+
+    static boolean validate(SaveContext ctx, List<DraftSpi> drafts) {
+        if (drafts.isEmpty()) {
+            return false;
+        }
+        ImmutableType type = ctx.path.getType();
+        if (ctx.path.getParent() == null) {
+            validateConfiguredTypes(ctx.options, type);
+        }
+        TypedUpdateCondition typedCondition = ctx.options.getUpdateWhere(type);
+        if (typedCondition == null) {
+            return false;
+        }
+        Set<Shape> shapes = new LinkedHashSet<>();
+        for (DraftSpi draft : drafts) {
+            shapes.add(Shape.of(ctx.options.getSqlClient(), draft, null));
+        }
+        boolean active = false;
+        for (Shape shape : shapes) {
+            Predicate predicate = validate(ctx, shape, typedCondition);
+            if (predicate != null) {
+                if (ctx.updateWherePredicate == null) {
+                    ctx.updateWherePredicate = predicate;
+                }
+                active = true;
+            }
+        }
+        return active;
+    }
+
+    private static void validateConfiguredTypes(SaveOptions options, ImmutableType savedType) {
+        ImmutableType savedFamily = familyType(savedType);
+        for (ImmutableType configuredType : options.getUpdateWheres().keySet()) {
+            if (familyType(configuredType) != savedFamily) {
+                throw new IllegalArgumentException(
+                        "The update-where table type \"" + configuredType +
+                                "\" is unrelated to the saved entity type \"" + savedType + "\""
+                );
+            }
+        }
+    }
+
+    private static ImmutableType familyType(ImmutableType type) {
+        ImmutableType rootType = type.getInheritanceRoot();
+        return rootType != null ? rootType : type;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static @Nullable Predicate validate(
+            SaveContext ctx,
+            Shape shape,
+            TypedUpdateCondition typedCondition
+    ) {
+        ImmutableType tableType = physicalTableType(shape.getType());
+        JSqlClientImplementor sqlClient = ctx.options.getSqlClient();
+        MutableRootQueryImpl<?> fakeQuery = new MutableRootQueryImpl<>(
+                sqlClient,
+                typedCondition.type,
+                ExecutionPurpose.MUTATE,
+                FilterLevel.DEFAULT
+        );
+        Table<?> table = fakeQuery.getTable();
+        if (table instanceof TableImplementor<?>) {
+            table = new UntypedJoinDisabledTableProxy<>(
+                    (TableImplementor<?>) table,
+                    DISABLED_JOIN_REASON
+            );
+        } else {
+            table = ((TableProxy<?>) table).__disableJoin(DISABLED_JOIN_REASON);
+        }
+        Predicate predicate = ((UpdateCondition) typedCondition.condition).predicate(
+                table,
+                ValueExpressionFactories.of()
+        );
+        if (predicate == null) {
+            return null;
+        }
+        ((Ast) predicate).accept(new AstVisitor(new AstContext(sqlClient)) {
+
+            @Override
+            public void visitTableReference(
+                    RealTable table,
+                    @Nullable ImmutableProp prop,
+                    boolean rawId
+            ) {
+                if (prop == null || !belongsToTable(prop, tableType) || singleGetter(sqlClient, prop) == null) {
+                    throw new IllegalArgumentException(
+                            "A save update-where predicate can only read local physical scalar target properties"
+                    );
+                }
+            }
+
+            @Override
+            public void visitSaveInputValue(ImmutableProp prop) {
+                PropertyGetter getter = singleGetter(sqlClient, prop);
+                if (getter == null || !belongsToTable(prop, tableType)) {
+                    throw new IllegalArgumentException(
+                            "A save update-where predicate can only read local physical scalar input properties"
+                    );
+                }
+                if (!shape.contains(getter)) {
+                    throw new IllegalArgumentException(
+                            "The input property \"" + prop +
+                                    "\" referenced by the save update-where predicate is unloaded"
+                    );
+                }
+            }
+        });
+        return predicate;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static boolean isAllowed(SaveContext ctx, DraftSpi draft) {
+        TypedUpdateCondition typedCondition = ctx.options.getUpdateWhere(ctx.path.getType());
+        if (typedCondition == null) {
+            return true;
+        }
+        ImmutableType type = ctx.path.getType();
+        Object id = draft.__get(type.getIdProp().getId());
+        List<?> ids = Queries.createQuery(
+                ctx.options.getSqlClient(),
+                type,
+                ExecutionPurpose.command(QueryReason.UPDATE_WHERE),
+                FilterLevel.IGNORE_USER_FILTERS,
+                (q, table) -> {
+                    q.where(((Expression) ((Table<?>) table).get(type.getIdProp())).eq(id));
+                    Predicate predicate = ((UpdateCondition) typedCondition.condition).predicate(
+                            table,
+                            new DraftValueExpressionFactory(draft)
+                    );
+                    if (predicate == null) {
+                        return q.select(((Table<?>) table).get(type.getIdProp()));
+                    }
+                    q.where(predicate);
+                    return q.select(((Table<?>) table).get(type.getIdProp()));
+                }
+        ).forUpdate(ctx.options.isPessimisticLocked(type)).execute(ctx.con);
+        return !ids.isEmpty();
+    }
+
+    private static ImmutableType physicalTableType(ImmutableType type) {
+        InheritanceInfo info = type.getInheritanceInfo();
+        if (info != null && info.getStrategy() == InheritanceType.SINGLE_TABLE) {
+            return info.getRootType();
+        }
+        return type;
+    }
+
+    private static boolean belongsToTable(ImmutableProp prop, ImmutableType tableType) {
+        ImmutableType declaringType = prop.getDeclaringType();
+        if (declaringType == tableType) {
+            return true;
+        }
+        InheritanceInfo info = declaringType.getInheritanceInfo();
+        return info != null &&
+                info.getStrategy() == InheritanceType.SINGLE_TABLE &&
+                info.getRootType() == tableType;
+    }
+
+    private static @Nullable PropertyGetter singleGetter(
+            JSqlClientImplementor sqlClient,
+            ImmutableProp prop
+    ) {
+        List<PropertyGetter> getters = PropertyGetter.propertyGetters(sqlClient, prop);
+        if (getters.size() != 1 || getters.get(0).metadata().getColumnName() == null) {
+            return null;
+        }
+        return getters.get(0);
+    }
+
+    private static final class DraftValueExpressionFactory implements ValueExpressionFactory<Object> {
+
+        private final DraftSpi draft;
+
+        private DraftValueExpressionFactory(DraftSpi draft) {
+            this.draft = draft;
+        }
+
+        @Override
+        public <V> Expression<V> newValue(org.babyfish.jimmer.meta.TypedProp.Scalar<Object, V> prop) {
+            return newValue(prop.unwrap());
+        }
+
+        @Override
+        public StringExpression newString(org.babyfish.jimmer.meta.TypedProp.Scalar<Object, String> prop) {
+            return Literals.string((String) value(prop.unwrap()));
+        }
+
+        @Override
+        public <N extends Number & Comparable<N>> NumericExpression<N> newNumber(
+                org.babyfish.jimmer.meta.TypedProp.Scalar<Object, N> prop
+        ) {
+            return Literals.number((N) value(prop.unwrap()));
+        }
+
+        @Override
+        public <C extends Comparable<?>> ComparableExpression<C> newComparable(
+                org.babyfish.jimmer.meta.TypedProp.Scalar<Object, C> prop
+        ) {
+            return Literals.comparable((C) value(prop.unwrap()));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <V> Expression<V> newValue(ImmutableProp prop) {
+            Object value = value(prop);
+            Expression<V> expression = value != null ?
+                    (Expression<V>) Literals.any(value) :
+                    Expression.nullValue((Class<V>) Classes.boxTypeOf(prop.getReturnClass()));
+            return expression;
+        }
+
+        private Object value(ImmutableProp prop) {
+            if (prop.isDiscriminator()) {
+                return ImmutableObjects.getDiscriminator(draft);
+            }
+            return draft.__get(prop.getId());
+        }
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Saver.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/Saver.java
@@ -46,11 +46,13 @@ public class Saver {
         validateInstantiableSaveType(immutableType, ctx.options);
         MutationTrigger trigger = ctx.trigger;
         // single object save also call `produceList` because `fetch` may change draft
+        boolean[] accepted = {true};
         E newEntity = (E) Internal.produceList(
                 immutableType,
                 Collections.singleton(entity),
                 drafts -> {
                     saveAllImpl((List<DraftSpi>) drafts);
+                    accepted[0] = !ctx.isRejected((DraftSpi) drafts.get(0));
                 },
                 trigger == null ? null : trigger::prepareSubmit
         ).get(0);
@@ -60,7 +62,8 @@ public class Saver {
         return new SimpleSaveResult<>(
                 ctx.affectedRowCountMap,
                 entity,
-                newEntity
+                newEntity,
+                accepted[0]
         );
     }
 
@@ -77,11 +80,15 @@ public class Saver {
         ImmutableType immutableType = ImmutableType.get(entities.iterator().next().getClass());
         validateInstantiableSaveType(immutableType, ctx.options);
         MutationTrigger trigger = ctx.trigger;
+        List<Boolean> accepted = new ArrayList<>(entities.size());
         List<E> newEntities = (List<E>) Internal.produceList(
                 immutableType,
                 entities,
                 drafts -> {
                     saveAllImpl((List<DraftSpi>) drafts);
+                    for (Object draft : drafts) {
+                        accepted.add(!ctx.isRejected((DraftSpi) draft));
+                    }
                 },
                 trigger == null ? null : trigger::prepareSubmit
         );
@@ -91,11 +98,13 @@ public class Saver {
         Iterator<E> oldItr = entities.iterator();
         Iterator<E> newItr = newEntities.iterator();
         List<BatchSaveResult.Item<E>> items = new ArrayList<>(entities.size());
-        while (oldItr.hasNext() && newItr.hasNext()) {
+        Iterator<Boolean> acceptedItr = accepted.iterator();
+        while (oldItr.hasNext() && newItr.hasNext() && acceptedItr.hasNext()) {
             items.add(
                     new BatchSaveResult.Item<>(
                             oldItr.next(),
-                            newItr.next()
+                            newItr.next(),
+                            acceptedItr.next()
                     )
             );
         }
@@ -218,6 +227,16 @@ public class Saver {
 
         SaveOperation operation = prepareSave(drafts);
         SaveSelfResult selfResult = saveSelf(operation);
+        if (selfResult.acceptedDrafts != null) {
+            for (DraftSpi draft : drafts) {
+                if (!selfResult.acceptedDrafts.contains(draft)) {
+                    ctx.markRejected(draft);
+                    if (ctx.options.getMode() != SaveMode.INSERT_IF_ABSENT) {
+                        ctx.markAssociationTargetUnavailable(draft);
+                    }
+                }
+            }
+        }
         finishSave(operation, selfResult);
     }
 
@@ -225,9 +244,12 @@ public class Saver {
         if (!drafts.isEmpty() && !isIdOnlyAssociationReference(drafts)) {
             validateInstantiableSaveType(drafts.get(0).__type(), ctx.options);
         }
+        ctx.updateWhereEnabled = SaveUpdateConditions.validate(ctx, drafts);
+        validateUpdateWhereMode();
+        validatePreAssociationsForUpdateWhere(drafts);
 
         for (ImmutableProp prop : ctx.path.getType().getProps().values()) {
-            if (isVisitable(prop) && prop.isReference(TargetLevel.ENTITY) && prop.isColumnDefinition()) {
+            if (isPreAssociation(prop)) {
                 savePreAssociation(prop, drafts);
             }
         }
@@ -237,14 +259,21 @@ public class Saver {
         for (DraftSpi draft : drafts) {
             preHandler.add(draft);
         }
-        return new SaveOperation(this, drafts, preHandler, isOwnerAcceptanceRequired(preHandler));
+        return new SaveOperation(this, drafts, preHandler, isOwnerAcceptanceRequired(preHandler, drafts));
     }
 
     private void finishSave(SaveOperation operation, SaveSelfResult selfResult) {
         finishAssociations(operation, selfResult);
+        // A rejected INSERT_IF_ABSENT target still needs its existing id so the parent can link to it.
+        boolean materializeAssociationTargets =
+                ctx.path.getParent() != null && ctx.options.getMode() == SaveMode.INSERT_IF_ABSENT;
         new SaveResultMaterializer(ctx).materialize(
-                SaveBatches.drafts(operation.drafts, selfResult.acceptedDrafts),
-                SaveBatches.selfBatches(operation.preHandler, selfResult.acceptedDrafts)
+                materializeAssociationTargets ?
+                        operation.drafts :
+                        SaveBatches.drafts(operation.drafts, selfResult.acceptedDrafts),
+                materializeAssociationTargets ?
+                        operation.preHandler.batches() :
+                        SaveBatches.selfBatches(operation.preHandler, selfResult.acceptedDrafts)
         );
     }
 
@@ -283,6 +312,53 @@ public class Saver {
             }
         }
         return true;
+    }
+
+    private void validatePreAssociationsForUpdateWhere(List<DraftSpi> drafts) {
+        if (!ctx.updateWhereEnabled) {
+            return;
+        }
+        for (ImmutableProp prop : ctx.path.getType().getProps().values()) {
+            if (!isPreAssociation(prop)) {
+                continue;
+            }
+            PropId propId = prop.getId();
+            for (DraftSpi draft : drafts) {
+                if (!draft.__isLoaded(propId)) {
+                    continue;
+                }
+                Object target = draft.__get(propId);
+                if (target != null && !ImmutableObjects.isIdOnly(target)) {
+                    throw new IllegalArgumentException(
+                            "Cannot save the owning-side reference property \"" + prop +
+                                    "\" because update-where is configured for its owner type and the reference " +
+                                    "is neither null nor id-only; saving it before the owner may execute DML even " +
+                                    "if the owner is rejected"
+                    );
+                }
+            }
+        }
+    }
+
+    private void validateUpdateWhereMode() {
+        if (!ctx.updateWhereEnabled) {
+            return;
+        }
+        switch (ctx.options.getMode()) {
+            case UPDATE_ONLY:
+            case UPSERT:
+            case NON_IDEMPOTENT_UPSERT:
+                return;
+            default:
+                throw new IllegalArgumentException(
+                        "Update-where predicates can only be used with UPDATE_ONLY, UPSERT or " +
+                                "NON_IDEMPOTENT_UPSERT mode"
+                );
+        }
+    }
+
+    private boolean isPreAssociation(ImmutableProp prop) {
+        return isVisitable(prop) && prop.isReference(TargetLevel.ENTITY) && prop.isColumnDefinition();
     }
 
     @SuppressWarnings("unchecked")
@@ -362,7 +438,12 @@ public class Saver {
             targetSaver.saveAllImpl(targets);
         }
 
-        updateAssociations(batch, prop, detachOtherSiblings);
+        updateAssociations(
+                batch,
+                prop,
+                detachOtherSiblings,
+                targetSaver
+        );
     }
 
     private boolean isVisitable(ImmutableProp prop) {
@@ -489,6 +570,13 @@ public class Saver {
             } else {
                 acceptedDrafts.addAll(batch.entities());
             }
+            if (batch.mode() == SaveMode.UPDATE_ONLY) {
+                for (DraftSpi draft : batch.entities()) {
+                    if (ctx.isPreselectedAccepted(draft)) {
+                        acceptedDrafts.add(draft);
+                    }
+                }
+            }
         }
         return new SaveSelfResult(detach, acceptedDrafts);
     }
@@ -514,15 +602,49 @@ public class Saver {
         return mode != SaveMode.INSERT_ONLY && mode != SaveMode.INSERT_IF_ABSENT;
     }
 
-    private boolean isOwnerAcceptanceRequired(PreHandler preHandler) {
+    private boolean isOwnerAcceptanceRequired(PreHandler preHandler, List<DraftSpi> drafts) {
         if (!isOwnerAcceptanceMode()) {
             return false;
+        }
+        if (ctx.options.isForceMatchedUpdate()) {
+            return true;
+        }
+        if (ctx.options.getMode() == SaveMode.INSERT_IF_ABSENT) {
+            return true;
+        }
+        if (ctx.updateWhereEnabled) {
+            return true;
+        }
+        if (hasSingleTableDiscriminatorGuard(preHandler, drafts)) {
+            return true;
         }
         if (isJoinedTypeBranchTarget()) {
             return ctx.trigger != null || hasLoadedPostAssociation(preHandler);
         }
-        return ctx.options.getUserOptimisticLock(ctx.path.getType()) != null &&
+        return ctx.options.getOptimisticLockCondition(ctx.path.getType()) != null &&
                 hasLoadedPostAssociation(preHandler);
+    }
+
+    private boolean hasSingleTableDiscriminatorGuard(PreHandler preHandler, List<DraftSpi> drafts) {
+        for (DraftSpi draft : drafts) {
+            if (hasSingleTableDiscriminatorGuard(draft.__type())) {
+                return true;
+            }
+        }
+        for (Batch<DraftSpi> batch : preHandler.batches()) {
+            if (hasSingleTableDiscriminatorGuard(batch.shape().getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasSingleTableDiscriminatorGuard(ImmutableType type) {
+        InheritanceInfo inheritanceInfo = type.getInheritanceInfo();
+        return inheritanceInfo != null &&
+                inheritanceInfo.getStrategy() == InheritanceType.SINGLE_TABLE &&
+                !ctx.options.isTypeChangeAllowed(type) &&
+                Operator.discriminatorGuardProp(ctx.options, inheritanceInfo, type) != null;
     }
 
     private boolean hasLoadedPostAssociation(PreHandler preHandler) {
@@ -604,7 +726,12 @@ public class Saver {
         }
     }
 
-    private void updateAssociations(Batch<DraftSpi> batch, ImmutableProp prop, boolean detach) {
+    private void updateAssociations(
+            Batch<DraftSpi> batch,
+            ImmutableProp prop,
+            boolean detach,
+            Saver targetSaver
+    ) {
         ChildTableOperator subOperator = null;
         MiddleTableOperator middleTableOperator = null;
         if (prop.isMiddleTableDefinition()) {
@@ -637,7 +764,11 @@ public class Saver {
         if (subOperator == null && middleTableOperator == null) {
             return;
         }
-        IdPairs.Retain retainedIdPairs = IdPairs.retain(batch.entities(), prop);
+        PropId targetIdPropId = prop.getTargetType().getIdProp().getId();
+        IdPairs.Retain retainedIdPairs = IdPairs.retain(batch.entities(), prop, target ->
+                target.__isLoaded(targetIdPropId) &&
+                        !targetSaver.ctx.isAssociationTargetUnavailable((DraftSpi) target)
+        );
         if (subOperator != null && detach && ctx.options.getAssociatedMode(prop) == AssociatedSaveMode.REPLACE) {
             subOperator.disconnectExcept(retainedIdPairs, true);
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SimpleEntitySaveCommandImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/SimpleEntitySaveCommandImpl.java
@@ -59,6 +59,11 @@ public class SimpleEntitySaveCommandImpl<E>
     }
 
     @Override
+    public SimpleEntitySaveCommand<E> setVersionMode(VersionMode mode) {
+        return new SimpleEntitySaveCommandImpl<>(new VersionModeCfg(cfg, mode));
+    }
+
+    @Override
     public SimpleEntitySaveCommand<E> setAssociatedModeAll(AssociatedSaveMode mode) {
         return new SimpleEntitySaveCommandImpl<>(new AssociatedModeCfg(cfg, mode));
     }
@@ -74,8 +79,27 @@ public class SimpleEntitySaveCommandImpl<E>
     }
 
     @Override
+    public SimpleEntitySaveCommand<E> forbidUpdate() {
+        RootCfg rootCfg = cfg.as(RootCfg.class);
+        assert rootCfg != null;
+        return new SimpleEntitySaveCommandImpl<>(
+                addForbiddenUpdateMask(cfg, ((ImmutableSpi) rootCfg.argument).__type())
+        );
+    }
+
+    @Override
     public SimpleEntitySaveCommand<E> setUpsertMask(UpsertMask<?> mask) {
         return new SimpleEntitySaveCommandImpl<>(new UpsertMaskCfg(cfg, mask));
+    }
+
+    @Override
+    public SimpleEntitySaveCommand<E> setForceMatchedUpdate() {
+        return new SimpleEntitySaveCommandImpl<>(new ForceMatchedUpdateCfg(cfg));
+    }
+
+    @Override
+    public SimpleEntitySaveCommand<E> setExactConflictTargetRequired() {
+        return new SimpleEntitySaveCommandImpl<>(new ExactConflictTargetRequiredCfg(cfg));
     }
 
     @Override
@@ -97,6 +121,24 @@ public class SimpleEntitySaveCommandImpl<E>
         return new SimpleEntitySaveCommandImpl<>(
                 new AssignmentCfg(cfg, prop, prop.getDeclaringType(), expression)
         );
+    }
+
+    @Override
+    public <X, T extends Table<X>> SimpleEntitySaveCommand<E> setUpdateWhere(
+            Class<T> tableType,
+            UpdateCondition<X, T> condition
+    ) {
+        return new SimpleEntitySaveCommandImpl<>(
+                new UpdateWhereCfg(cfg, ImmutableType.get(tableType), condition)
+        );
+    }
+
+    @Override
+    public SimpleEntitySaveCommand<E> setEntityUpdateWhere(
+            ImmutableType type,
+            UpdateCondition<?, ?> condition
+    ) {
+        return new SimpleEntitySaveCommandImpl<>(new UpdateWhereCfg(cfg, type, condition));
     }
 
     @Override
@@ -126,7 +168,7 @@ public class SimpleEntitySaveCommandImpl<E>
 
     @Override
     public SimpleEntitySaveCommand<E> setKeyOnlyAsReference(ImmutableProp prop, boolean asReference) {
-        return new SimpleEntitySaveCommandImpl<>(new KeyOnlyAsReferenceCfg(cfg, prop,asReference));
+        return new SimpleEntitySaveCommandImpl<>(new KeyOnlyAsReferenceCfg(cfg, prop, asReference));
     }
 
     @Override
@@ -159,14 +201,14 @@ public class SimpleEntitySaveCommandImpl<E>
     public <T extends Table<E>> SimpleEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     ) {
         return new SimpleEntitySaveCommandImpl<>(
-                new OptimisticLockLambdaCfg(
+                new OptimisticLockConditionCfg(
                         cfg,
                         ImmutableType.get(tableType),
                         behavior,
-                        (UserOptimisticLock<Object, Table<Object>>) block
+                        (UpdateCondition<Object, Table<Object>>) condition
                 )
         );
     }
@@ -175,14 +217,14 @@ public class SimpleEntitySaveCommandImpl<E>
     public SimpleEntitySaveCommand<E> setEntityOptimisticLock(
             ImmutableType type,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<Object, Table<Object>> block
+            UpdateCondition<Object, Table<Object>> condition
     ) {
         return new SimpleEntitySaveCommandImpl<>(
-                new OptimisticLockLambdaCfg(
+                new OptimisticLockConditionCfg(
                         cfg,
                         type,
                         behavior,
-                        block
+                        condition
                 )
         );
     }
@@ -323,6 +365,6 @@ public class SimpleEntitySaveCommandImpl<E>
                 entity.__type(),
                 fetcher
         );
-        return saver.save((E)entity);
+        return saver.save((E) entity);
     }
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/TypedUpdateCondition.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/mutation/TypedUpdateCondition.java
@@ -1,0 +1,16 @@
+package org.babyfish.jimmer.sql.ast.impl.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.sql.ast.mutation.UpdateCondition;
+
+final class TypedUpdateCondition {
+
+    final ImmutableType type;
+
+    final UpdateCondition<?, ?> condition;
+
+    TypedUpdateCondition(ImmutableType type, UpdateCondition<?, ?> condition) {
+        this.type = type;
+        this.condition = condition;
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractConfigurableTypedQueryImpl.java
@@ -90,7 +90,10 @@ abstract class AbstractConfigurableTypedQueryImpl implements TypedQueryImplement
                 for (Selection<?> selection : data.selections) {
                     acceptSelection(selection, visitor);
                 }
-                visitBaseTable(mutableQuery.getTableLikeImplementor(), visitor);
+                TableLikeImplementor<?> tableLikeImplementor = mutableQuery.getTableLikeImplementor();
+                if (tableLikeImplementor != null) {
+                    visitBaseTable(tableLikeImplementor, visitor);
+                }
             }
         } finally {
             astContext.popStatement();

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractMutableQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/AbstractMutableQueryImpl.java
@@ -45,6 +45,10 @@ public abstract class AbstractMutableQueryImpl
 
     private int acceptedByPriority = ORDER_BY_PRIORITY_STATEMENT;
 
+    protected AbstractMutableQueryImpl(JSqlClientImplementor sqlClient) {
+        super(sqlClient);
+    }
+
     protected AbstractMutableQueryImpl(
             JSqlClientImplementor sqlClient,
             ImmutableType immutableType
@@ -107,7 +111,7 @@ public abstract class AbstractMutableQueryImpl
      *         eq?, ne?, lt?, le?, gt?, ge?, like?, ilike?, betweenIf?
      *     </li>
      * </ul>
-     *
+     * <p>
      * Taking Java's {@code geIf} as an example, this functionality
      * is ultimately implemented like this.
      * <pre>{@code
@@ -134,7 +138,7 @@ public abstract class AbstractMutableQueryImpl
     }
 
     @Override
-    public AbstractMutableQueryImpl groupBy(Expression<?> ... expressions) {
+    public AbstractMutableQueryImpl groupBy(Expression<?>... expressions) {
         validateMutable();
         for (Expression<?> expression : expressions) {
             if (expression != null) {
@@ -145,7 +149,7 @@ public abstract class AbstractMutableQueryImpl
     }
 
     @Override
-    public AbstractMutableQueryImpl having(Predicate ... predicates) {
+    public AbstractMutableQueryImpl having(Predicate... predicates) {
         validateMutable();
         for (Predicate predicate : predicates) {
             if (predicate != null) {
@@ -156,7 +160,7 @@ public abstract class AbstractMutableQueryImpl
     }
 
     @Override
-    public AbstractMutableQueryImpl orderBy(Expression<?> ... expressions) {
+    public AbstractMutableQueryImpl orderBy(Expression<?>... expressions) {
         validateMutable();
         Order[] orders = new Order[expressions.length];
         for (int i = orders.length - 1; i >= 0; --i) {
@@ -240,7 +244,9 @@ public abstract class AbstractMutableQueryImpl
         visitor.visitStatement(this);
 
         TableLikeImplementor<?> tableLikeImplementor = getTableLikeImplementor();
-        tableLikeImplementor.accept(visitor);
+        if (tableLikeImplementor != null) {
+            tableLikeImplementor.accept(visitor);
+        }
 
         List<Predicate> havingPredicates = this.havingPredicates;
         if (groupByExpressions.isEmpty() && !havingPredicates.isEmpty()) {
@@ -251,23 +257,23 @@ public abstract class AbstractMutableQueryImpl
 
         Predicate havingPredicate = getHavingPredicate(visitor.getAstContext());
         for (Predicate predicate : unfrozenPredicates()) {
-            ((Ast)predicate).accept(visitor);
+            ((Ast) predicate).accept(visitor);
         }
         for (Expression<?> expression : groupByExpressions) {
-            ((Ast)expression).accept(visitor);
+            ((Ast) expression).accept(visitor);
         }
         if (havingPredicate != null) {
-            ((Ast)havingPredicate).accept(visitor);
+            ((Ast) havingPredicate).accept(visitor);
         }
         AstContext astContext = visitor.getAstContext();
         if (withoutSortingAndPaging) {
             AstVisitor ignoredVisitor = new UseJoinOfIgnoredClauseVisitor(astContext);
             for (Order order : orders) {
-                ((Ast)order.getExpression()).accept(ignoredVisitor);
+                ((Ast) order.getExpression()).accept(ignoredVisitor);
             }
         } else {
             for (Order order : orders) {
-                ((Ast)order.getExpression()).accept(visitor);
+                ((Ast) order.getExpression()).accept(visitor);
             }
         }
         if (overriddenSelections != null) {
@@ -280,6 +286,14 @@ public abstract class AbstractMutableQueryImpl
 
     void renderTo(SqlBuilder builder, boolean withoutSortingAndPaging, boolean reverseOrder) {
         TableLikeImplementor<?> tableLikeImplementor = getTableLikeImplementor();
+        if (tableLikeImplementor == null) {
+            String constantTableName = getSqlClient().getDialect().getConstantTableName();
+            if (constantTableName != null) {
+                builder.from().sql(constantTableName);
+            }
+            renderClausesAfterTable(builder, withoutSortingAndPaging, reverseOrder);
+            return;
+        }
         if (tableLikeImplementor.hasBaseTable()) {
             SqlBuilder tmpBuilder = builder.createTempBuilder();
             renderClausesAfterTable(tmpBuilder, withoutSortingAndPaging, reverseOrder);
@@ -303,7 +317,7 @@ public abstract class AbstractMutableQueryImpl
             builder.enter(SqlBuilder.ScopeType.GROUP_BY);
             for (Expression<?> expression : groupByExpressions) {
                 builder.separator();
-                ((Ast)expression).renderTo(builder);
+                ((Ast) expression).renderTo(builder);
             }
             builder.leave();
         }
@@ -319,7 +333,7 @@ public abstract class AbstractMutableQueryImpl
             builder.enter(SqlBuilder.ScopeType.ORDER_BY);
             for (Order order : orders) {
                 builder.separator();
-                ((Ast)order.getExpression()).renderTo(builder);
+                ((Ast) order.getExpression()).renderTo(builder);
                 if (order.getOrderMode() == OrderMode.DESC) {
                     builder.sql(reverseOrder ? " asc" : " desc");
                 } else {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/BaseQueryExportAnalysis.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/BaseQueryExportAnalysis.java
@@ -4,28 +4,24 @@ import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.Selection;
 import org.babyfish.jimmer.sql.ast.impl.AbstractMutableStatementImpl;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseQueryExportCollectorSelection;
-import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
+import org.babyfish.jimmer.sql.ast.impl.base.BaseTableOwner;
 import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
 import org.babyfish.jimmer.sql.ast.impl.table.TableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
 import org.babyfish.jimmer.sql.ast.impl.table.TableUtils;
 import org.babyfish.jimmer.sql.ast.table.Table;
-import org.babyfish.jimmer.sql.meta.ColumnDefinition;
-import org.babyfish.jimmer.sql.meta.EmbeddedColumns;
-import org.babyfish.jimmer.sql.meta.FormulaTemplate;
-import org.babyfish.jimmer.sql.meta.JoinTemplate;
-import org.babyfish.jimmer.sql.meta.MetadataStrategy;
-import org.babyfish.jimmer.sql.meta.SqlTemplate;
-import org.babyfish.jimmer.sql.meta.Storage;
+import org.babyfish.jimmer.sql.meta.*;
 import org.jetbrains.annotations.Nullable;
 
 final class BaseQueryExportAnalysis {
 
-    private BaseQueryExportAnalysis() {}
+    private BaseQueryExportAnalysis() {
+    }
 
     static void analyze(AbstractMutableStatementImpl statement, QueryAnalyzer analysis) {
-        if (!TableUtils.hasBaseTable(statement.getTableLikeImplementor())) {
+        if (statement.getTableLikeImplementor() == null ||
+                !TableUtils.hasBaseTable(statement.getTableLikeImplementor())) {
             return;
         }
         analyze(statement.getTableLikeImplementor(), analysis);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableBaseQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/ConfigurableBaseQueryImpl.java
@@ -18,6 +18,7 @@ import org.babyfish.jimmer.sql.ast.table.base.*;
 import org.babyfish.jimmer.sql.ast.table.spi.AbstractTypedTable;
 import org.babyfish.jimmer.sql.ast.table.spi.BaseTableFactory;
 import org.babyfish.jimmer.sql.ast.table.spi.BaseTableSelectionLayout;
+import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
 import org.babyfish.jimmer.sql.runtime.SqlBuilder;
 import org.babyfish.jimmer.sql.runtime.TupleCreator;
 import org.jetbrains.annotations.NotNull;
@@ -243,7 +244,8 @@ public class ConfigurableBaseQueryImpl<T extends BaseTable>
     @Override
     public TableImplementor<?> resolveRootTable(Table<?> table) {
         MutableBaseQueryImpl mutableQuery = getMutableQuery();
-        return AbstractTypedTable.__refEquals(mutableQuery.getTable(), table) ?
+        TableLike<?> rootTable = mutableQuery.getTable();
+        return rootTable != null && AbstractTypedTable.__refEquals(rootTable, table) ?
                 (TableImplementor<?>) mutableQuery.getTableLikeImplementor() :
                 null;
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/CteTableDependencyAnalyzer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/CteTableDependencyAnalyzer.java
@@ -6,12 +6,7 @@ import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.table.RealTable;
 import org.babyfish.jimmer.sql.ast.impl.table.TableLikeImplementor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 final class CteTableDependencyAnalyzer {
 
@@ -29,7 +24,7 @@ final class CteTableDependencyAnalyzer {
         Map<AbstractMutableStatementImpl, List<CteTableDeclaration>> declarationMap = null;
         for (AbstractMutableStatementImpl statement : statements) {
             TableLikeImplementor<?> tableLikeImplementor = statement.getTableLikeImplementor();
-            if (!tableLikeImplementor.hasBaseTable()) {
+            if (tableLikeImplementor == null || !tableLikeImplementor.hasBaseTable()) {
                 continue;
             }
             List<RealTable> tables = collectRenderTables(tableLikeImplementor.realTable(astContext));
@@ -188,7 +183,7 @@ final class CteTableDependencyAnalyzer {
             astContext.pushStatement(query.getMutableQuery());
             try {
                 TableLikeImplementor<?> tableLikeImplementor = query.getMutableQuery().getTableLikeImplementor();
-                if (tableLikeImplementor.hasBaseTable()) {
+                if (tableLikeImplementor != null && tableLikeImplementor.hasBaseTable()) {
                     collectCteTables(tableLikeImplementor.realTable(astContext));
                 }
             } finally {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableBaseQueryImpl.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutableBaseQueryImpl.java
@@ -29,6 +29,10 @@ public class MutableBaseQueryImpl extends AbstractMutableQueryImpl implements Mu
 
     private StatementContext ctx;
 
+    public MutableBaseQueryImpl(JSqlClientImplementor sqlClient) {
+        super(sqlClient);
+    }
+
     public MutableBaseQueryImpl(
             JSqlClientImplementor sqlClient,
             TableLike<?> table

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutationQueryAnalyzer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/MutationQueryAnalyzer.java
@@ -1,0 +1,43 @@
+package org.babyfish.jimmer.sql.ast.impl.query;
+
+import org.babyfish.jimmer.sql.ast.impl.AstContext;
+import org.babyfish.jimmer.sql.ast.impl.table.StatementContext;
+import org.babyfish.jimmer.sql.runtime.SqlBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Internal bridge that lets mutation statements reuse the normal base-query analysis.
+ */
+public final class MutationQueryAnalyzer {
+
+    private MutationQueryAnalyzer() {
+    }
+
+    public static void apply(
+            SqlBuilder builder,
+            TypedQueryImplementor mutation,
+            TypedBaseQueryImplementor<?> source
+    ) {
+        AstContext astContext = builder.getAstContext();
+        QueryAnalyzer analyzer = new QueryAnalyzer(astContext, mutation);
+        List<ConfigurableBaseQueryImpl<?>> queries = new ArrayList<>();
+        source.collectConfigurableQueries(queries);
+        // Join requirements must be analyzed after virtual predicates have been resolved.
+        // Do this per branch because a merged query can contain both frozen and mutable branches.
+        for (ConfigurableBaseQueryImpl<?> query : queries) {
+            MutableBaseQueryImpl mutableQuery = query.getMutableQuery();
+            if (!mutableQuery.isFrozen()) {
+                mutableQuery.applyVirtualPredicates(astContext);
+            }
+        }
+        StatementContext sourceContext = source.firstConfigurableQuery().getMutableQuery().getContext();
+        source.applyGlobalFilters(
+                astContext,
+                sourceContext != null ? sourceContext.getFilterLevel() : FilterLevel.DEFAULT,
+                analyzer.analyzeJoinRequirements()
+        );
+        builder.setQueryAnalysis(analyzer.analyze());
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/query/TableUsageVisitor.java
@@ -69,8 +69,11 @@ public abstract class TableUsageVisitor extends AstVisitor {
 
     @Override
     public void visitStatement(AbstractMutableStatementImpl statement) {
-        AstContext ctx = getAstContext();
-        RealTable table = realTable(ctx.getStatement().getTableLikeImplementor());
+        TableLikeImplementor<?> tableLikeImplementor = getAstContext().getStatement().getTableLikeImplementor();
+        if (tableLikeImplementor == null) {
+            return;
+        }
+        RealTable table = realTable(tableLikeImplementor);
         addRootTable(table);
         table.use(this);
     }
@@ -86,7 +89,8 @@ public abstract class TableUsageVisitor extends AstVisitor {
             RealTable table,
             @Nullable ImmutableProp prop,
             boolean rawId
-    ) {}
+    ) {
+    }
 
     protected final RealTable realTable(TableLikeImplementor<?> tableLikeImplementor) {
         return realTableForAnalysis(tableLikeImplementor);

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/render/AbstractSqlBuilder.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/render/AbstractSqlBuilder.java
@@ -37,6 +37,8 @@ public abstract class AbstractSqlBuilder<T extends AbstractSqlBuilder<T>> {
 
     private SaveInputValueRenderFrame saveInputValueRenderFrame;
 
+    private MutationExpressionFrame mutationExpressionFrame;
+
     private boolean indentRequired;
 
     protected abstract SqlFormatter formatter();
@@ -100,6 +102,26 @@ public abstract class AbstractSqlBuilder<T extends AbstractSqlBuilder<T>> {
         }
         renderSingleColumnValueGetter(getters.get(0), frame.prefix, frame.suffix);
         return true;
+    }
+
+    public void pushMutationExpressionMap(Map<?, ?> map) {
+        mutationExpressionFrame = new MutationExpressionFrame(map, mutationExpressionFrame);
+    }
+
+    public void popMutationExpressionMap() {
+        mutationExpressionFrame = mutationExpressionFrame.parent;
+    }
+
+    @Nullable
+    public Object getMutationExpressionReplacement(Object expression) {
+        for (MutationExpressionFrame frame = mutationExpressionFrame; frame != null; frame = frame.parent) {
+            Object replacement = frame.map.get(expression);
+            if (replacement != null) {
+                return replacement;
+            }
+        }
+        AstContext astContext = getAstContext();
+        return astContext != null ? astContext.getMutationExpressionReplacement(expression) : null;
     }
 
     public void pushSaveInputValueRender(@Nullable String prefix, String suffix) {
@@ -720,6 +742,18 @@ public abstract class AbstractSqlBuilder<T extends AbstractSqlBuilder<T>> {
             this.parent = parent;
             this.prefix = prefix;
             this.suffix = suffix;
+        }
+    }
+
+    private static class MutationExpressionFrame {
+
+        final Map<?, ?> map;
+
+        final MutationExpressionFrame parent;
+
+        MutationExpressionFrame(Map<?, ?> map, MutationExpressionFrame parent) {
+            this.map = map;
+            this.parent = parent;
         }
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableUtils.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/impl/table/TableUtils.java
@@ -3,7 +3,6 @@ package org.babyfish.jimmer.sql.ast.impl.table;
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableImplementor;
 import org.babyfish.jimmer.sql.ast.impl.base.BaseTableSymbol;
-import org.babyfish.jimmer.sql.ast.table.BaseTable;
 import org.babyfish.jimmer.sql.ast.table.Table;
 import org.babyfish.jimmer.sql.ast.table.spi.TableLike;
 import org.babyfish.jimmer.sql.ast.table.spi.TableProxy;
@@ -14,11 +13,12 @@ import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
 
 public class TableUtils {
 
-    private TableUtils() {}
+    private TableUtils() {
+    }
 
     public static TableLike<?> parent(TableLike<?> tableLike) {
         if (tableLike instanceof BaseTableSymbol) {
-            return ((BaseTableSymbol)tableLike).getParent();
+            return ((BaseTableSymbol) tableLike).getParent();
         }
         return parent((Table<?>) tableLike);
     }
@@ -31,6 +31,9 @@ public class TableUtils {
     }
 
     public static boolean hasBaseTable(TableLikeImplementor<?> tableLike) {
+        if (tableLike == null) {
+            return false;
+        }
         if (tableLike instanceof BaseTableImplementor) {
             return true;
         }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/AbstractEntitySaveCommand.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/AbstractEntitySaveCommand.java
@@ -14,6 +14,20 @@ public interface AbstractEntitySaveCommand {
     @NewChain
     AbstractEntitySaveCommand setMode(SaveMode mode);
 
+    /**
+     * Configure how the {@code @Version} property of the root entity is saved.
+     * This configuration does not propagate to associated entities.
+     *
+     * <p>The default is {@link VersionMode#OPTIMISTIC_LOCK}. In
+     * {@link VersionMode#ASSIGNMENT} mode, a loaded version is treated as an
+     * ordinary insert/update value and does not enable an implicit optimistic
+     * lock or automatic increment.</p>
+     *
+     * @param mode The version mode, it cannot be {@code null}
+     */
+    @NewChain
+    AbstractEntitySaveCommand setVersionMode(VersionMode mode);
+
     @NewChain
     AbstractEntitySaveCommand setAssociatedModeAll(AssociatedSaveMode mode);
 
@@ -24,16 +38,26 @@ public interface AbstractEntitySaveCommand {
     AbstractEntitySaveCommand setAssociatedMode(TypedProp.Association<?, ?> prop, AssociatedSaveMode mode);
 
     @NewChain
-    AbstractEntitySaveCommand setKeyProps(ImmutableProp ... props);
+    AbstractEntitySaveCommand setKeyProps(ImmutableProp... props);
 
     @NewChain
-    AbstractEntitySaveCommand setKeyProps(String group, ImmutableProp ... props);
+    AbstractEntitySaveCommand setKeyProps(String group, ImmutableProp... props);
 
     @NewChain
-    AbstractEntitySaveCommand setKeyProps(TypedProp.Single<?, ?> ... props);
+    AbstractEntitySaveCommand setKeyProps(TypedProp.Single<?, ?>... props);
 
     @NewChain
-    AbstractEntitySaveCommand setKeyProps(String group, TypedProp.Single<?, ?> ... props);
+    AbstractEntitySaveCommand setKeyProps(String group, TypedProp.Single<?, ?>... props);
+
+    /**
+     * Forbid update assignments derived from entity properties during upsert.
+     *
+     * <p>This is equivalent to specifying an {@link UpsertMask} whose updatable
+     * property list is empty. A dialect can still render a fake update assignment
+     * when it is required by id fetching, returning, or other save semantics.</p>
+     */
+    @NewChain
+    AbstractEntitySaveCommand forbidUpdate();
 
     /**
      * Set UpsertMask with updatable properties
@@ -54,13 +78,13 @@ public interface AbstractEntitySaveCommand {
      * }</pre>
      *
      * @param props Properties that can be updated
-     *          <ul>
-     *              <li>its length cannot be 0</li>
-     *              <li>all properties must belong to one entity type</li>
-     *          </ul>
+     *              <ul>
+     *                  <li>An empty array selects no entity properties for update</li>
+     *                  <li>all properties must belong to one entity type</li>
+     *              </ul>
      */
     @NewChain
-    AbstractEntitySaveCommand setUpsertMask(ImmutableProp ... props);
+    AbstractEntitySaveCommand setUpsertMask(ImmutableProp... props);
 
     /**
      * Set UpsertMask with updatable properties
@@ -81,13 +105,13 @@ public interface AbstractEntitySaveCommand {
      * }</pre>
      *
      * @param props Properties that can be updated
-     *          <ul>
-     *              <li>its length cannot be 0</li>
-     *              <li>all properties must belong to one entity type</li>
-     *          </ul>
+     *              <ul>
+     *                  <li>An empty array selects no entity properties for update</li>
+     *                  <li>all properties must belong to one entity type</li>
+     *              </ul>
      */
     @NewChain
-    AbstractEntitySaveCommand setUpsertMask(TypedProp.Single<?, ?> ... props);
+    AbstractEntitySaveCommand setUpsertMask(TypedProp.Single<?, ?>... props);
 
     /**
      * Set UpsertMask object
@@ -126,6 +150,12 @@ public interface AbstractEntitySaveCommand {
             Class<T> tableType,
             TypedProp.Scalar<E, V> prop,
             SaveAssignmentExpression<E, T, V> expression
+    );
+
+    @NewChain
+    <E, T extends Table<E>> AbstractEntitySaveCommand setUpdateWhere(
+            Class<T> tableType,
+            UpdateCondition<E, T> condition
     );
 
     @NewChain

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/BatchEntitySaveCommand.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/BatchEntitySaveCommand.java
@@ -24,6 +24,10 @@ public interface BatchEntitySaveCommand<E>
 
     @NewChain
     @Override
+    BatchEntitySaveCommand<E> setVersionMode(VersionMode mode);
+
+    @NewChain
+    @Override
     BatchEntitySaveCommand<E> setAssociatedModeAll(AssociatedSaveMode mode);
 
     @NewChain
@@ -64,9 +68,13 @@ public interface BatchEntitySaveCommand<E>
 
     @NewChain
     @Override
+    BatchEntitySaveCommand<E> forbidUpdate();
+
+    @NewChain
+    @Override
     default BatchEntitySaveCommand<E> setUpsertMask(ImmutableProp... props) {
         if (props.length == 0) {
-            throw new IllegalArgumentException("props cannot be empty");
+            return forbidUpdate();
         }
         UpsertMask<?> mask = UpsertMask.of(props[0].getDeclaringType().getJavaClass());
         for (ImmutableProp prop : props) {
@@ -79,7 +87,7 @@ public interface BatchEntitySaveCommand<E>
     @Override
     default BatchEntitySaveCommand<E> setUpsertMask(TypedProp.Single<?, ?>... props) {
         if (props.length == 0) {
-            throw new IllegalArgumentException("props cannot be empty");
+            return forbidUpdate();
         }
         UpsertMask<?> mask = UpsertMask.of(props[0].unwrap().getDeclaringType().getJavaClass());
         for (TypedProp.Single<?, ?> prop : props) {
@@ -98,6 +106,13 @@ public interface BatchEntitySaveCommand<E>
             Class<T> tableType,
             TypedProp.Scalar<X, V> prop,
             SaveAssignmentExpression<X, T, V> expression
+    );
+
+    @NewChain
+    @Override
+    <X, T extends Table<X>> BatchEntitySaveCommand<E> setUpdateWhere(
+            Class<T> tableType,
+            UpdateCondition<X, T> condition
     );
 
     @NewChain
@@ -309,9 +324,9 @@ public interface BatchEntitySaveCommand<E>
     @NewChain
     default <T extends Table<E>> BatchEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     ) {
-        return setOptimisticLock(tableType, UnloadedVersionBehavior.IGNORE, block);
+        return setOptimisticLock(tableType, UnloadedVersionBehavior.IGNORE, condition);
     }
 
     /**
@@ -334,7 +349,7 @@ public interface BatchEntitySaveCommand<E>
     <T extends Table<E>> BatchEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
             UnloadedVersionBehavior unloadedVersionBehavior,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     );
 
     @NewChain

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/BatchSaveResult.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/BatchSaveResult.java
@@ -52,6 +52,7 @@ public class BatchSaveResult<E> extends AbstractMutationResult {
             View.ViewItem<E, V> viewItem = new View.ViewItem<>(
                     item.originalEntity,
                     item.modifiedEntity,
+                    item.accepted,
                     converter.apply(item.modifiedEntity)
             );
             viewItems.add(viewItem);
@@ -65,9 +66,16 @@ public class BatchSaveResult<E> extends AbstractMutationResult {
 
         final E modifiedEntity;
 
+        final boolean accepted;
+
         public Item(E originalEntity, E modifiedEntity) {
+            this(originalEntity, modifiedEntity, true);
+        }
+
+        public Item(E originalEntity, E modifiedEntity, boolean accepted) {
             this.originalEntity = originalEntity;
             this.modifiedEntity = modifiedEntity;
+            this.accepted = accepted;
         }
 
         @NotNull
@@ -83,10 +91,16 @@ public class BatchSaveResult<E> extends AbstractMutationResult {
         }
 
         @Override
+        public boolean isAccepted() {
+            return accepted;
+        }
+
+        @Override
         public String toString() {
             return "Item{" +
                     "originalEntity=" + originalEntity +
                     ", modifiedEntity=" + modifiedEntity +
+                    ", accepted=" + accepted +
                     '}';
         }
     }
@@ -100,7 +114,7 @@ public class BatchSaveResult<E> extends AbstractMutationResult {
 
         @SuppressWarnings("unchecked")
         public List<ViewItem<E, V>> getViewItems() {
-            return (List<ViewItem<E, V>>)(List<?>) items;
+            return (List<ViewItem<E, V>>) (List<?>) items;
         }
 
         @Override
@@ -117,7 +131,11 @@ public class BatchSaveResult<E> extends AbstractMutationResult {
             private final V modifiedView;
 
             public ViewItem(E originalEntity, E modifiedEntity, V modifiedView) {
-                super(originalEntity, modifiedEntity);
+                this(originalEntity, modifiedEntity, true, modifiedView);
+            }
+
+            public ViewItem(E originalEntity, E modifiedEntity, boolean accepted, V modifiedView) {
+                super(originalEntity, modifiedEntity, accepted);
                 this.modifiedView = modifiedView;
             }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableInsert.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableInsert.java
@@ -1,0 +1,33 @@
+package org.babyfish.jimmer.sql.ast.mutation;
+
+import org.babyfish.jimmer.lang.OldChain;
+import org.babyfish.jimmer.sql.ast.Executable;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable;
+import org.babyfish.jimmer.sql.ast.table.BaseTable;
+
+/**
+ * Bulk insert whose rows are supplied by a typed {@link BaseTable} source.
+ */
+public interface MutableInsert<S extends BaseTable>
+        extends Executable<Integer>, ReturningSelectable {
+
+    @OldChain
+    <T> MutableInsert<S> set(PropExpression<T> target, Expression<T> source);
+
+    /**
+     * Skip conflicts for the highest-priority eligible id/key group inferred
+     * from target metadata.
+     */
+    @OldChain
+    MutableInsert<S> onConflictDoNothing();
+
+    /**
+     * Skip conflicts for one explicitly specified unique physical key.
+     * The array must not be empty; call {@link #onConflictDoNothing()} to use
+     * metadata inference.
+     */
+    @OldChain
+    MutableInsert<S> onConflictDoNothing(PropExpression<?>... targetProps);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpsert.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutableUpsert.java
@@ -1,0 +1,37 @@
+package org.babyfish.jimmer.sql.ast.mutation;
+
+import org.babyfish.jimmer.lang.OldChain;
+import org.babyfish.jimmer.sql.ast.Executable;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.Predicate;
+import org.babyfish.jimmer.sql.ast.PropExpression;
+import org.babyfish.jimmer.sql.ast.query.selectable.ReturningSelectable;
+import org.babyfish.jimmer.sql.ast.table.BaseTable;
+
+/**
+ * Bulk upsert whose rows are supplied by a typed {@link BaseTable} source.
+ * Source rows must be unique by the properties declared with {@link #key}; a
+ * materialized plan validates this precondition before executing mutations.
+ */
+public interface MutableUpsert<S extends BaseTable>
+        extends Executable<Integer>, ReturningSelectable {
+
+    @OldChain
+    <T> MutableUpsert<S> key(PropExpression<T> target, Expression<T> source);
+
+    @OldChain
+    <T> MutableUpsert<S> insert(PropExpression<T> target, Expression<T> source);
+
+    @OldChain
+    <T> MutableUpsert<S> merge(PropExpression<T> target, Expression<T> source);
+
+    @OldChain
+    <T> MutableUpsert<S> merge(
+            PropExpression<T> target,
+            Expression<T> insertSource,
+            Expression<T> updateExpression
+    );
+
+    @OldChain
+    MutableUpsert<S> updateWhere(Predicate... predicates);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutationResultItem.kt
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/MutationResultItem.kt
@@ -1,10 +1,13 @@
 package org.babyfish.jimmer.sql.ast.mutation
 
-interface MutationResultItem<E: Any> {
+interface MutationResultItem<E : Any> {
 
     val originalEntity: E
 
     val modifiedEntity: E
+
+    val isAccepted: Boolean
+        get() = true
 
     /**
      * If it is true, that means the save object is changed,

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/QueryReason.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/QueryReason.java
@@ -202,6 +202,13 @@ public enum QueryReason {
     OPTIMISTIC_LOCK,
 
     /**
+     * The update arm of an upsert has a selective predicate. The existing
+     * row is locked before mutation so a predicate rejection performs no
+     * update at all and cannot fire an update trigger.
+     */
+    UPDATE_WHERE,
+
+    /**
      * The current entity type being operated on is annotated with
      * {@link org.babyfish.jimmer.sql.KeyUniqueConstraint}.
      *

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/SimpleEntitySaveCommand.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/SimpleEntitySaveCommand.java
@@ -24,6 +24,10 @@ public interface SimpleEntitySaveCommand<E>
 
     @NewChain
     @Override
+    SimpleEntitySaveCommand<E> setVersionMode(VersionMode mode);
+
+    @NewChain
+    @Override
     SimpleEntitySaveCommand<E> setAssociatedModeAll(AssociatedSaveMode mode);
 
     @NewChain
@@ -63,9 +67,13 @@ public interface SimpleEntitySaveCommand<E>
 
     @NewChain
     @Override
+    SimpleEntitySaveCommand<E> forbidUpdate();
+
+    @NewChain
+    @Override
     default SimpleEntitySaveCommand<E> setUpsertMask(ImmutableProp... props) {
         if (props.length == 0) {
-            throw new IllegalArgumentException("props cannot be empty");
+            return forbidUpdate();
         }
         UpsertMask<?> mask = UpsertMask.of(props[0].getDeclaringType().getJavaClass());
         for (ImmutableProp prop : props) {
@@ -78,7 +86,7 @@ public interface SimpleEntitySaveCommand<E>
     @Override
     default SimpleEntitySaveCommand<E> setUpsertMask(TypedProp.Single<?, ?>... props) {
         if (props.length == 0) {
-            throw new IllegalArgumentException("props cannot be empty");
+            return forbidUpdate();
         }
         UpsertMask<?> mask = UpsertMask.of(props[0].unwrap().getDeclaringType().getJavaClass());
         for (TypedProp.Single<?, ?> prop : props) {
@@ -97,6 +105,13 @@ public interface SimpleEntitySaveCommand<E>
             Class<T> tableType,
             TypedProp.Scalar<X, V> prop,
             SaveAssignmentExpression<X, T, V> expression
+    );
+
+    @NewChain
+    @Override
+    <X, T extends Table<X>> SimpleEntitySaveCommand<E> setUpdateWhere(
+            Class<T> tableType,
+            UpdateCondition<X, T> condition
     );
 
     @NewChain
@@ -308,9 +323,9 @@ public interface SimpleEntitySaveCommand<E>
     @NewChain
     default <T extends Table<E>> SimpleEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     ) {
-        return setOptimisticLock(tableType, UnloadedVersionBehavior.IGNORE, block);
+        return setOptimisticLock(tableType, UnloadedVersionBehavior.IGNORE, condition);
     }
 
     /**
@@ -331,7 +346,7 @@ public interface SimpleEntitySaveCommand<E>
     <T extends Table<E>> SimpleEntitySaveCommand<E> setOptimisticLock(
             Class<T> tableType,
             UnloadedVersionBehavior behavior,
-            UserOptimisticLock<E, T> block
+            UpdateCondition<E, T> condition
     );
 
     @NewChain

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/SimpleSaveResult.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/SimpleSaveResult.java
@@ -11,14 +11,26 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
 
     final E modifiedEntity;
 
+    final boolean accepted;
+
     public SimpleSaveResult(
             Map<AffectedTable, Integer> affectedRowCountMap,
             E originalEntity,
             E modifiedEntity
     ) {
+        this(affectedRowCountMap, originalEntity, modifiedEntity, true);
+    }
+
+    public SimpleSaveResult(
+            Map<AffectedTable, Integer> affectedRowCountMap,
+            E originalEntity,
+            E modifiedEntity,
+            boolean accepted
+    ) {
         super(affectedRowCountMap);
         this.originalEntity = originalEntity;
         this.modifiedEntity = modifiedEntity;
+        this.accepted = accepted;
     }
 
     @NotNull
@@ -34,10 +46,16 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
     }
 
     @Override
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    @Override
     public int hashCode() {
         int hash = affectedRowCountMap.hashCode();
         hash = hash * 31 + System.identityHashCode(originalEntity);
         hash = hash * 31 + System.identityHashCode(modifiedEntity);
+        hash = hash * 31 + Boolean.hashCode(accepted);
         return hash;
     }
 
@@ -48,7 +66,8 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
         SimpleSaveResult<?> that = (SimpleSaveResult<?>) o;
         return affectedRowCountMap.equals(that.affectedRowCountMap) &&
                 originalEntity == that.originalEntity &&
-                modifiedEntity == that.modifiedEntity;
+                modifiedEntity == that.modifiedEntity &&
+                accepted == that.accepted;
     }
 
     @Override
@@ -58,6 +77,7 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
                 ", affectedRowCountMap=" + affectedRowCountMap +
                 ", originalEntity=" + originalEntity +
                 ", modifiedEntity=" + modifiedEntity +
+                ", accepted=" + accepted +
                 '}';
     }
 
@@ -68,6 +88,7 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
                 affectedRowCountMap,
                 originalEntity,
                 modifiedEntity,
+                accepted,
                 converter.apply(modifiedEntity)
         );
     }
@@ -80,9 +101,10 @@ public class SimpleSaveResult<E> extends AbstractMutationResult implements Mutat
                 Map<AffectedTable, Integer> affectedRowCountMap,
                 E originalEntity,
                 E modifiedEntity,
+                boolean accepted,
                 V modifiedView
         ) {
-            super(affectedRowCountMap, originalEntity, modifiedEntity);
+            super(affectedRowCountMap, originalEntity, modifiedEntity, accepted);
             this.modifiedView = modifiedView;
         }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UpdateCondition.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UpdateCondition.java
@@ -1,0 +1,12 @@
+package org.babyfish.jimmer.sql.ast.mutation;
+
+import org.babyfish.jimmer.sql.ast.Predicate;
+import org.babyfish.jimmer.sql.ast.table.Table;
+import org.jetbrains.annotations.Nullable;
+
+@FunctionalInterface
+public interface UpdateCondition<E, T extends Table<E>> {
+
+    @Nullable
+    Predicate predicate(T table, ValueExpressionFactory<E> values);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UpsertMask.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UpsertMask.java
@@ -8,7 +8,10 @@ import org.babyfish.jimmer.meta.TypedProp;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class UpsertMask<E> {
 
@@ -54,6 +57,12 @@ public class UpsertMask<E> {
         return new UpsertMask<>(immutableType);
     }
 
+    /**
+     * Start with no entity properties selected for insertion. Conflict columns
+     * and framework-required columns are still rendered independently of this
+     * mask. Add the insertable properties explicitly after this call. If an
+     * omitted database column is mandatory and has no default, insertion fails.
+     */
     @NewChain
     public UpsertMask<E> forbidInsert() {
         if (insertablePaths != null && insertablePaths.isEmpty()) {
@@ -62,6 +71,10 @@ public class UpsertMask<E> {
         return new UpsertMask<>(type, Collections.emptyList(), updatablePaths);
     }
 
+    /**
+     * Select no entity properties for the update branch. A fake update can still
+     * be rendered when required by id fetching, returning, or other save semantics.
+     */
     @NewChain
     public UpsertMask<E> forbidUpdate() {
         if (updatablePaths != null && updatablePaths.isEmpty()) {
@@ -82,22 +95,24 @@ public class UpsertMask<E> {
 
     /**
      * Add insertable path, the type of first property must be embeddable
+     *
      * @param props The properties of embeddable properties path
      * @return Another UpsertMask object which is not current object
      */
     @NewChain
-    public UpsertMask<E> addInsertablePath(ImmutableProp ... props) {
+    public UpsertMask<E> addInsertablePath(ImmutableProp... props) {
         return addInsertablePath0(new ArrayList<>(Arrays.asList(props)));
     }
 
     /**
      * Add insertable path, the first property must be embeddable
-     * @param prop The entity property whose type is embeddable
+     *
+     * @param prop          The entity property whose type is embeddable
      * @param embeddedProps Deeper properties of embeddable path
      * @return Another UpsertMask object which is not current object
      */
     @NewChain
-    public UpsertMask<E> addInsertablePath(TypedProp.Single<E, ?> prop, TypedProp.Single<?, ?> ... embeddedProps) {
+    public UpsertMask<E> addInsertablePath(TypedProp.Single<E, ?> prop, TypedProp.Single<?, ?>... embeddedProps) {
         return addInsertablePath0(toList(prop, embeddedProps));
     }
 
@@ -113,22 +128,24 @@ public class UpsertMask<E> {
 
     /**
      * Add updatable path, the type of first property must be embeddable
+     *
      * @param props The properties of embeddable properties path
      * @return Another UpsertMask object which is not current object
      */
     @NewChain
-    public UpsertMask<E> addUpdatablePath(ImmutableProp ... props) {
+    public UpsertMask<E> addUpdatablePath(ImmutableProp... props) {
         return addUpdatablePath0(new ArrayList<>(Arrays.asList(props)));
     }
 
     /**
      * Add updatable path, the first property must be embeddable
-     * @param prop The entity property whose type is embeddable
+     *
+     * @param prop          The entity property whose type is embeddable
      * @param embeddedProps Deeper properties of embeddable path
      * @return Another UpsertMask object which is not current object
      */
     @NewChain
-    public UpsertMask<E> addUpdatablePath(TypedProp.Single<E, ?> prop, TypedProp.Single<?, ?> ... embeddedProps) {
+    public UpsertMask<E> addUpdatablePath(TypedProp.Single<E, ?> prop, TypedProp.Single<?, ?>... embeddedProps) {
         return addUpdatablePath0(toList(prop, embeddedProps));
     }
 

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UserOptimisticLock.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/UserOptimisticLock.java
@@ -1,9 +1,11 @@
 package org.babyfish.jimmer.sql.ast.mutation;
 
-import org.babyfish.jimmer.sql.ast.Predicate;
 import org.babyfish.jimmer.sql.ast.table.Table;
 
-public interface UserOptimisticLock<E, T extends Table<E>> {
-
-    Predicate predicate(T table, ValueExpressionFactory<E> valueExpressionFactory);
+/**
+ * @deprecated Use {@link UpdateCondition}.
+ */
+@Deprecated
+@FunctionalInterface
+public interface UserOptimisticLock<E, T extends Table<E>> extends UpdateCondition<E, T> {
 }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/VersionMode.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/ast/mutation/VersionMode.java
@@ -1,0 +1,23 @@
+package org.babyfish.jimmer.sql.ast.mutation;
+
+/**
+ * Determines how a save command treats the {@code @Version} property of its
+ * root entity.
+ */
+public enum VersionMode {
+
+    /**
+     * Use the loaded version as an implicit optimistic-lock condition and
+     * increase the version automatically after a successful update.
+     */
+    OPTIMISTIC_LOCK,
+
+    /**
+     * Treat the version as an ordinary assignment controlled by the entity
+     * shape, upsert mask, custom save assignments, and update conditions.
+     * A loaded version is neither an implicit optimistic-lock condition nor
+     * increased automatically. On insertion, an unloaded version still uses
+     * its framework-defined initial value.
+     */
+    ASSIGNMENT
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/di/AbstractJSqlClientDelegate.java
@@ -57,12 +57,30 @@ public abstract class AbstractJSqlClientDelegate implements JSqlClientImplemento
     }
 
     @Override
+    public <SE, ST extends Table<SE>, TE, TT extends Table<TE>>
+    MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createQuery(
+            AssociationTable<SE, ST, TE, TT> table
+    ) {
+        return sqlClient().createQuery(table);
+    }
+
+    @Override
     public <T extends BaseTable> MutableRootQuery<T> createQuery(T baseTable) {
         return sqlClient().createQuery(baseTable);
     }
 
     @Override
+    public MutableBaseQuery createBaseQuery() {
+        return sqlClient().createBaseQuery();
+    }
+
+    @Override
     public MutableBaseQuery createBaseQuery(TableProxy<?> table) {
+        return sqlClient().createBaseQuery(table);
+    }
+
+    @Override
+    public MutableBaseQuery createBaseQuery(AssociationTable<?, ?, ?, ?> table) {
         return sqlClient().createBaseQuery(table);
     }
 
@@ -96,8 +114,21 @@ public abstract class AbstractJSqlClientDelegate implements JSqlClientImplemento
     }
 
     @Override
-    public <SE, ST extends Table<SE>, TE, TT extends Table<TE>> MutableRootQuery<AssociationTable<SE, ST, TE, TT>> createAssociationQuery(AssociationTable<SE, ST, TE, TT> table) {
-        return sqlClient().createAssociationQuery(table);
+    public <S extends BaseTable> MutableInsert<S> createInsert(TableProxy<?> target, S source) {
+        return sqlClient().createInsert(target, source);
+    }
+
+    @Override
+    public <S extends BaseTable> MutableInsert<S> createInsert(
+            AssociationTable<?, ?, ?, ?> target,
+            S source
+    ) {
+        return sqlClient().createInsert(target, source);
+    }
+
+    @Override
+    public <S extends BaseTable> MutableUpsert<S> createUpsert(TableProxy<?> target, S source) {
+        return sqlClient().createUpsert(target, source);
     }
 
     @Override

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/Dialect.java
@@ -54,11 +54,17 @@ public interface Dialect extends SqlTypeStrategy {
         return null;
     }
 
-    default boolean isDeletedAliasRequired() { return false; }
+    default boolean isDeletedAliasRequired() {
+        return false;
+    }
 
-    default boolean isDeleteNeedsAsKeyword() { return false; }
+    default boolean isDeleteNeedsAsKeyword() {
+        return false;
+    }
 
-    default boolean isUpdateNeedsAsKeyword() { return false; }
+    default boolean isUpdateNeedsAsKeyword() {
+        return false;
+    }
 
     /**
      * Whether UPDATE statement requires alias before table name.
@@ -71,16 +77,22 @@ public interface Dialect extends SqlTypeStrategy {
      *
      * @return whether update alias is required before table name
      */
-    default boolean isUpdateAliasRequired() { return false; }
+    default boolean isUpdateAliasRequired() {
+        return false;
+    }
 
     @Nullable
     default String getOffsetOptimizationNumField() {
         return null;
     }
 
-    default boolean isMultiInsertionSupported() { return true; }
+    default boolean isMultiInsertionSupported() {
+        return true;
+    }
 
-    default boolean isArraySupported() { return false; }
+    default boolean isArraySupported() {
+        return false;
+    }
 
     default boolean isAnyEqualityOfArraySupported() {
         return isArraySupported();
@@ -107,7 +119,21 @@ public interface Dialect extends SqlTypeStrategy {
     }
 
     @Nullable
-    default String getConstantTableName() { return null; }
+    default String getConstantTableName() {
+        return null;
+    }
+
+    /**
+     * Whether selections of a rootless base query must be explicitly typed
+     * when that query is rendered as a derived table.
+     */
+    default boolean isRootlessSelectionCastRequired() {
+        return false;
+    }
+
+    default InsertFromSelectRenderer getInsertFromSelectRenderer() {
+        return InsertFromSelectRenderers.DEFAULT;
+    }
 
     default Class<?> getJsonBaseType() {
         return String.class;
@@ -127,7 +153,9 @@ public interface Dialect extends SqlTypeStrategy {
         return true;
     }
 
-    default boolean isIgnoreCaseLikeSupported() { return false; }
+    default boolean isIgnoreCaseLikeSupported() {
+        return false;
+    }
 
     default int resolveJdbcType(Class<?> sqlType) {
         return Types.OTHER;
@@ -183,6 +211,14 @@ public interface Dialect extends SqlTypeStrategy {
     }
 
     default boolean isUpsertWithOptimisticLockSupported() {
+        return false;
+    }
+
+    /**
+     * Whether native upsert can put a predicate on the update branch so that
+     * a non-matching conflict executes no update at all.
+     */
+    default boolean isUpsertWithUpdateWhereSupported() {
         return false;
     }
 
@@ -253,19 +289,29 @@ public interface Dialect extends SqlTypeStrategy {
     interface UpdateContext {
 
         boolean isIdInteger();
+
         boolean isUpdatedByKey();
+
         boolean hasUpdatedColumns();
+
         boolean isFakeUpdateRequired();
 
         UpdateContext sql(String sql);
+
         UpdateContext sql(ValueGetter getter);
+
         UpdateContext enter(AbstractSqlBuilder.ScopeType type);
+
         UpdateContext separator();
+
         UpdateContext leave();
 
         UpdateContext appendTableName();
+
         UpdateContext appendAssignments();
+
         UpdateContext appendPredicates();
+
         UpdateContext appendId();
     }
 
@@ -325,44 +371,68 @@ public interface Dialect extends SqlTypeStrategy {
     interface UpsertContext {
 
         boolean hasUpdatedColumns();
+
         boolean hasUpdateCondition();
+
         boolean hasGeneratedId();
+
         boolean isFakeUpdateRequired();
+
         boolean isUpdateIgnored();
+
         boolean isComplete();
+
         boolean isIdInteger();
+
         boolean hasConflictPredicate();
+
         default boolean isCurrentRowReturningRequired() {
             return false;
         }
+
         List<ValueGetter> getConflictGetters();
 
         UpsertContext sql(String sql);
+
         UpsertContext sql(ValueGetter getter);
+
         UpsertContext enter(AbstractSqlBuilder.ScopeType type);
+
         UpsertContext separator();
+
         UpsertContext leave();
 
         UpsertContext appendTableName();
+
         UpsertContext appendInsertedColumns(String prefix);
+
         UpsertContext appendConflictColumns();
+
         UpsertContext appendConflictPredicate(String alias);
+
         UpsertContext appendInsertingValues();
+
         default UpsertContext appendInsertingRows() {
             return enter(AbstractSqlBuilder.ScopeType.TUPLE)
                     .appendInsertingValues()
                     .leave();
         }
+
         UpsertContext appendUpdatingAssignments(
                 String targetPrefix,
                 String targetSuffix,
                 String sourcePrefix,
                 String sourceSuffix
         );
+
         UpsertContext appendFakeUpdateAssignment(String targetPrefix, String targetSuffix);
+
         UpsertContext appendConditionalUpdatingAssignments(String sourcePrefix, String sourceSuffix, String valuePrefix, String valueSuffix);
+
         UpsertContext appendUpdateCondition(String targetPrefix, String targetSuffix, String sourcePrefix, String sourceSuffix);
+
         UpsertContext appendGeneratedId();
+
         default UpsertContext appendReturning(String prefix) {
             throw new UnsupportedOperationException(
                     "The upsert-returning statement is not supported by \"" +
@@ -370,6 +440,7 @@ public interface Dialect extends SqlTypeStrategy {
                             "\""
             );
         }
+
         UpsertContext appendId();
     }
 
@@ -420,10 +491,10 @@ public interface Dialect extends SqlTypeStrategy {
             );
         }
         builder.sql("position(")
-                    .ast(expressionAst, currentPrecedence)
-                    .sql(" in ")
-                    .ast(subStrAst, currentPrecedence)
-                    .sql(")");
+                .ast(expressionAst, currentPrecedence)
+                .sql(" in ")
+                .ast(subStrAst, currentPrecedence)
+                .sql(")");
     }
 
     default void renderLeft(

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/H2Dialect.java
@@ -37,6 +37,16 @@ public class H2Dialect extends DefaultDialect {
     }
 
     @Override
+    public boolean isRootlessSelectionCastRequired() {
+        return true;
+    }
+
+    @Override
+    public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+        return InsertFromSelectRenderers.H2;
+    }
+
+    @Override
     public String arrayTypeSuffix() {
         return " array";
     }
@@ -133,6 +143,11 @@ public class H2Dialect extends DefaultDialect {
 
     @Override
     public boolean isUpsertSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isUpsertWithUpdateWhereSupported() {
         return true;
     }
 
@@ -267,7 +282,7 @@ public class H2Dialect extends DefaultDialect {
             }
             ctx.sql(" then update").enter(AbstractSqlBuilder.ScopeType.SET);
             if (ctx.hasUpdatedColumns()) {
-            ctx.appendUpdatingAssignments("tb_1_.", "", "tb_2_.", "");
+                ctx.appendUpdatingAssignments("tb_1_.", "", "tb_2_.", "");
             } else {
                 ctx.appendFakeUpdateAssignment("tb_1_.", "");
             }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectContext.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectContext.java
@@ -1,0 +1,109 @@
+package org.babyfish.jimmer.sql.dialect;
+
+import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Semantic rendering context for a native insert/upsert-from-select statement.
+ *
+ * <p>The dialect owns the SQL grammar. This context owns mutation metadata and
+ * AST rendering, so dialect implementations do not depend on mutation internals.</p>
+ */
+public interface InsertFromSelectContext {
+
+    InsertFromSelectMode getMode();
+
+    boolean hasReturning();
+
+    boolean hasUpdateAssignments();
+
+    boolean hasUpdatePredicates();
+
+    /**
+     * Whether key-based conflict detection is restricted to active rows by a
+     * logical-delete predicate.
+     */
+    boolean hasConflictPredicate();
+
+    /**
+     * Whether every source expression used by the update branch can be
+     * represented by the corresponding inserted column.
+     */
+    boolean isUpdateExpressionAliasingSupported();
+
+    /**
+     * Whether the update branch consists only of direct assignments from the
+     * inserted values and has no update predicate.
+     */
+    boolean isSimpleInsertedValueUpdate();
+
+    /**
+     * Whether reacting to any unique-constraint conflict is equivalent to
+     * reacting to the explicitly selected conflict target.
+     */
+    boolean isConflictTargetUnambiguous();
+
+    /**
+     * Whether the selected conflict target is safe for native conflict
+     * detection when one or more of its properties are nullable.
+     *
+     * <p>This is always {@code true} for a non-null conflict target. For a
+     * nullable key it is true only when the model declares nulls to be not
+     * distinct and the current dialect supports that conflict semantics.</p>
+     */
+    boolean isNullableConflictTargetSupported();
+
+    InsertFromSelectContext sql(String sql);
+
+    InsertFromSelectContext enter(AbstractSqlBuilder.ScopeType type);
+
+    InsertFromSelectContext separator();
+
+    InsertFromSelectContext leave();
+
+    InsertFromSelectContext appendTableName();
+
+    InsertFromSelectContext appendTargetAlias();
+
+    InsertFromSelectContext appendInsertColumns();
+
+    InsertFromSelectContext appendConflictColumns();
+
+    /**
+     * Append the active-row predicate for a conditional logical-delete key.
+     * When {@code targetAlias} is true, the target-table alias is rendered for
+     * merge-style SQL; it is omitted in an {@code ON CONFLICT} target predicate.
+     */
+    InsertFromSelectContext appendConflictPredicate(boolean targetAlias);
+
+    InsertFromSelectContext appendSourceSelect();
+
+    InsertFromSelectContext appendSourceTable();
+
+    InsertFromSelectContext appendConflictCondition();
+
+    InsertFromSelectContext appendInsertValues();
+
+    /**
+     * Append update assignments. When {@code insertedValuePrefix} is non-null,
+     * source expressions are replaced by the corresponding inserted column,
+     * wrapped by the supplied prefix and suffix.
+     */
+    InsertFromSelectContext appendUpdateAssignments(
+            boolean targetAlias,
+            @Nullable String insertedValuePrefix,
+            @Nullable String insertedValueSuffix
+    );
+
+    InsertFromSelectContext appendFakeUpdateAssignment(
+            boolean leftTargetAlias,
+            boolean rightTargetAlias
+    );
+
+    InsertFromSelectContext appendUpdatePredicates(
+            @Nullable String insertedValuePrefix,
+            @Nullable String insertedValueSuffix
+    );
+
+    InsertFromSelectContext appendReturning();
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectMode.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectMode.java
@@ -1,0 +1,7 @@
+package org.babyfish.jimmer.sql.dialect;
+
+public enum InsertFromSelectMode {
+    INSERT,
+    INSERT_IF_ABSENT,
+    UPSERT
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRenderer.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRenderer.java
@@ -1,0 +1,22 @@
+package org.babyfish.jimmer.sql.dialect;
+
+/**
+ * Renders a native insert/upsert-from-select statement for a dialect.
+ */
+public interface InsertFromSelectRenderer {
+
+    /**
+     * Whether this renderer can preserve all semantics described by {@code ctx}.
+     */
+    boolean isSupported(InsertFromSelectContext ctx);
+
+    /**
+     * Whether the native statement exposes enough change images for precise
+     * transaction-trigger events.
+     */
+    default boolean isTransactionTriggerSupported(InsertFromSelectContext ctx) {
+        return false;
+    }
+
+    void render(InsertFromSelectContext ctx);
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRenderers.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRenderers.java
@@ -1,0 +1,233 @@
+package org.babyfish.jimmer.sql.dialect;
+
+import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
+
+final class InsertFromSelectRenderers {
+
+    static final InsertFromSelectRenderer DEFAULT = new DefaultRenderer();
+
+    static final InsertFromSelectRenderer H2 = new H2Renderer();
+
+    static final InsertFromSelectRenderer POSTGRES = new ConflictClauseRenderer(true, false);
+
+    static final InsertFromSelectRenderer SQLITE = new ConflictClauseRenderer(false, true);
+
+    static final InsertFromSelectRenderer MYSQL = new MySqlRenderer();
+
+    private InsertFromSelectRenderers() {
+    }
+
+    private static void renderInsertHead(InsertFromSelectContext ctx, boolean aliasTarget) {
+        ctx.sql("insert into ").appendTableName();
+        if (aliasTarget) {
+            ctx.sql(" as ").appendTargetAlias();
+        }
+        ctx.enter(AbstractSqlBuilder.ScopeType.TUPLE)
+                .appendInsertColumns()
+                .leave()
+                .sql(" ");
+    }
+
+    private static void renderStrictInsert(InsertFromSelectContext ctx) {
+        renderStrictInsert(ctx, true);
+    }
+
+    private static void renderStrictInsert(InsertFromSelectContext ctx, boolean appendReturning) {
+        renderInsertHead(ctx, false);
+        ctx.appendSourceSelect();
+        if (appendReturning && ctx.hasReturning()) {
+            ctx.sql(" returning ").appendReturning();
+        }
+    }
+
+    private static class DefaultRenderer implements InsertFromSelectRenderer {
+
+        @Override
+        public boolean isSupported(InsertFromSelectContext ctx) {
+            return ctx.getMode() == InsertFromSelectMode.INSERT && !ctx.hasReturning();
+        }
+
+        @Override
+        public void render(InsertFromSelectContext ctx) {
+            renderStrictInsert(ctx);
+        }
+    }
+
+    private static class ConflictClauseRenderer implements InsertFromSelectRenderer {
+
+        private final boolean returningSupported;
+
+        private final boolean wrapSourceWithWhere;
+
+        private ConflictClauseRenderer(boolean returningSupported, boolean wrapSourceWithWhere) {
+            this.returningSupported = returningSupported;
+            this.wrapSourceWithWhere = wrapSourceWithWhere;
+        }
+
+        @Override
+        public boolean isSupported(InsertFromSelectContext ctx) {
+            if (ctx.hasReturning() && !returningSupported) {
+                return false;
+            }
+            if (ctx.getMode() != InsertFromSelectMode.INSERT &&
+                    !ctx.isNullableConflictTargetSupported()) {
+                return false;
+            }
+            return ctx.getMode() != InsertFromSelectMode.UPSERT ||
+                    ctx.isUpdateExpressionAliasingSupported();
+        }
+
+        @Override
+        public void render(InsertFromSelectContext ctx) {
+            if (ctx.getMode() == InsertFromSelectMode.INSERT) {
+                renderStrictInsert(ctx);
+                return;
+            }
+            renderInsertHead(ctx, true);
+            if (wrapSourceWithWhere) {
+                ctx.sql("select * from ")
+                        .enter(AbstractSqlBuilder.ScopeType.SUB_QUERY)
+                        .appendSourceSelect()
+                        .leave()
+                        .sql(" where true");
+            } else {
+                ctx.appendSourceSelect();
+            }
+            ctx.sql(" on conflict")
+                    .enter(AbstractSqlBuilder.ScopeType.TUPLE)
+                    .appendConflictColumns()
+                    .leave();
+            if (ctx.hasConflictPredicate()) {
+                ctx.sql(" where ").appendConflictPredicate(false);
+            }
+            if (ctx.getMode() == InsertFromSelectMode.INSERT_IF_ABSENT) {
+                ctx.sql(" do nothing");
+            } else {
+                ctx.sql(" do update set ").enter(AbstractSqlBuilder.ScopeType.COMMA);
+                if (ctx.hasUpdateAssignments()) {
+                    ctx.appendUpdateAssignments(false, "excluded.", "");
+                } else {
+                    ctx.separator().appendFakeUpdateAssignment(false, true);
+                }
+                ctx.leave();
+                if (ctx.hasUpdatePredicates()) {
+                    ctx.sql(" where ")
+                            .enter(AbstractSqlBuilder.ScopeType.AND)
+                            .appendUpdatePredicates("excluded.", "")
+                            .leave();
+                }
+            }
+            if (ctx.hasReturning()) {
+                ctx.sql(" returning ").appendReturning();
+            }
+        }
+    }
+
+    private static class H2Renderer implements InsertFromSelectRenderer {
+
+        @Override
+        public boolean isSupported(InsertFromSelectContext ctx) {
+            return ctx.getMode() == InsertFromSelectMode.INSERT ||
+                    ctx.isNullableConflictTargetSupported();
+        }
+
+        @Override
+        public void render(InsertFromSelectContext ctx) {
+            if (ctx.hasReturning()) {
+                ctx.sql("select ").appendReturning().sql(" from final table (");
+            }
+            if (ctx.getMode() == InsertFromSelectMode.INSERT) {
+                renderStrictInsert(ctx, false);
+            } else {
+                renderMerge(ctx);
+            }
+            if (ctx.hasReturning()) {
+                ctx.sql(")");
+            }
+        }
+
+        private void renderMerge(InsertFromSelectContext ctx) {
+            ctx.sql("merge into ")
+                    .appendTableName()
+                    .sql(" ")
+                    .appendTargetAlias()
+                    .sql(" using ")
+                    .appendSourceTable()
+                    .sql(" on ")
+                    .enter(AbstractSqlBuilder.ScopeType.AND)
+                    .appendConflictCondition();
+            if (ctx.hasConflictPredicate()) {
+                ctx.separator().appendConflictPredicate(true);
+            }
+            ctx.leave();
+            if (ctx.getMode() == InsertFromSelectMode.UPSERT) {
+                ctx.sql(" when matched");
+                if (ctx.hasUpdatePredicates()) {
+                    ctx.sql(" and ")
+                            .enter(AbstractSqlBuilder.ScopeType.AND)
+                            .appendUpdatePredicates(null, null)
+                            .leave();
+                }
+                ctx.sql(" then update set ").enter(AbstractSqlBuilder.ScopeType.COMMA);
+                if (ctx.hasUpdateAssignments()) {
+                    ctx.appendUpdateAssignments(true, null, null);
+                } else {
+                    ctx.separator().appendFakeUpdateAssignment(true, true);
+                }
+                ctx.leave();
+            }
+            ctx.sql(" when not matched then insert")
+                    .enter(AbstractSqlBuilder.ScopeType.TUPLE)
+                    .appendInsertColumns()
+                    .leave()
+                    .enter(AbstractSqlBuilder.ScopeType.VALUES)
+                    .enter(AbstractSqlBuilder.ScopeType.TUPLE)
+                    .appendInsertValues()
+                    .leave()
+                    .leave();
+        }
+    }
+
+    private static class MySqlRenderer implements InsertFromSelectRenderer {
+
+        @Override
+        public boolean isSupported(InsertFromSelectContext ctx) {
+            if (ctx.hasReturning()) {
+                return false;
+            }
+            if (ctx.hasConflictPredicate()) {
+                return false;
+            }
+            switch (ctx.getMode()) {
+                case INSERT:
+                    return true;
+                case INSERT_IF_ABSENT:
+                    return false;
+                case UPSERT:
+                    return ctx.isNullableConflictTargetSupported() &&
+                            ctx.isSimpleInsertedValueUpdate() &&
+                            ctx.isConflictTargetUnambiguous();
+                default:
+                    return false;
+            }
+        }
+
+        @Override
+        public void render(InsertFromSelectContext ctx) {
+            if (ctx.getMode() == InsertFromSelectMode.INSERT) {
+                renderStrictInsert(ctx);
+                return;
+            }
+            renderInsertHead(ctx, false);
+            ctx.appendSourceSelect()
+                    .sql(" on duplicate key update ")
+                    .enter(AbstractSqlBuilder.ScopeType.COMMA);
+            if (ctx.hasUpdateAssignments()) {
+                ctx.appendUpdateAssignments(false, "values(", ")");
+            } else {
+                ctx.separator().appendFakeUpdateAssignment(false, false);
+            }
+            ctx.leave();
+        }
+    }
+}

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlStyleDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/MySqlStyleDialect.java
@@ -15,6 +15,11 @@ import java.util.UUID;
 
 public abstract class MySqlStyleDialect extends DefaultDialect {
 
+    @Override
+    public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+        return InsertFromSelectRenderers.MYSQL;
+    }
+
     public void paginate(PaginationContext ctx) {
         ctx.origin().space().sql("limit ").variable(ctx.getOffset()).sql(", ").variable(ctx.getLimit());
     }

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/PostgresDialect.java
@@ -18,6 +18,11 @@ import java.util.function.IntSupplier;
 
 public class PostgresDialect extends DefaultDialect {
 
+    @Override
+    public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+        return InsertFromSelectRenderers.POSTGRES;
+    }
+
     private static final Reader<PGobject> PG_OBJECT_READER = new Reader<PGobject>() {
         @Override
         public PGobject read(ResultSet rs, Context ctx) throws SQLException {
@@ -190,6 +195,11 @@ public class PostgresDialect extends DefaultDialect {
     }
 
     @Override
+    public boolean isUpsertWithUpdateWhereSupported() {
+        return true;
+    }
+
+    @Override
     public boolean isUpsertWithNullableKeySupported() {
         return true;
     }
@@ -327,6 +337,9 @@ public class PostgresDialect extends DefaultDialect {
             }
         } else if (ctx.hasGeneratedId() || ctx.isFakeUpdateRequired()) {
             ctx.sql(" do update set ").appendFakeUpdateAssignment("tb_1_.", "");
+            if (ctx.hasUpdateCondition()) {
+                ctx.sql(" where ").appendUpdateCondition("tb_1_.", "", "excluded.", "");
+            }
             if (ctx.isCurrentRowReturningRequired()) {
                 ctx.sql(" returning ").appendReturning("");
             } else if (ctx.hasGeneratedId()) {

--- a/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
+++ b/project/jimmer-sql/src/main/java/org/babyfish/jimmer/sql/dialect/SQLiteDialect.java
@@ -14,6 +14,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class SQLiteDialect extends DefaultDialect {
+
+    @Override
+    public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+        return InsertFromSelectRenderers.SQLITE;
+    }
+
     @Override
     public boolean isDeleteNeedsAsKeyword() {
         return true;
@@ -31,6 +37,11 @@ public class SQLiteDialect extends DefaultDialect {
 
     @Override
     public boolean isUpsertSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isUpsertWithUpdateWhereSupported() {
         return true;
     }
 
@@ -69,6 +80,9 @@ public class SQLiteDialect extends DefaultDialect {
             }
         } else if (ctx.hasGeneratedId() || ctx.isFakeUpdateRequired()) {
             ctx.sql(" do update set ").appendFakeUpdateAssignment("", "");
+            if (ctx.hasUpdateCondition()) {
+                ctx.sql(" where ").appendUpdateCondition("", "", "excluded.", "");
+            }
         } else {
             ctx.sql(" do nothing");
         }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/OperatorTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/OperatorTest.java
@@ -96,7 +96,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setPrice(new BigDecimal("49.9"));
         });
         execute(
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Book.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, BOOK_KEY_MATCHER);
@@ -141,7 +141,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setName("Wheel");
         });
         execute(
-                new Department[] {department1, department2},
+                new Department[]{department1, department2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Department.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, DEPARTMENT_KEY_MATCHER);
@@ -176,14 +176,14 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setName("MotoBike");
         });
         execute(
-                new TreeNode[] { treeNode1, treeNode2 },
+                new TreeNode[]{treeNode1, treeNode2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, TreeNode.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, TREE_NODE_KEY_MATCHER);
                     for (DraftSpi draft : drafts) {
                         shapedEntityMap.add(draft);
                     }
-                   operator.insert(shapedEntityMap.iterator().next());
+                    operator.insert(shapedEntityMap.iterator().next());
                     Assertions.assertEquals(100L, drafts.get(0).__get(DepartmentProps.ID.unwrap().getId()));
                     Assertions.assertEquals(101L, drafts.get(1).__get(DepartmentProps.ID.unwrap().getId()));
                     return operator.ctx.affectedRowCountMap;
@@ -219,7 +219,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setModifiedTime(time);
         });
         execute(
-                new Administrator[] { administrator1, administrator2 },
+                new Administrator[]{administrator1, administrator2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Administrator.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, ADMINISTRATOR_KEY_MATCHER);
@@ -274,7 +274,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setEdition(5);
         });
         execute(
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Book.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, BOOK_KEY_MATCHER);
@@ -314,7 +314,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setVersion(0);
         });
         execute(
-                new BookStore[] { store1, store2 },
+                new BookStore[]{store1, store2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, BookStore.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, BOOK_STORE_KEY_MATCHER);
@@ -356,7 +356,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setVersion(1);
         });
         execute(
-                new BookStore[] { store1, store2 },
+                new BookStore[]{store1, store2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, BookStore.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, BOOK_STORE_KEY_MATCHER);
@@ -392,7 +392,7 @@ public class OperatorTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testByUserOptimisticLock() {
+    public void testByOptimisticLockCondition() {
         BookStore store1 = BookStoreDraft.$.produce(draft -> {
             draft.setId(oreillyId);
             draft.setWebsite("https://www.oreilly.com");
@@ -404,10 +404,10 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setVersion(0);
         });
         execute(
-                new BookStore[] { store1, store2 },
+                new BookStore[]{store1, store2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, BookStore.class, options -> {
-        options.userOptimisticLock = (BookStoreTable table, ValueExpressionFactory<BookStore> f) -> {
+                        options.optimisticLockCondition = (BookStoreTable table, ValueExpressionFactory<BookStore> f) -> {
                             return Predicate.sql(
                                     "coalesce(length(%e), 0) <= length(%e)",
                                     new Expression<?>[]{
@@ -447,7 +447,7 @@ public class OperatorTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testByUserOptimisticLockFailed() {
+    public void testByOptimisticLockConditionFailed() {
         BookStore store1 = BookStoreDraft.$.produce(draft -> {
             draft.setId(oreillyId);
             draft.setWebsite("https://www.oreilly.com");
@@ -459,10 +459,10 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setVersion(1);
         });
         execute(
-                new BookStore[] { store1, store2 },
+                new BookStore[]{store1, store2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, BookStore.class, options -> {
-        options.userOptimisticLock = (BookStoreTable table, ValueExpressionFactory<BookStore> f) -> {
+                        options.optimisticLockCondition = (BookStoreTable table, ValueExpressionFactory<BookStore> f) -> {
                             return Predicate.sql(
                                     "coalesce(length(%e), 0) <= length(%e)",
                                     new Expression<?>[]{
@@ -521,7 +521,7 @@ public class OperatorTest extends AbstractMutationTest {
             draft.setPrice(new BigDecimal("49.9"));
         });
         execute(
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Book.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, BOOK_KEY_MATCHER);
@@ -576,7 +576,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.MYSQL_DATA_SOURCE,
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(
                             getSqlClient(it -> {
@@ -657,7 +657,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.MYSQL_BATCH_DATA_SOURCE,
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(
                             getSqlClient(it -> {
@@ -734,7 +734,7 @@ public class OperatorTest extends AbstractMutationTest {
             });
         });
         execute(
-                new Machine[] { machine1, machine2 },
+                new Machine[]{machine1, machine2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(), con, Machine.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, MACHINE_KEY_MATCHER);
@@ -829,7 +829,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.MYSQL_DATA_SOURCE,
-                new Machine[] { machine1, machine2 },
+                new Machine[]{machine1, machine2},
                 (con, drafts) -> {
                     Operator operator = operator(
                             getSqlClient(it -> {
@@ -948,7 +948,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.MYSQL_BATCH_DATA_SOURCE,
-                new Machine[] { machine1, machine2 },
+                new Machine[]{machine1, machine2},
                 (con, drafts) -> {
                     Operator operator = operator(
                             getSqlClient(it -> {
@@ -1042,7 +1042,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.POSTGRES_DATA_SOURCE,
-                new Book[] { book1, book2 },
+                new Book[]{book1, book2},
                 (con, drafts) -> {
                     Operator operator = operator(
                             getSqlClient(it -> {
@@ -1121,7 +1121,7 @@ public class OperatorTest extends AbstractMutationTest {
         });
         execute(
                 NativeDatabases.POSTGRES_DATA_SOURCE,
-                new Machine[] { machine1, machine2 },
+                new Machine[]{machine1, machine2},
                 (con, drafts) -> {
                     Operator operator = operator(getSqlClient(it -> it.setDialect(new PostgresDialect())), con, Machine.class);
                     ShapedEntityMap<DraftSpi> shapedEntityMap = shapedEntityMap(operator, MACHINE_KEY_MATCHER);

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveOptionsImpl.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/mutation/SaveOptionsImpl.java
@@ -1,12 +1,11 @@
 package org.babyfish.jimmer.sql.ast.impl.mutation;
 
-import org.babyfish.jimmer.sql.ast.TypeMatchMode;
-
 import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.meta.ImmutableType;
 import org.babyfish.jimmer.meta.KeyMatcher;
 import org.babyfish.jimmer.sql.DissociateAction;
 import org.babyfish.jimmer.sql.TargetTransferMode;
+import org.babyfish.jimmer.sql.ast.TypeMatchMode;
 import org.babyfish.jimmer.sql.ast.mutation.*;
 import org.babyfish.jimmer.sql.event.TriggerType;
 import org.babyfish.jimmer.sql.event.Triggers;
@@ -24,7 +23,7 @@ public class SaveOptionsImpl implements SaveOptions {
 
     AssociatedSaveMode associatedMode = AssociatedSaveMode.REPLACE;
 
-    UserOptimisticLock<?, ?> userOptimisticLock;
+    UpdateCondition<?, ?> optimisticLockCondition;
 
     public SaveOptionsImpl(JSqlClientImplementor sqlClient) {
         this.sqlClient = sqlClient;
@@ -119,8 +118,8 @@ public class SaveOptionsImpl implements SaveOptions {
     }
 
     @Override
-    public UserOptimisticLock<?, ?> getUserOptimisticLock(ImmutableType type) {
-        return userOptimisticLock;
+    public UpdateCondition<?, ?> getOptimisticLockCondition(ImmutableType type) {
+        return optimisticLockCondition;
     }
 
     @Override

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/query/MutationQueryAnalyzerTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/ast/impl/query/MutationQueryAnalyzerTest.java
@@ -1,0 +1,77 @@
+package org.babyfish.jimmer.sql.ast.impl.query;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.impl.AstContext;
+import org.babyfish.jimmer.sql.ast.query.ConfigurableBaseQuery;
+import org.babyfish.jimmer.sql.ast.query.TypedBaseQuery;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.filter.Filter;
+import org.babyfish.jimmer.sql.filter.FilterArgs;
+import org.babyfish.jimmer.sql.model.BookProps;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.babyfish.jimmer.sql.tuple.BookUpdateReturningTupleMapper;
+import org.babyfish.jimmer.sql.tuple.BookUpdateReturningTupleTable;
+import org.junit.jupiter.api.Test;
+
+import static org.babyfish.jimmer.sql.common.Constants.graphQLInActionId1;
+import static org.babyfish.jimmer.sql.common.Constants.learningGraphQLId1;
+
+public class MutationQueryAnalyzerTest extends AbstractMutationTest {
+
+    @Test
+    public void testGlobalFiltersAreAppliedToUnfrozenUnionBranches() {
+        JSqlClient sqlClient = getSqlClient(it -> it.addFilters(new Filter<BookProps>() {
+            @Override
+            public void filter(FilterArgs<BookProps> args) {
+                args.where(args.getTable().name().ne("GraphQL in Action"));
+            }
+        }));
+        BookTable book = BookTable.$;
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> firstQuery = sqlClient
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .where(book.name().ne("GraphQL in Action"))
+                .select(BookUpdateReturningTupleMapper.id(book.id()).name(book.name()));
+        ConfigurableBaseQueryImpl<?> first = (ConfigurableBaseQueryImpl<?>) firstQuery;
+        first.getMutableQuery().freeze(new AstContext((JSqlClientImplementor) sqlClient));
+
+        BookUpdateReturningTupleTable source = TypedBaseQuery.unionAll(
+                firstQuery,
+                sqlClient
+                        .createBaseQuery(book)
+                        .where(book.id().eq(graphQLInActionId1))
+                        .select(BookUpdateReturningTupleMapper.id(book.id()).name(book.name()))
+        ).asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        executeAndExpectRowCount(
+                sqlClient
+                        .createInsert(store, source)
+                        .set(store.id(), source.getId())
+                        .set(store.name(), source.getName()),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                                        "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                        "select tb_1_.ID c1, tb_1_.NAME c2 from BOOK tb_1_ " +
+                                        "where tb_1_.ID = ? and tb_1_.NAME <> ? " +
+                                        "union all " +
+                                        "select tb_2_.ID c1, tb_2_.NAME c2 from BOOK tb_2_ " +
+                                        "where tb_2_.ID = ? and tb_2_.NAME <> ?" +
+                                        ") tb_1_"
+                        );
+                        it.variables(
+                                0,
+                                learningGraphQLId1,
+                                "GraphQL in Action",
+                                graphQLInActionId1,
+                                "GraphQL in Action"
+                        );
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/BaseQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/BaseQueryTest.java
@@ -1,10 +1,5 @@
 package org.babyfish.jimmer.sql.base;
 
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
 import org.babyfish.jimmer.sql.ast.*;
 import org.babyfish.jimmer.sql.ast.query.BaseTableProjection;
 import org.babyfish.jimmer.sql.ast.query.TypedBaseQuery;
@@ -23,11 +18,38 @@ import org.babyfish.jimmer.sql.model.embedded.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
 public class BaseQueryTest extends AbstractQueryTest {
 
     private static final BaseTableFactory<StoreStatisticsTable, StoreStatisticsTable>
             STORE_STATISTICS_FACTORY =
             BaseTableFactory.of(StoreStatisticsTable::new);
+
+    @Test
+    public void testRootlessBaseQuery() {
+        BaseTable2<NumericExpression<Integer>, StringExpression> baseTable = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(1))
+                .addSelect(Expression.value("rootless"))
+                .asBaseTable();
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(baseTable)
+                        .select(baseTable.get_1(), baseTable.get_2()),
+                ctx -> {
+                    ctx.sql(
+                            "select tb_1_.c1, tb_1_.c2 from (" +
+                                    "select cast(? as int) as c1, cast(? as varchar) as c2" +
+                                    ") tb_1_"
+                    );
+                    ctx.rows("[{\"_1\":1,\"_2\":\"rootless\"}]");
+                }
+        );
+    }
 
     @Test
     public void testNamedBaseTable() {

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/CteBaseQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/base/CteBaseQueryTest.java
@@ -20,6 +20,28 @@ import java.math.BigDecimal;
 public class CteBaseQueryTest extends AbstractQueryTest {
 
     @Test
+    public void testRootlessCteBaseQuery() {
+        BaseTable2<NumericExpression<Integer>, StringExpression> baseTable = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(1))
+                .addSelect(Expression.value("rootless"))
+                .asCteBaseTable();
+        executeAndExpect(
+                getSqlClient()
+                        .createQuery(baseTable)
+                        .select(baseTable.get_1(), baseTable.get_2()),
+                ctx -> {
+                    ctx.sql(
+                            "with tb_1_(c1, c2) as (" +
+                                    "select cast(? as int), cast(? as varchar)" +
+                                    ") select tb_1_.c1, tb_1_.c2 from tb_1_"
+                    );
+                    ctx.rows("[{\"_1\":1,\"_2\":\"rootless\"}]");
+                }
+        );
+    }
+
+    @Test
     public void testBaseQueryWithFetch() {
         BookStoreTable store = BookStoreTable.$;
         BookTable book = BookTable.$;
@@ -127,10 +149,10 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3, c4, c5, c6) as (select tb_2_.ID, tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, " +
-                            "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_5_ on tb_3_.ID = " +
-                            "tb_5_.AUTHOR_ID where tb_5_.BOOK_ID = tb_2_.ID) from BOOK tb_2_) select tb_1_.c1, tb_1_.c2, tb_1_.c3, " +
-                            "tb_1_.c4, tb_4_.ID, tb_4_.NAME, tb_4_.WEBSITE, tb_4_.VERSION from tb_1_ left join BOOK_STORE tb_4_ on tb_1_.c5 " +
-                            "= tb_4_.ID where tb_1_.c6 > ?"
+                                    "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_5_ on tb_3_.ID = " +
+                                    "tb_5_.AUTHOR_ID where tb_5_.BOOK_ID = tb_2_.ID) from BOOK tb_2_) select tb_1_.c1, tb_1_.c2, tb_1_.c3, " +
+                                    "tb_1_.c4, tb_4_.ID, tb_4_.NAME, tb_4_.WEBSITE, tb_4_.VERSION from tb_1_ left join BOOK_STORE tb_4_ on tb_1_.c5 " +
+                                    "= tb_4_.ID where tb_1_.c6 > ?"
                     );
                     ctx.rows(
                             "[{" +
@@ -240,13 +262,13 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                         .createBaseQuery(store)
                         .where(store.name().eq("MANNING"))
                         .where(store.asTableEx().books().edition().eq(3))
-                        .addSelect((BookTable)store.asTableEx().books())
+                        .addSelect((BookTable) store.asTableEx().books())
                         .addSelect(
                                 getSqlClient().createSubQuery(authorEx)
                                         .where(authorEx.books().id().eq(store.asTableEx().books().id()))
                                         .select(Expression.rowCount())
                         )
-                .asCteBaseTable();
+                        .asCteBaseTable();
         executeAndExpect(
                 getSqlClient()
                         .createQuery(baseTable)
@@ -292,7 +314,7 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                         .createBaseQuery(store)
                         .where(store.name().eq("MANNING"))
                         .where(store.asTableEx().books().edition().eq(3))
-                        .addSelect((BookTable)store.asTableEx().books())
+                        .addSelect((BookTable) store.asTableEx().books())
                         .addSelect(
                                 getSqlClient().createSubQuery(authorEx)
                                         .where(authorEx.books().id().eq(store.asTableEx().books().id()))
@@ -315,11 +337,11 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3, c4, c5, c6) as (select tb_3_.ID, tb_3_.NAME, tb_3_.EDITION, tb_3_.PRICE, " +
-                            "tb_3_.STORE_ID, (select count(1) from AUTHOR tb_4_ inner join BOOK_AUTHOR_MAPPING tb_6_ on tb_4_.ID = " +
-                            "tb_6_.AUTHOR_ID where tb_6_.BOOK_ID = tb_3_.ID) from BOOK_STORE tb_2_ inner join BOOK tb_3_ on tb_2_.ID = " +
-                            "tb_3_.STORE_ID where tb_2_.NAME = ? and tb_3_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, " +
-                            "tb_5_.ID, tb_5_.NAME, tb_5_.WEBSITE, tb_5_.VERSION from tb_1_ left join BOOK_STORE tb_5_ on tb_1_.c5 = " +
-                            "tb_5_.ID where tb_1_.c6 > ?"
+                                    "tb_3_.STORE_ID, (select count(1) from AUTHOR tb_4_ inner join BOOK_AUTHOR_MAPPING tb_6_ on tb_4_.ID = " +
+                                    "tb_6_.AUTHOR_ID where tb_6_.BOOK_ID = tb_3_.ID) from BOOK_STORE tb_2_ inner join BOOK tb_3_ on tb_2_.ID = " +
+                                    "tb_3_.STORE_ID where tb_2_.NAME = ? and tb_3_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, " +
+                                    "tb_5_.ID, tb_5_.NAME, tb_5_.WEBSITE, tb_5_.VERSION from tb_1_ left join BOOK_STORE tb_5_ on tb_1_.c5 = " +
+                                    "tb_5_.ID where tb_1_.c6 > ?"
                     );
                     ctx.rows(
                             "[{" +
@@ -375,12 +397,12 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3, c4, c5, c6) as (select tb_2_.ID, tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, " +
-                            "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_7_ on tb_3_.ID = " +
-                            "tb_7_.AUTHOR_ID where tb_7_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? " +
-                            "union all select tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.PRICE, tb_5_.STORE_ID, (select count(1) from " +
-                            "AUTHOR tb_6_ inner join BOOK_AUTHOR_MAPPING tb_8_ on tb_6_.ID = tb_8_.AUTHOR_ID where tb_8_.BOOK_ID = " +
-                            "tb_5_.ID) from BOOK_STORE tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID where tb_4_.NAME = ? and " +
-                            "tb_5_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_1_.c5 from tb_1_ where tb_1_.c6 > ?"
+                                    "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_7_ on tb_3_.ID = " +
+                                    "tb_7_.AUTHOR_ID where tb_7_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? " +
+                                    "union all select tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.PRICE, tb_5_.STORE_ID, (select count(1) from " +
+                                    "AUTHOR tb_6_ inner join BOOK_AUTHOR_MAPPING tb_8_ on tb_6_.ID = tb_8_.AUTHOR_ID where tb_8_.BOOK_ID = " +
+                                    "tb_5_.ID) from BOOK_STORE tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID where tb_4_.NAME = ? and " +
+                                    "tb_5_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_1_.c5 from tb_1_ where tb_1_.c6 > ?"
                     );
                     ctx.rows(
                             "[{" +
@@ -446,13 +468,13 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3, c4, c5, c6) as (select tb_2_.ID, tb_2_.NAME, tb_2_.EDITION, tb_2_.PRICE, " +
-                            "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_8_ on tb_3_.ID = " +
-                            "tb_8_.AUTHOR_ID where tb_8_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? " +
-                            "union all select tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.PRICE, tb_5_.STORE_ID, (select count(1) from " +
-                            "AUTHOR tb_6_ inner join BOOK_AUTHOR_MAPPING tb_9_ on tb_6_.ID = tb_9_.AUTHOR_ID where tb_9_.BOOK_ID = " +
-                            "tb_5_.ID) from BOOK_STORE tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID where tb_4_.NAME = ? and " +
-                            "tb_5_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_7_.ID, tb_7_.NAME, tb_7_.WEBSITE, " +
-                            "tb_7_.VERSION from tb_1_ left join BOOK_STORE tb_7_ on tb_1_.c5 = tb_7_.ID where tb_1_.c6 > ?"
+                                    "tb_2_.STORE_ID, (select count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_8_ on tb_3_.ID = " +
+                                    "tb_8_.AUTHOR_ID where tb_8_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? " +
+                                    "union all select tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.PRICE, tb_5_.STORE_ID, (select count(1) from " +
+                                    "AUTHOR tb_6_ inner join BOOK_AUTHOR_MAPPING tb_9_ on tb_6_.ID = tb_9_.AUTHOR_ID where tb_9_.BOOK_ID = " +
+                                    "tb_5_.ID) from BOOK_STORE tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID where tb_4_.NAME = ? and " +
+                                    "tb_5_.EDITION = ?) select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4, tb_7_.ID, tb_7_.NAME, tb_7_.WEBSITE, " +
+                                    "tb_7_.VERSION from tb_1_ left join BOOK_STORE tb_7_ on tb_1_.c5 = tb_7_.ID where tb_1_.c6 > ?"
                     );
                     ctx.rows(
                             "[{" +
@@ -530,14 +552,14 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3, c4, c5) as (select tb_2_.ID, tb_2_.NAME, tb_2_.EDITION, tb_2_.STORE_ID, (select " +
-                            "count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_10_ on tb_3_.ID = tb_10_.AUTHOR_ID where " +
-                            "tb_10_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? union all select " +
-                            "tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.STORE_ID, (select count(1) from AUTHOR tb_8_ inner join " +
-                            "BOOK_AUTHOR_MAPPING tb_11_ on tb_8_.ID = tb_11_.AUTHOR_ID where tb_11_.BOOK_ID = tb_5_.ID) from BOOK_STORE " +
-                            "tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID inner join BOOK_AUTHOR_MAPPING tb_6_ on tb_5_.ID = " +
-                            "tb_6_.BOOK_ID inner join AUTHOR tb_7_ on tb_6_.AUTHOR_ID = tb_7_.ID where tb_4_.NAME = ? and tb_5_.EDITION = ? " +
-                            "and tb_7_.GENDER = ?) select tb_1_.c1, tb_1_.c2, tb_9_.ID, tb_9_.NAME from tb_1_ left join BOOK_STORE tb_9_ on " +
-                            "tb_1_.c4 = tb_9_.ID where tb_1_.c5 > ? and (tb_1_.c3 between ? and ?)"
+                                    "count(1) from AUTHOR tb_3_ inner join BOOK_AUTHOR_MAPPING tb_10_ on tb_3_.ID = tb_10_.AUTHOR_ID where " +
+                                    "tb_10_.BOOK_ID = tb_2_.ID) from BOOK tb_2_ where tb_2_.NAME = ? and tb_2_.EDITION = ? union all select " +
+                                    "tb_5_.ID, tb_5_.NAME, tb_5_.EDITION, tb_5_.STORE_ID, (select count(1) from AUTHOR tb_8_ inner join " +
+                                    "BOOK_AUTHOR_MAPPING tb_11_ on tb_8_.ID = tb_11_.AUTHOR_ID where tb_11_.BOOK_ID = tb_5_.ID) from BOOK_STORE " +
+                                    "tb_4_ inner join BOOK tb_5_ on tb_4_.ID = tb_5_.STORE_ID inner join BOOK_AUTHOR_MAPPING tb_6_ on tb_5_.ID = " +
+                                    "tb_6_.BOOK_ID inner join AUTHOR tb_7_ on tb_6_.AUTHOR_ID = tb_7_.ID where tb_4_.NAME = ? and tb_5_.EDITION = ? " +
+                                    "and tb_7_.GENDER = ?) select tb_1_.c1, tb_1_.c2, tb_9_.ID, tb_9_.NAME from tb_1_ left join BOOK_STORE tb_9_ on " +
+                                    "tb_1_.c4 = tb_9_.ID where tb_1_.c5 > ? and (tb_1_.c3 between ? and ?)"
                     );
                     ctx.rows(
                             "[{" +
@@ -1032,10 +1054,10 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3) as (select tb_3_.PRICE, tb_3_.ID, tb_3_.NAME from BOOK tb_3_ where tb_3_.ID = ?), " +
-                            "tb_2_(c4, c5, c6) as (select tb_4_.GENDER, tb_4_.ID, concat(tb_4_.FIRST_NAME, ' ', tb_4_.LAST_NAME) from " +
-                            "AUTHOR tb_4_ where tb_4_.ID = ?) select tb_1_.c2, tb_1_.c3, tb_2_.c5, tb_2_.c6 from tb_1_ inner join " +
-                            "BOOK_AUTHOR_MAPPING tb_5_ on tb_1_.c2 = tb_5_.BOOK_ID inner join tb_2_ on tb_5_.AUTHOR_ID = tb_2_.c5 where " +
-                            "tb_1_.c1 > ? and tb_2_.c4 = ?"
+                                    "tb_2_(c4, c5, c6) as (select tb_4_.GENDER, tb_4_.ID, concat(tb_4_.FIRST_NAME, ' ', tb_4_.LAST_NAME) from " +
+                                    "AUTHOR tb_4_ where tb_4_.ID = ?) select tb_1_.c2, tb_1_.c3, tb_2_.c5, tb_2_.c6 from tb_1_ inner join " +
+                                    "BOOK_AUTHOR_MAPPING tb_5_ on tb_1_.c2 = tb_5_.BOOK_ID inner join tb_2_ on tb_5_.AUTHOR_ID = tb_2_.c5 where " +
+                                    "tb_1_.c1 > ? and tb_2_.c4 = ?"
                     );
                 }
         );
@@ -1090,12 +1112,12 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 ctx -> {
                     ctx.sql(
                             "with tb_1_(c1, c2, c3) as (select tb_3_.PRICE, tb_3_.ID, tb_3_.NAME from BOOK tb_3_ where tb_3_.ID = ? union " +
-                            "all select tb_4_.PRICE, tb_4_.ID, tb_4_.NAME from BOOK tb_4_ where tb_4_.ID = ?), tb_2_(c4, c5, c6) as (select " +
-                            "tb_5_.GENDER, tb_5_.ID, concat(tb_5_.FIRST_NAME, ' ', tb_5_.LAST_NAME) from AUTHOR tb_5_ where tb_5_.ID = ? " +
-                            "union all select tb_6_.GENDER, tb_6_.ID, concat(tb_6_.FIRST_NAME, ' ', tb_6_.LAST_NAME) from AUTHOR tb_6_ " +
-                            "where tb_6_.ID = ?) select tb_1_.c2, tb_1_.c3, tb_2_.c5, tb_2_.c6 from tb_1_ inner join BOOK_AUTHOR_MAPPING " +
-                            "tb_7_ on tb_1_.c2 = tb_7_.BOOK_ID inner join tb_2_ on tb_7_.AUTHOR_ID = tb_2_.c5 where tb_1_.c1 > ? and " +
-                            "tb_2_.c4 = ?"
+                                    "all select tb_4_.PRICE, tb_4_.ID, tb_4_.NAME from BOOK tb_4_ where tb_4_.ID = ?), tb_2_(c4, c5, c6) as (select " +
+                                    "tb_5_.GENDER, tb_5_.ID, concat(tb_5_.FIRST_NAME, ' ', tb_5_.LAST_NAME) from AUTHOR tb_5_ where tb_5_.ID = ? " +
+                                    "union all select tb_6_.GENDER, tb_6_.ID, concat(tb_6_.FIRST_NAME, ' ', tb_6_.LAST_NAME) from AUTHOR tb_6_ " +
+                                    "where tb_6_.ID = ?) select tb_1_.c2, tb_1_.c3, tb_2_.c5, tb_2_.c6 from tb_1_ inner join BOOK_AUTHOR_MAPPING " +
+                                    "tb_7_ on tb_1_.c2 = tb_7_.BOOK_ID inner join tb_2_ on tb_7_.AUTHOR_ID = tb_2_.c5 where tb_1_.c1 > ? and " +
+                                    "tb_2_.c4 = ?"
                     );
                 }
         );
@@ -1430,7 +1452,7 @@ public class CteBaseQueryTest extends AbstractQueryTest {
                 }
         );
     }
-    
+
     private static class BaseBookAuthorJoin implements WeakJoin<BaseTable1<BookTable>, BaseTable1<AuthorTable>> {
 
         @Override

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRendererTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/dialect/InsertFromSelectRendererTest.java
@@ -1,0 +1,444 @@
+package org.babyfish.jimmer.sql.dialect;
+
+import org.babyfish.jimmer.sql.ast.impl.render.AbstractSqlBuilder;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InsertFromSelectRendererTest {
+
+    @Test
+    public void testCapabilityMatrix() {
+        assertSupported(true, DefaultDialect.INSTANCE, ctx(InsertFromSelectMode.INSERT));
+        assertSupported(false, DefaultDialect.INSTANCE, ctx(InsertFromSelectMode.INSERT).returning());
+        assertSupported(false, DefaultDialect.INSTANCE, ctx(InsertFromSelectMode.INSERT_IF_ABSENT));
+        assertSupported(false, DefaultDialect.INSTANCE, ctx(InsertFromSelectMode.UPSERT));
+
+        assertSupported(true, new H2Dialect(), ctx(InsertFromSelectMode.INSERT).returning());
+        assertSupported(true, new H2Dialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT).returning());
+        assertSupported(true, new H2Dialect(), ctx(InsertFromSelectMode.UPSERT).returning());
+        assertSupported(true, new H2Dialect(), ctx(InsertFromSelectMode.UPSERT).conflictPredicate());
+
+        assertSupported(true, new PostgresDialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT).returning());
+        assertSupported(true, new PostgresDialect(), ctx(InsertFromSelectMode.UPSERT).aliasing(true));
+        assertSupported(true, new PostgresDialect(), ctx(InsertFromSelectMode.UPSERT).conflictPredicate());
+        assertSupported(false, new PostgresDialect(), ctx(InsertFromSelectMode.UPSERT).aliasing(false));
+
+        assertSupported(true, new SQLiteDialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT));
+        assertSupported(true, new SQLiteDialect(), ctx(InsertFromSelectMode.UPSERT).conflictPredicate());
+        assertSupported(false, new SQLiteDialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT).returning());
+        assertSupported(false, new SQLiteDialect(), ctx(InsertFromSelectMode.UPSERT).aliasing(false));
+
+        assertSupported(true, new MySqlDialect(), ctx(InsertFromSelectMode.INSERT));
+        assertSupported(false, new MySqlDialect(), ctx(InsertFromSelectMode.INSERT).returning());
+        assertSupported(false, new MySqlDialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT).unambiguous(true));
+        assertSupported(false, new MySqlDialect(), ctx(InsertFromSelectMode.INSERT_IF_ABSENT).unambiguous(false));
+        assertSupported(true, new MySqlDialect(), ctx(InsertFromSelectMode.UPSERT).simple(true).unambiguous(true));
+        assertSupported(
+                false,
+                new MySqlDialect(),
+                ctx(InsertFromSelectMode.UPSERT).simple(true).unambiguous(true).conflictPredicate()
+        );
+        assertSupported(false, new MySqlDialect(), ctx(InsertFromSelectMode.UPSERT).simple(false).unambiguous(true));
+        assertSupported(false, new MySqlDialect(), ctx(InsertFromSelectMode.UPSERT).simple(true).unambiguous(false));
+    }
+
+    @Test
+    public void testNullableConflictTargetCapability() {
+        assertSupported(
+                false,
+                new H2Dialect(),
+                ctx(InsertFromSelectMode.UPSERT).nullableConflictTargetSupported(false)
+        );
+        assertSupported(
+                false,
+                new PostgresDialect(),
+                ctx(InsertFromSelectMode.UPSERT).nullableConflictTargetSupported(false)
+        );
+        assertSupported(
+                false,
+                new SQLiteDialect(),
+                ctx(InsertFromSelectMode.INSERT_IF_ABSENT).nullableConflictTargetSupported(false)
+        );
+        assertSupported(
+                false,
+                new MySqlDialect(),
+                ctx(InsertFromSelectMode.UPSERT)
+                        .simple(true)
+                        .unambiguous(true)
+                        .nullableConflictTargetSupported(false)
+        );
+    }
+
+    @Test
+    public void testH2MergeRendering() {
+        RecordingContext ctx = ctx(InsertFromSelectMode.UPSERT)
+                .returning()
+                .updateAssignments()
+                .updatePredicates();
+        new H2Dialect().getInsertFromSelectRenderer().render(ctx);
+        assertEquals(
+                "select [returning] from final table (" +
+                        "merge into [table] [target] using [source-table] on " +
+                        "<and>[conflict-condition]</and> " +
+                        "when matched and <and>[update-predicates prefix=null,suffix=null]</and> " +
+                        "then update set <comma>[update-assignments target=true,prefix=null,suffix=null]</comma> " +
+                        "when not matched then insert([insert-columns])" +
+                        "<values>([insert-values])</values>)",
+                ctx.toString()
+        );
+    }
+
+    @Test
+    public void testH2FakeUpdateRendering() {
+        RecordingContext ctx = ctx(InsertFromSelectMode.UPSERT);
+        new H2Dialect().getInsertFromSelectRenderer().render(ctx);
+        assertEquals(
+                "merge into [table] [target] using [source-table] on " +
+                        "<and>[conflict-condition]</and> " +
+                        "when matched then update set <comma>|[fake left=true,right=true]</comma> " +
+                        "when not matched then insert([insert-columns])<values>([insert-values])</values>",
+                ctx.toString()
+        );
+    }
+
+    @Test
+    public void testConflictClauseRendering() {
+        RecordingContext postgres = ctx(InsertFromSelectMode.INSERT_IF_ABSENT).returning();
+        new PostgresDialect().getInsertFromSelectRenderer().render(postgres);
+        assertEquals(
+                "insert into [table] as [target]([insert-columns]) [source-select] " +
+                        "on conflict([conflict-columns]) do nothing returning [returning]",
+                postgres.toString()
+        );
+
+        RecordingContext sqlite = ctx(InsertFromSelectMode.UPSERT)
+                .updateAssignments()
+                .updatePredicates();
+        new SQLiteDialect().getInsertFromSelectRenderer().render(sqlite);
+        assertEquals(
+                "insert into [table] as [target]([insert-columns]) " +
+                        "select * from <SUB_QUERY>[source-select]</SUB_QUERY> where true " +
+                        "on conflict([conflict-columns]) do update set " +
+                        "<comma>[update-assignments target=false,prefix=excluded.,suffix=]</comma> " +
+                        "where <and>[update-predicates prefix=excluded.,suffix=]</and>",
+                sqlite.toString()
+        );
+    }
+
+    @Test
+    public void testLogicalDeleteConflictPredicateRendering() {
+        RecordingContext h2 = ctx(InsertFromSelectMode.UPSERT)
+                .conflictPredicate()
+                .updateAssignments();
+        new H2Dialect().getInsertFromSelectRenderer().render(h2);
+        assertEquals(
+                "merge into [table] [target] using [source-table] on " +
+                        "<and>[conflict-condition]|[conflict-predicate target=true]</and> " +
+                        "when matched then update set " +
+                        "<comma>[update-assignments target=true,prefix=null,suffix=null]</comma> " +
+                        "when not matched then insert([insert-columns])<values>([insert-values])</values>",
+                h2.toString()
+        );
+
+        RecordingContext postgres = ctx(InsertFromSelectMode.UPSERT)
+                .conflictPredicate()
+                .updateAssignments();
+        new PostgresDialect().getInsertFromSelectRenderer().render(postgres);
+        assertEquals(
+                "insert into [table] as [target]([insert-columns]) [source-select] " +
+                        "on conflict([conflict-columns]) where [conflict-predicate target=false] " +
+                        "do update set <comma>[update-assignments target=false,prefix=excluded.,suffix=]</comma>",
+                postgres.toString()
+        );
+
+        RecordingContext sqlite = ctx(InsertFromSelectMode.INSERT_IF_ABSENT)
+                .conflictPredicate();
+        new SQLiteDialect().getInsertFromSelectRenderer().render(sqlite);
+        assertEquals(
+                "insert into [table] as [target]([insert-columns]) " +
+                        "select * from <SUB_QUERY>[source-select]</SUB_QUERY> where true " +
+                        "on conflict([conflict-columns]) where [conflict-predicate target=false] do nothing",
+                sqlite.toString()
+        );
+    }
+
+    @Test
+    public void testMySqlAndDefaultRendering() {
+        RecordingContext mysql = ctx(InsertFromSelectMode.UPSERT).updateAssignments();
+        new MySqlDialect().getInsertFromSelectRenderer().render(mysql);
+        assertEquals(
+                "insert into [table]([insert-columns]) [source-select] on duplicate key update " +
+                        "<comma>[update-assignments target=false,prefix=values(,suffix=)]</comma>",
+                mysql.toString()
+        );
+
+        RecordingContext strictInsert = ctx(InsertFromSelectMode.INSERT);
+        DefaultDialect.INSTANCE.getInsertFromSelectRenderer().render(strictInsert);
+        assertEquals(
+                "insert into [table]([insert-columns]) [source-select]",
+                strictInsert.toString()
+        );
+    }
+
+    private static RecordingContext ctx(InsertFromSelectMode mode) {
+        return new RecordingContext(mode);
+    }
+
+    private static void assertSupported(
+            boolean expected,
+            Dialect dialect,
+            RecordingContext ctx
+    ) {
+        assertEquals(
+                expected,
+                dialect.getInsertFromSelectRenderer().isSupported(ctx),
+                dialect.getClass().getSimpleName() + ": " + ctx.mode
+        );
+    }
+
+    private static final class RecordingContext implements InsertFromSelectContext {
+
+        private final InsertFromSelectMode mode;
+        private final StringBuilder builder = new StringBuilder();
+        private final Deque<String> closingScopes = new ArrayDeque<>();
+        private boolean returning;
+        private boolean updateAssignments;
+        private boolean updatePredicates;
+        private boolean conflictPredicate;
+        private boolean aliasing = true;
+        private boolean simple;
+        private boolean unambiguous;
+        private boolean nullableConflictTargetSupported = true;
+
+        private RecordingContext(InsertFromSelectMode mode) {
+            this.mode = mode;
+        }
+
+        RecordingContext returning() {
+            returning = true;
+            return this;
+        }
+
+        RecordingContext updateAssignments() {
+            updateAssignments = true;
+            return this;
+        }
+
+        RecordingContext updatePredicates() {
+            updatePredicates = true;
+            return this;
+        }
+
+        RecordingContext conflictPredicate() {
+            conflictPredicate = true;
+            return this;
+        }
+
+        RecordingContext aliasing(boolean value) {
+            aliasing = value;
+            return this;
+        }
+
+        RecordingContext simple(boolean value) {
+            simple = value;
+            return this;
+        }
+
+        RecordingContext unambiguous(boolean value) {
+            unambiguous = value;
+            return this;
+        }
+
+        RecordingContext nullableConflictTargetSupported(boolean value) {
+            nullableConflictTargetSupported = value;
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectMode getMode() {
+            return mode;
+        }
+
+        @Override
+        public boolean hasReturning() {
+            return returning;
+        }
+
+        @Override
+        public boolean hasUpdateAssignments() {
+            return updateAssignments;
+        }
+
+        @Override
+        public boolean hasUpdatePredicates() {
+            return updatePredicates;
+        }
+
+        @Override
+        public boolean hasConflictPredicate() {
+            return conflictPredicate;
+        }
+
+        @Override
+        public boolean isUpdateExpressionAliasingSupported() {
+            return aliasing;
+        }
+
+        @Override
+        public boolean isSimpleInsertedValueUpdate() {
+            return simple;
+        }
+
+        @Override
+        public boolean isConflictTargetUnambiguous() {
+            return unambiguous;
+        }
+
+        @Override
+        public boolean isNullableConflictTargetSupported() {
+            return nullableConflictTargetSupported;
+        }
+
+        @Override
+        public InsertFromSelectContext sql(String sql) {
+            builder.append(sql);
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext enter(AbstractSqlBuilder.ScopeType type) {
+            switch (type) {
+                case TUPLE:
+                    builder.append('(');
+                    closingScopes.push(")");
+                    break;
+                case COMMA:
+                    builder.append("<comma>");
+                    closingScopes.push("</comma>");
+                    break;
+                case AND:
+                    builder.append("<and>");
+                    closingScopes.push("</and>");
+                    break;
+                case VALUES:
+                    builder.append("<values>");
+                    closingScopes.push("</values>");
+                    break;
+                default:
+                    builder.append('<').append(type).append('>');
+                    closingScopes.push("</" + type + ">");
+                    break;
+            }
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext separator() {
+            builder.append('|');
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext leave() {
+            builder.append(closingScopes.pop());
+            return this;
+        }
+
+        @Override
+        public InsertFromSelectContext appendTableName() {
+            return marker("table");
+        }
+
+        @Override
+        public InsertFromSelectContext appendTargetAlias() {
+            return marker("target");
+        }
+
+        @Override
+        public InsertFromSelectContext appendInsertColumns() {
+            return marker("insert-columns");
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictColumns() {
+            return marker("conflict-columns");
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictPredicate(boolean targetAlias) {
+            return marker("conflict-predicate target=" + targetAlias);
+        }
+
+        @Override
+        public InsertFromSelectContext appendSourceSelect() {
+            return marker("source-select");
+        }
+
+        @Override
+        public InsertFromSelectContext appendSourceTable() {
+            return marker("source-table");
+        }
+
+        @Override
+        public InsertFromSelectContext appendConflictCondition() {
+            return marker("conflict-condition");
+        }
+
+        @Override
+        public InsertFromSelectContext appendInsertValues() {
+            return marker("insert-values");
+        }
+
+        @Override
+        public InsertFromSelectContext appendUpdateAssignments(
+                boolean targetAlias,
+                @Nullable String insertedValuePrefix,
+                @Nullable String insertedValueSuffix
+        ) {
+            return marker(
+                    "update-assignments target=" + targetAlias +
+                            ",prefix=" + insertedValuePrefix +
+                            ",suffix=" + insertedValueSuffix
+            );
+        }
+
+        @Override
+        public InsertFromSelectContext appendFakeUpdateAssignment(
+                boolean leftTargetAlias,
+                boolean rightTargetAlias
+        ) {
+            return marker("fake left=" + leftTargetAlias + ",right=" + rightTargetAlias);
+        }
+
+        @Override
+        public InsertFromSelectContext appendUpdatePredicates(
+                @Nullable String insertedValuePrefix,
+                @Nullable String insertedValueSuffix
+        ) {
+            return marker(
+                    "update-predicates prefix=" + insertedValuePrefix +
+                            ",suffix=" + insertedValueSuffix
+            );
+        }
+
+        @Override
+        public InsertFromSelectContext appendReturning() {
+            return marker("returning");
+        }
+
+        private InsertFromSelectContext marker(String marker) {
+            builder.append('[').append(marker).append(']');
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return builder.toString();
+        }
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/BooleanLogicalDeletedKeyUpsertTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/BooleanLogicalDeletedKeyUpsertTest.java
@@ -1,22 +1,33 @@
 package org.babyfish.jimmer.sql.mutation;
 
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.NumericExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable3;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
 import org.babyfish.jimmer.sql.common.NativeDatabases;
 import org.babyfish.jimmer.sql.dialect.PostgresDialect;
 import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
 import org.babyfish.jimmer.sql.model.ld.BoolKeyFile;
 import org.babyfish.jimmer.sql.model.ld.BoolKeyFileDraft;
+import org.babyfish.jimmer.sql.model.ld.BoolKeyFileTable;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class BooleanLogicalDeletedKeyUpsertTest extends AbstractMutationTest {
 
     @Test
     public void testUpsertByH2() {
         resetIdentity(null, "BOOL_KEY_FILE");
-        List<BoolKeyFile> files = Arrays.asList(
+        List<BoolKeyFile> files = asList(
                 BoolKeyFileDraft.$.produce(draft -> {
                     draft.setPath("/active");
                     draft.setName("new-active");
@@ -54,7 +65,7 @@ public class BooleanLogicalDeletedKeyUpsertTest extends AbstractMutationTest {
     public void testUpsertByPostgres() {
         NativeDatabases.assumeNativeDatabase();
         resetIdentity(NativeDatabases.POSTGRES_DATA_SOURCE, "BOOL_KEY_FILE");
-        List<BoolKeyFile> files = Arrays.asList(
+        List<BoolKeyFile> files = asList(
                 BoolKeyFileDraft.$.produce(draft -> {
                     draft.setPath("/active");
                     draft.setName("new-active");
@@ -88,5 +99,211 @@ public class BooleanLogicalDeletedKeyUpsertTest extends AbstractMutationTest {
                     ctx.entity(it -> it.modified("{\"id\":101,\"path\":\"/deleted\",\"name\":\"new-deleted\"}"));
                 }
         );
+    }
+
+    @Test
+    public void testInsertFromSelectUpsertAgainstDeletedRowByH2() {
+        resetIdentity(null, "BOOL_KEY_FILE");
+        JSqlClient sqlClient = getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE));
+        BaseTable2<StringExpression, StringExpression> source = source(sqlClient, "/deleted", "new-deleted");
+        BoolKeyFileTable table = BoolKeyFileTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.path(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .returning(table.id(), table.path(), table.name(), table.deleted())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, PATH, NAME, DELETED from final table (" +
+                                        "merge into BOOL_KEY_FILE tb_2_ using (" +
+                                        "select cast(? as varchar) as c1, cast(? as varchar) as c2" +
+                                        ") tb_1_ on tb_2_.PATH = tb_1_.c1 and tb_2_.DELETED = false " +
+                                        "when matched then update set tb_2_.NAME = tb_1_.c2 " +
+                                        "when not matched then insert(PATH, NAME, DELETED) " +
+                                        "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                        ")"
+                        );
+                        it.variables("/deleted", "new-deleted", false);
+                    });
+                    ctx.value(rows -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(100L, rows.get(0).get_1());
+                        assertEquals("/deleted", rows.get(0).get_2());
+                        assertEquals("new-deleted", rows.get(0).get_3());
+                        assertFalse(rows.get(0).get_4());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testInsertFromSelectUpsertAgainstActiveRowByH2() {
+        resetIdentity(null, "BOOL_KEY_FILE");
+        JSqlClient sqlClient = getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE));
+        BaseTable2<StringExpression, StringExpression> source = source(sqlClient, "/active", "new-active");
+        BoolKeyFileTable table = BoolKeyFileTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.path(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .returning(table.id(), table.path(), table.name(), table.deleted())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, PATH, NAME, DELETED from final table (" +
+                                        "merge into BOOL_KEY_FILE tb_2_ using (" +
+                                        "select cast(? as varchar) as c1, cast(? as varchar) as c2" +
+                                        ") tb_1_ on tb_2_.PATH = tb_1_.c1 and tb_2_.DELETED = false " +
+                                        "when matched then update set tb_2_.NAME = tb_1_.c2 " +
+                                        "when not matched then insert(PATH, NAME, DELETED) " +
+                                        "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                        ")"
+                        );
+                        it.variables("/active", "new-active", false);
+                    });
+                    ctx.value(rows -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(1L, rows.get(0).get_1());
+                        assertEquals("/active", rows.get(0).get_2());
+                        assertEquals("new-active", rows.get(0).get_3());
+                        assertFalse(rows.get(0).get_4());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testInsertFromSelectIfAbsentAgainstDeletedRowByH2() {
+        resetIdentity(null, "BOOL_KEY_FILE");
+        JSqlClient sqlClient = getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE));
+        BaseTable2<StringExpression, StringExpression> source = source(sqlClient, "/deleted", "new-deleted");
+        BoolKeyFileTable table = BoolKeyFileTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createInsert(table, source)
+                        .set(table.path(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .onConflictDoNothing(table.path())
+                        .returning(table.id(), table.path(), table.name(), table.deleted())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, PATH, NAME, DELETED from final table (" +
+                                        "merge into BOOL_KEY_FILE tb_2_ using (" +
+                                        "select cast(? as varchar) as c1, cast(? as varchar) as c2" +
+                                        ") tb_1_ on tb_2_.PATH = tb_1_.c1 and tb_2_.DELETED = false " +
+                                        "when not matched then insert(PATH, NAME, DELETED) " +
+                                        "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                        ")"
+                        );
+                        it.variables("/deleted", "new-deleted", false);
+                    });
+                    ctx.value(rows -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(100L, rows.get(0).get_1());
+                        assertEquals("/deleted", rows.get(0).get_2());
+                        assertEquals("new-deleted", rows.get(0).get_3());
+                        assertFalse(rows.get(0).get_4());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testInsertFromSelectIdConflictIsNotRestrictedByLogicalDelete() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE));
+        BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source = sqlClient
+                .createBaseQuery()
+                .addSelect(Expression.value(1L))
+                .addSelect(Expression.value("/unused"))
+                .addSelect(Expression.value("new-active"))
+                .asBaseTable();
+        BoolKeyFileTable table = BoolKeyFileTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .insert(table.path(), source.get_2())
+                        .merge(table.name(), source.get_3())
+                        .returning(table.id())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID from final table (" +
+                                        "merge into BOOL_KEY_FILE tb_2_ using (" +
+                                        "select cast(? as bigint) as c1, " +
+                                        "cast(? as varchar) as c2, cast(? as varchar) as c3" +
+                                        ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                                        "when matched then update set tb_2_.NAME = tb_1_.c3 " +
+                                        "when not matched then insert(ID, PATH, NAME, DELETED) " +
+                                        "values(tb_1_.c1, tb_1_.c2, tb_1_.c3, ?)" +
+                                        ")"
+                        );
+                        it.variables(1L, "/unused", "new-active", false);
+                    });
+                    ctx.value(rows -> assertEquals(singletonList(1L), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertFromSelectUpsertAgainstDeletedRowByPostgres() {
+        NativeDatabases.assumeNativeDatabase();
+        resetIdentity(NativeDatabases.POSTGRES_DATA_SOURCE, "BOOL_KEY_FILE");
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new PostgresDialect());
+            it.setIdGenerator(IdentityIdGenerator.INSTANCE);
+        });
+        BaseTable2<StringExpression, StringExpression> source = source(sqlClient, "/deleted", "new-deleted");
+        BoolKeyFileTable table = BoolKeyFileTable.$;
+        connectAndExpect(
+                NativeDatabases.POSTGRES_DATA_SOURCE,
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.path(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .returning(table.id(), table.path(), table.name(), table.deleted())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into BOOL_KEY_FILE as tb_2_(PATH, NAME, DELETED) " +
+                                        "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                        "select ? as c1, ? as c2" +
+                                        ") tb_1_ " +
+                                        "on conflict(PATH) where DELETED = false " +
+                                        "do update set NAME = excluded.NAME " +
+                                        "returning ID, PATH, NAME, DELETED"
+                        );
+                        it.variables(false, "/deleted", "new-deleted");
+                    });
+                    ctx.value(rows -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(100L, rows.get(0).get_1());
+                        assertEquals("/deleted", rows.get(0).get_2());
+                        assertEquals("new-deleted", rows.get(0).get_3());
+                        assertFalse(rows.get(0).get_4());
+                    });
+                }
+        );
+    }
+
+    private BaseTable2<StringExpression, StringExpression> source(
+            JSqlClient sqlClient,
+            String path,
+            String name
+    ) {
+        return sqlClient
+                .createBaseQuery()
+                .addSelect(Expression.value(path))
+                .addSelect(Expression.value(name))
+                .asBaseTable();
     }
 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/CascadeSaveTest.java
@@ -57,7 +57,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ where tb_1_.NAME = ?"
+                                        "from BOOK_STORE tb_1_ where tb_1_.NAME = ?"
                         );
                         it.variables("TURING");
                     });
@@ -68,8 +68,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
                         );
                         it.variables("Kotlin in Action", 1);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -82,23 +82,23 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     });
                     ctx.entity(it -> {
                         it.original("{" +
-                                    "\"name\":\"Kotlin in Action\"," +
-                                    "\"edition\":1," +
-                                    "\"price\":40," +
-                                    "\"store\":{\"name\":\"TURING\",\"website\":\"http://www.turing.com\"}" +
-                                    "}");
+                                "\"name\":\"Kotlin in Action\"," +
+                                "\"edition\":1," +
+                                "\"price\":40," +
+                                "\"store\":{\"name\":\"TURING\",\"website\":\"http://www.turing.com\"}" +
+                                "}");
                         it.modified("{" +
-                                    "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
-                                    "\"name\":\"Kotlin in Action\"," +
-                                    "\"edition\":1," +
-                                    "\"price\":40," +
-                                    "\"store\":{" +
-                                    "\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
-                                    "\"name\":\"TURING\"," +
-                                    "\"website\":\"http://www.turing.com\"," +
-                                    "\"version\":0" +
-                                    "}" +
-                                    "}");
+                                "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
+                                "\"name\":\"Kotlin in Action\"," +
+                                "\"edition\":1," +
+                                "\"price\":40," +
+                                "\"store\":{" +
+                                "\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
+                                "\"name\":\"TURING\"," +
+                                "\"website\":\"http://www.turing.com\"," +
+                                "\"version\":0" +
+                                "}" +
+                                "}");
                     });
                     ctx.totalRowCount(2);
                     ctx.rowCount(AffectedTable.of(Book.class), 1);
@@ -122,8 +122,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ " +
-                                "where tb_1_.ID = ?"
+                                        "from BOOK_STORE tb_1_ " +
+                                        "where tb_1_.ID = ?"
                         );
                         it.variables(oreillyId);
                         it.queryReason(QueryReason.OPTIMISTIC_LOCK);
@@ -131,8 +131,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "update BOOK_STORE " +
-                                "set WEBSITE = ?, VERSION = VERSION + 1 " +
-                                "where ID = ? and VERSION = ?"
+                                        "set WEBSITE = ?, VERSION = VERSION + 1 " +
+                                        "where ID = ? and VERSION = ?"
                         );
                         it.variables("http://www.oreilly.com", oreillyId, 0);
                     });
@@ -143,21 +143,21 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{\"id\":\"e110c564-23cc-4811-9e81-d587a13db634\"," +
-                                "\"price\":40," +
-                                "\"store\":{" +
-                                "\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
-                                "\"website\":\"http://www.oreilly.com\"," +
-                                "\"version\":0}" +
-                                "}"
+                                        "\"price\":40," +
+                                        "\"store\":{" +
+                                        "\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
+                                        "\"website\":\"http://www.oreilly.com\"," +
+                                        "\"version\":0}" +
+                                        "}"
                         );
                         it.modified(
                                 "{\"id\":\"e110c564-23cc-4811-9e81-d587a13db634\"," +
-                                "\"price\":40," +
-                                "\"store\":{" +
-                                "\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
-                                "\"website\":\"http://www.oreilly.com\"," +
-                                "\"version\":1}" +
-                                "}"
+                                        "\"price\":40," +
+                                        "\"store\":{" +
+                                        "\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
+                                        "\"website\":\"http://www.oreilly.com\"," +
+                                        "\"version\":1}" +
+                                        "}"
                         );
                         ctx.totalRowCount(2);
                         ctx.rowCount(AffectedTable.of(Book.class), 1);
@@ -190,8 +190,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ " +
-                                "where tb_1_.NAME = ?"
+                                        "from BOOK_STORE tb_1_ " +
+                                        "where tb_1_.NAME = ?"
                         );
                         it.variables("TURING");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -203,8 +203,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION, tb_1_.STORE_ID " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
                         );
                         it.variables("SQL Cookbook", 1, "Learning SQL", 1);
                         it.queryReason(QueryReason.TARGET_NOT_TRANSFERABLE);
@@ -217,34 +217,34 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"name\":\"TURING\"," +
-                                "\"books\":[" +
-                                "{\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":50}," +
-                                "{\"name\":\"Learning SQL\",\"edition\":1,\"price\":40}" +
-                                "]" +
-                                "}"
+                                        "\"name\":\"TURING\"," +
+                                        "\"books\":[" +
+                                        "{\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":50}," +
+                                        "{\"name\":\"Learning SQL\",\"edition\":1,\"price\":40}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
-                                "\"name\":\"TURING\"," +
-                                "\"version\":0," +
-                                "\"books\":[" +
-                                "{" +
-                                "\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
-                                "\"name\":\"SQL Cookbook\"," +
-                                "\"edition\":1," +
-                                "\"price\":50," +
-                                "\"store\":{\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"}" +
-                                "},{" +
-                                "\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
-                                "\"name\":\"Learning SQL\"," +
-                                "\"edition\":1," +
-                                "\"price\":40," +
-                                "\"store\":{\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"}" +
-                                "}" +
-                                "]" +
-                                "}"
+                                        "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
+                                        "\"name\":\"TURING\"," +
+                                        "\"version\":0," +
+                                        "\"books\":[" +
+                                        "{" +
+                                        "\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
+                                        "\"name\":\"SQL Cookbook\"," +
+                                        "\"edition\":1," +
+                                        "\"price\":50," +
+                                        "\"store\":{\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"}" +
+                                        "},{" +
+                                        "\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
+                                        "\"name\":\"Learning SQL\"," +
+                                        "\"edition\":1," +
+                                        "\"price\":40," +
+                                        "\"store\":{\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"}" +
+                                        "}" +
+                                        "]" +
+                                        "}"
                         );
                     });
                     ctx.totalRowCount(3);
@@ -277,8 +277,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ " +
-                                "where tb_1_.NAME = ?"
+                                        "from BOOK_STORE tb_1_ " +
+                                        "where tb_1_.NAME = ?"
                         );
                         it.variables("O'REILLY");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -290,8 +290,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
                         );
                         it.variables("Learning GraphQL", 3, "GraphQL in Action", 3);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -311,34 +311,34 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"name\":\"O'REILLY\"," +
-                                "\"version\":0," +
-                                "\"books\":[" +
-                                "{\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":45}," +
-                                "{\"name\":\"GraphQL in Action\",\"edition\":3,\"price\":42}" +
-                                "]" +
-                                "}"
+                                        "\"name\":\"O'REILLY\"," +
+                                        "\"version\":0," +
+                                        "\"books\":[" +
+                                        "{\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":45}," +
+                                        "{\"name\":\"GraphQL in Action\",\"edition\":3,\"price\":42}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"," +
-                                "\"name\":\"O'REILLY\"," +
-                                "\"version\":1," +
-                                "\"books\":[" +
-                                "{" +
-                                "\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
-                                "\"name\":\"Learning GraphQL\"," +
-                                "\"edition\":3," +
-                                "\"price\":45," +
-                                "\"store\":{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"}" +
-                                "},{" +
-                                "\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
-                                "\"name\":\"GraphQL in Action\"," +
-                                "\"edition\":3," +
-                                "\"price\":42," +
-                                "\"store\":{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"}" +
-                                "}" +
-                                "]" +
-                                "}");
+                                        "\"name\":\"O'REILLY\"," +
+                                        "\"version\":1," +
+                                        "\"books\":[" +
+                                        "{" +
+                                        "\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
+                                        "\"name\":\"Learning GraphQL\"," +
+                                        "\"edition\":3," +
+                                        "\"price\":45," +
+                                        "\"store\":{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"}" +
+                                        "},{" +
+                                        "\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
+                                        "\"name\":\"GraphQL in Action\"," +
+                                        "\"edition\":3," +
+                                        "\"price\":42," +
+                                        "\"store\":{\"id\":\"d38c10da-6be8-4924-b9b9-5e81899612a0\"}" +
+                                        "}" +
+                                        "]" +
+                                        "}");
                     });
                     ctx.totalRowCount(11);
                     ctx.rowCount(AffectedTable.of(Book.class), 10);
@@ -363,7 +363,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ where tb_1_.NAME = ?"
+                                        "from BOOK_STORE tb_1_ where tb_1_.NAME = ?"
                         );
                         it.variables("MANNING");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -371,15 +371,15 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "update BOOK_STORE " +
-                                "set VERSION = VERSION + 1 " +
-                                "where ID = ? and VERSION = ?"
+                                        "set VERSION = VERSION + 1 " +
+                                        "where ID = ? and VERSION = ?"
                         );
                         it.variables(manningId, 0);
                     });
                     ctx.statement(it -> {
                         it.sql(
                                 "update BOOK set STORE_ID = null " +
-                                "where STORE_ID = ?"
+                                        "where STORE_ID = ?"
                         );
                         it.variables(manningId);
                     });
@@ -470,8 +470,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
                         );
                         it.variables("Kotlin in Action", 1);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -483,8 +483,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.FIRST_NAME, tb_1_.LAST_NAME " +
-                                "from AUTHOR tb_1_ " +
-                                "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) in ((?, ?), (?, ?))"
+                                        "from AUTHOR tb_1_ " +
+                                        "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) in ((?, ?), (?, ?))"
                         );
                         it.variables("Andrey", "Breslav", "Pierre-Yves", "Saumont");
                     });
@@ -503,28 +503,28 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"name\":\"Kotlin in Action\"," +
-                                "\"edition\":1," +
-                                "\"price\":49," +
-                                "\"authors\":[" +
-                                "{\"firstName\":\"Andrey\",\"lastName\":\"Breslav\",\"gender\":\"MALE\"}," +
-                                "{\"firstName\":\"Pierre-Yves\",\"lastName\":\"Saumont\",\"gender\":\"MALE\"}" +
-                                "]" +
-                                "}"
+                                        "\"name\":\"Kotlin in Action\"," +
+                                        "\"edition\":1," +
+                                        "\"price\":49," +
+                                        "\"authors\":[" +
+                                        "{\"firstName\":\"Andrey\",\"lastName\":\"Breslav\",\"gender\":\"MALE\"}," +
+                                        "{\"firstName\":\"Pierre-Yves\",\"lastName\":\"Saumont\",\"gender\":\"MALE\"}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
-                                "\"name\":\"Kotlin in Action\"," +
-                                "\"edition\":1," +
-                                "\"price\":49," +
-                                "\"authors\":[" +
-                                "{\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
-                                "\"firstName\":\"Andrey\",\"lastName\":\"Breslav\",\"gender\":\"MALE\"}," +
-                                "{\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
-                                "\"firstName\":\"Pierre-Yves\",\"lastName\":\"Saumont\",\"gender\":\"MALE\"}" +
-                                "]" +
-                                "}"
+                                        "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
+                                        "\"name\":\"Kotlin in Action\"," +
+                                        "\"edition\":1," +
+                                        "\"price\":49," +
+                                        "\"authors\":[" +
+                                        "{\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
+                                        "\"firstName\":\"Andrey\",\"lastName\":\"Breslav\",\"gender\":\"MALE\"}," +
+                                        "{\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
+                                        "\"firstName\":\"Pierre-Yves\",\"lastName\":\"Saumont\",\"gender\":\"MALE\"}" +
+                                        "]" +
+                                        "}"
                         );
                         ctx.totalRowCount(5);
                         ctx.rowCount(AffectedTable.of(Book.class), 1);
@@ -553,8 +553,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
                         );
                         it.variables("Learning GraphQL", 3);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -566,8 +566,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.FIRST_NAME, tb_1_.LAST_NAME " +
-                                "from AUTHOR tb_1_ " +
-                                "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) in ((?, ?), (?, ?))"
+                                        "from AUTHOR tb_1_ " +
+                                        "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) in ((?, ?), (?, ?))"
                         );
                         it.variables("Dan", "Vanderkam", "Boris", "Cherny");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -593,24 +593,24 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":49," +
-                                "\"authors\":[" +
-                                "{\"firstName\":\"Dan\",\"lastName\":\"Vanderkam\",\"gender\":\"FEMALE\"}," +
-                                "{\"firstName\":\"Boris\",\"lastName\":\"Cherny\",\"gender\":\"FEMALE\"}" +
-                                "]" +
-                                "}"
+                                        "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":49," +
+                                        "\"authors\":[" +
+                                        "{\"firstName\":\"Dan\",\"lastName\":\"Vanderkam\",\"gender\":\"FEMALE\"}," +
+                                        "{\"firstName\":\"Boris\",\"lastName\":\"Cherny\",\"gender\":\"FEMALE\"}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
-                                "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":49," +
-                                "\"authors\":[" +
-                                "{\"id\":\"c14665c8-c689-4ac7-b8cc-6f065b8d835d\"," +
-                                "\"firstName\":\"Dan\",\"lastName\":\"Vanderkam\",\"gender\":\"FEMALE\"}," +
-                                "{\"id\":\"718795ad-77c1-4fcf-994a-fec6a5a11f0f\"," +
-                                "\"firstName\":\"Boris\",\"lastName\":\"Cherny\",\"gender\":\"FEMALE\"}" +
-                                "]" +
-                                "}"
+                                        "\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
+                                        "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":49," +
+                                        "\"authors\":[" +
+                                        "{\"id\":\"c14665c8-c689-4ac7-b8cc-6f065b8d835d\"," +
+                                        "\"firstName\":\"Dan\",\"lastName\":\"Vanderkam\",\"gender\":\"FEMALE\"}," +
+                                        "{\"id\":\"718795ad-77c1-4fcf-994a-fec6a5a11f0f\"," +
+                                        "\"firstName\":\"Boris\",\"lastName\":\"Cherny\",\"gender\":\"FEMALE\"}" +
+                                        "]" +
+                                        "}"
                         );
                     });
                     ctx.totalRowCount(7);
@@ -634,8 +634,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
                         );
                         it.variables("Learning GraphQL", 3);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -684,8 +684,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.FIRST_NAME, tb_1_.LAST_NAME " +
-                                "from AUTHOR tb_1_ " +
-                                "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) = (?, ?)"
+                                        "from AUTHOR tb_1_ " +
+                                        "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) = (?, ?)"
                         );
                         it.variables("Jim", "Green");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -697,8 +697,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
                         );
                         it.variables("Learning SQL", 1, "SQL Cookbook", 1);
                     });
@@ -717,24 +717,24 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"firstName\":\"Jim\",\"lastName\":\"Green\",\"gender\":\"MALE\"," +
-                                "\"books\":[" +
-                                "{\"name\":\"Learning SQL\",\"edition\":1,\"price\":30}," +
-                                "{\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":40}" +
-                                "]" +
-                                "}"
+                                        "\"firstName\":\"Jim\",\"lastName\":\"Green\",\"gender\":\"MALE\"," +
+                                        "\"books\":[" +
+                                        "{\"name\":\"Learning SQL\",\"edition\":1,\"price\":30}," +
+                                        "{\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":40}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
-                                "\"firstName\":\"Jim\",\"lastName\":\"Green\",\"gender\":\"MALE\"," +
-                                "\"books\":[" +
-                                "{\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
-                                "\"name\":\"Learning SQL\",\"edition\":1,\"price\":30}," +
-                                "{\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
-                                "\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":40}" +
-                                "]" +
-                                "}"
+                                        "\"id\":\"56506a3c-801b-4f7d-a41d-e889cdc3d67d\"," +
+                                        "\"firstName\":\"Jim\",\"lastName\":\"Green\",\"gender\":\"MALE\"," +
+                                        "\"books\":[" +
+                                        "{\"id\":\"4749d255-2745-4f6b-99ae-61aa8fd463e0\"," +
+                                        "\"name\":\"Learning SQL\",\"edition\":1,\"price\":30}," +
+                                        "{\"id\":\"4f351857-6cbc-4aad-ac3a-140a20034a3b\"," +
+                                        "\"name\":\"SQL Cookbook\",\"edition\":1,\"price\":40}" +
+                                        "]" +
+                                        "}"
                         );
                         ctx.totalRowCount(5);
                         ctx.rowCount(AffectedTable.of(Book.class), 2);
@@ -763,8 +763,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.FIRST_NAME, tb_1_.LAST_NAME " +
-                                "from AUTHOR tb_1_ " +
-                                "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) = (?, ?)"
+                                        "from AUTHOR tb_1_ " +
+                                        "where (tb_1_.FIRST_NAME, tb_1_.LAST_NAME) = (?, ?)"
                         );
                         it.variables("Eve", "Procello");
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -778,8 +778,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
                         );
                         it.variables("Learning GraphQL", 3, "GraphQL in Action", 3);
                         it.queryReason(QueryReason.IDENTITY_GENERATOR_REQUIRED);
@@ -807,28 +807,28 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "\"firstName\":\"Eve\",\"lastName\":\"Procello\",\"gender\":\"FEMALE\"," +
-                                "\"books\":[" +
-                                "{\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":35}," +
-                                "{\"name\":\"GraphQL in Action\",\"edition\":3,\"price\":28}" +
-                                "]" +
-                                "}"
+                                        "\"firstName\":\"Eve\",\"lastName\":\"Procello\",\"gender\":\"FEMALE\"," +
+                                        "\"books\":[" +
+                                        "{\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":35}," +
+                                        "{\"name\":\"GraphQL in Action\",\"edition\":3,\"price\":28}" +
+                                        "]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "\"id\":\"fd6bb6cf-336d-416c-8005-1ae11a6694b5\"," +
-                                "\"firstName\":\"Eve\",\"lastName\":\"Procello\",\"gender\":\"FEMALE\"," +
-                                "\"books\":[" +
-                                "{\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
-                                "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":35" +
-                                "},{" +
-                                "\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
-                                "\"name\":\"GraphQL in Action\"," +
-                                "\"edition\":3," +
-                                "\"price\":28" +
-                                "}" +
-                                "]" +
-                                "}"
+                                        "\"id\":\"fd6bb6cf-336d-416c-8005-1ae11a6694b5\"," +
+                                        "\"firstName\":\"Eve\",\"lastName\":\"Procello\",\"gender\":\"FEMALE\"," +
+                                        "\"books\":[" +
+                                        "{\"id\":\"64873631-5d82-4bae-8eb8-72dd955bfc56\"," +
+                                        "\"name\":\"Learning GraphQL\",\"edition\":3,\"price\":35" +
+                                        "},{" +
+                                        "\"id\":\"780bdf07-05af-48bf-9be9-f8c65236fecc\"," +
+                                        "\"name\":\"GraphQL in Action\"," +
+                                        "\"edition\":3," +
+                                        "\"price\":28" +
+                                        "}" +
+                                        "]" +
+                                        "}"
                         );
                     });
                     ctx.totalRowCount(6);
@@ -840,7 +840,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testAssociationOnlyUpdateUsesUserOptimisticLockAsOwnerGate() {
+    public void testAssociationOnlyUpdateUsesOptimisticLockConditionAsOwnerGate() {
         executeAndExpectResult(
                 getSqlClient()
                         .getEntities()
@@ -875,7 +875,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testAssociationOnlyUpdateContinuesAfterUserOptimisticLockOwnerGate() {
+    public void testAssociationOnlyUpdateContinuesAfterOptimisticLockConditionOwnerGate() {
         executeAndExpectResult(
                 getSqlClient()
                         .getEntities()
@@ -944,8 +944,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME from " +
-                                "ADMINISTRATOR tb_1_ " +
-                                "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
+                                        "ADMINISTRATOR tb_1_ " +
+                                        "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
                         );
                         it.variables("a_5", true);
                         it.queryReason(QueryReason.INTERCEPTOR);
@@ -953,7 +953,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into ADMINISTRATOR(ID, NAME, DELETED, CREATED_TIME, MODIFIED_TIME) " +
-                                "values(?, ?, ?, ?, ?)"
+                                        "values(?, ?, ?, ?, ?)"
                         );
                         it.variables(
                                 5L,
@@ -966,17 +966,17 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from ADMINISTRATOR_METADATA tb_1_ " +
-                                "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
+                                        "from ADMINISTRATOR_METADATA tb_1_ " +
+                                        "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
                         );
                         it.variables("am_5", true);
                     });
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into ADMINISTRATOR_METADATA(" +
-                                "--->ID, " +
-                                "--->NAME, DELETED, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID" +
-                                ") values(?, ?, ?, ?, ?, ?, ?, ?)"
+                                        "--->ID, " +
+                                        "--->NAME, DELETED, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID" +
+                                        ") values(?, ?, ?, ?, ?, ?, ?, ?)"
                         );
                         it.variables(
                                 50L,
@@ -995,32 +995,32 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "--->\"name\":\"a_5\"," +
-                                "--->\"metadata\":{" +
-                                "--->--->\"name\":\"am_5\"," +
-                                "--->--->\"email\":\"email_5\"," +
-                                "--->--->\"website\":\"website_5\"" +
-                                "--->}" +
-                                "}"
+                                        "--->\"name\":\"a_5\"," +
+                                        "--->\"metadata\":{" +
+                                        "--->--->\"name\":\"am_5\"," +
+                                        "--->--->\"email\":\"email_5\"," +
+                                        "--->--->\"website\":\"website_5\"" +
+                                        "--->}" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "--->\"name\":\"a_5\"," +
-                                "--->\"deleted\":false," +
-                                "--->\"createdTime\":\"2022-10-15 16:55:00\"," +
-                                "--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
-                                "--->\"metadata\":{" +
-                                "--->--->\"name\":\"am_5\"," +
-                                "--->--->\"deleted\":false," +
-                                "--->--->\"createdTime\":\"2022-10-15 16:55:00\"," +
-                                "--->--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
-                                "--->--->\"email\":\"email_5\"," +
-                                "--->--->\"website\":\"website_5\"," +
-                                "--->--->\"administrator\":{\"id\":5}," +
-                                "--->--->\"id\":50" +
-                                "--->}," +
-                                "--->\"id\":5" +
-                                "}"
+                                        "--->\"name\":\"a_5\"," +
+                                        "--->\"deleted\":false," +
+                                        "--->\"createdTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->\"metadata\":{" +
+                                        "--->--->\"name\":\"am_5\"," +
+                                        "--->--->\"deleted\":false," +
+                                        "--->--->\"createdTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->--->\"email\":\"email_5\"," +
+                                        "--->--->\"website\":\"website_5\"," +
+                                        "--->--->\"administrator\":{\"id\":5}," +
+                                        "--->--->\"id\":50" +
+                                        "--->}," +
+                                        "--->\"id\":5" +
+                                        "}"
                         );
                     });
                 }
@@ -1050,8 +1050,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from ADMINISTRATOR tb_1_ " +
-                                "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
+                                        "from ADMINISTRATOR tb_1_ " +
+                                        "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
                         );
                         it.variables("a_4", true);
                         it.queryReason(QueryReason.INTERCEPTOR);
@@ -1059,7 +1059,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into ADMINISTRATOR(ID, NAME, DELETED, CREATED_TIME, MODIFIED_TIME) " +
-                                "values(?, ?, ?, ?, ?)"
+                                        "values(?, ?, ?, ?, ?)"
                         );
                         it.variables(
                                 10001L,
@@ -1072,17 +1072,17 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from ADMINISTRATOR_METADATA tb_1_ " +
-                                "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
+                                        "from ADMINISTRATOR_METADATA tb_1_ " +
+                                        "where tb_1_.NAME = ? and tb_1_.DELETED <> ?"
                         );
                         it.variables("am_4", true);
                     });
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into ADMINISTRATOR_METADATA(" +
-                                "--->ID, " +
-                                "--->NAME, DELETED, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID" +
-                                ") values(?, ?, ?, ?, ?, ?, ?, ?)"
+                                        "--->ID, " +
+                                        "--->NAME, DELETED, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID" +
+                                        ") values(?, ?, ?, ?, ?, ?, ?, ?)"
                         );
                         it.variables(
                                 10010L,
@@ -1098,35 +1098,35 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "--->\"name\":\"a_4\"," +
-                                "--->\"metadata\":{" +
-                                "--->--->\"name\":\"am_4\"," +
-                                "--->--->\"email\":\"email_4+\"," +
-                                "--->--->\"website\":\"website_4+\"" +
-                                "--->}" +
-                                "}"
+                                        "--->\"name\":\"a_4\"," +
+                                        "--->\"metadata\":{" +
+                                        "--->--->\"name\":\"am_4\"," +
+                                        "--->--->\"email\":\"email_4+\"," +
+                                        "--->--->\"website\":\"website_4+\"" +
+                                        "--->}" +
+                                        "}"
                         );
                         ctx.totalRowCount(2);
                         ctx.rowCount(AffectedTable.of(Administrator.class), 1);
                         ctx.rowCount(AffectedTable.of(AdministratorMetadata.class), 1);
                         it.modified(
                                 "{" +
-                                "--->\"name\":\"a_4\"," +
-                                "--->\"deleted\":false," +
-                                "--->\"createdTime\":\"2022-10-15 16:55:00\"," +
-                                "--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
-                                "--->\"metadata\":{" +
-                                "--->--->\"name\":\"am_4\"," +
-                                "--->--->\"deleted\":false," +
-                                "--->--->\"createdTime\":\"2022-10-15 16:55:00\"," +
-                                "--->--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
-                                "--->--->\"email\":\"email_4+\"," +
-                                "--->--->\"website\":\"website_4+\"," +
-                                "--->--->\"administrator\":{\"id\":10001}," +
-                                "--->--->\"id\":10010" +
-                                "--->}," +
-                                "--->\"id\":10001" +
-                                "}"
+                                        "--->\"name\":\"a_4\"," +
+                                        "--->\"deleted\":false," +
+                                        "--->\"createdTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->\"metadata\":{" +
+                                        "--->--->\"name\":\"am_4\"," +
+                                        "--->--->\"deleted\":false," +
+                                        "--->--->\"createdTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->--->\"modifiedTime\":\"2022-10-15 16:55:00\"," +
+                                        "--->--->\"email\":\"email_4+\"," +
+                                        "--->--->\"website\":\"website_4+\"," +
+                                        "--->--->\"administrator\":{\"id\":10001}," +
+                                        "--->--->\"id\":10010" +
+                                        "--->}," +
+                                        "--->\"id\":10001" +
+                                        "}"
                         );
                     });
                 }
@@ -1154,8 +1154,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID " +
-                                "from TREE_NODE tb_1_ " +
-                                "where tb_1_.PARENT_ID is null and tb_1_.NAME = ?"
+                                        "from TREE_NODE tb_1_ " +
+                                        "where tb_1_.PARENT_ID is null and tb_1_.NAME = ?"
                         );
                         it.variables("Parent");
                     });
@@ -1166,8 +1166,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID " +
-                                "from TREE_NODE tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.PARENT_ID) in ((?, ?), (?, ?))"
+                                        "from TREE_NODE tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.PARENT_ID) in ((?, ?), (?, ?))"
                         );
                         it.variables("Child-1", 100L, "Child-2", 100L);
                     });
@@ -1180,31 +1180,31 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "--->\"name\":\"Parent\"," +
-                                "--->\"parent\":null," +
-                                "--->\"childNodes\":[" +
-                                "--->--->{\"name\":\"Child-1\"}," +
-                                "--->--->{\"name\":\"Child-2\"}" +
-                                "--->]" +
-                                "}"
+                                        "--->\"name\":\"Parent\"," +
+                                        "--->\"parent\":null," +
+                                        "--->\"childNodes\":[" +
+                                        "--->--->{\"name\":\"Child-1\"}," +
+                                        "--->--->{\"name\":\"Child-2\"}" +
+                                        "--->]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "--->\"id\":100,\"name\":" +
-                                "--->\"Parent\",\"" +
-                                "--->parent\":null," +
-                                "--->\"childNodes\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"id\":101," +
-                                "--->--->--->\"name\":\"Child-1\"," +
-                                "--->--->--->\"parent\":{\"id\":100}" +
-                                "--->--->},{" +
-                                "--->--->--->\"id\":102," +
-                                "--->--->--->\"name\":\"Child-2\"," +
-                                "--->--->--->\"parent\":{\"id\":100}" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}"
+                                        "--->\"id\":100,\"name\":" +
+                                        "--->\"Parent\",\"" +
+                                        "--->parent\":null," +
+                                        "--->\"childNodes\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"id\":101," +
+                                        "--->--->--->\"name\":\"Child-1\"," +
+                                        "--->--->--->\"parent\":{\"id\":100}" +
+                                        "--->--->},{" +
+                                        "--->--->--->\"id\":102," +
+                                        "--->--->--->\"name\":\"Child-2\"," +
+                                        "--->--->--->\"parent\":{\"id\":100}" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}"
                         );
                     });
                 }
@@ -1243,7 +1243,7 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME " +
-                                "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                                        "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
                         );
                     });
                     ctx.statement(it -> {
@@ -1254,14 +1254,14 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
-                                "from BOOK tb_1_ " +
-                                "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
+                                        "from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) in ((?, ?), (?, ?))"
                         );
                     });
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into BOOK(ID, NAME, EDITION, PRICE, STORE_ID) " +
-                                "values(?, ?, ?, ?, ?)"
+                                        "values(?, ?, ?, ?, ?)"
                         );
                         it.batches(2);
                     });
@@ -1326,18 +1326,18 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         );
                         it.modified(
                                 "{" +
-                                "--->\"id\":\"1\"," +
-                                "--->\"name\":\"Develop\"," +
-                                "--->\"employees\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"id\":\"100\"," +
-                                "--->--->--->\"name\":\"Tim\"," +
-                                "--->--->--->\"gender\":\"MALE\"," +
-                                "--->--->--->\"deletedMillis\":0," +
-                                "--->--->--->\"department\":{\"id\":\"1\"}" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}");
+                                        "--->\"id\":\"1\"," +
+                                        "--->\"name\":\"Develop\"," +
+                                        "--->\"employees\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"id\":\"100\"," +
+                                        "--->--->--->\"name\":\"Tim\"," +
+                                        "--->--->--->\"gender\":\"MALE\"," +
+                                        "--->--->--->\"deletedMillis\":0," +
+                                        "--->--->--->\"department\":{\"id\":\"1\"}" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}");
                     });
                 }
         );
@@ -1375,19 +1375,19 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         );
                         it.modified(
                                 "{" +
-                                "--->\"id\":\"10\"," +
-                                "--->\"name\":\"Develop\"," +
-                                "--->\"deletedMillis\":0," +
-                                "--->\"employees\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"id\":\"100\"," +
-                                "--->--->--->\"name\":\"Tim\"," +
-                                "--->--->--->\"gender\":\"MALE\"," +
-                                "--->--->--->\"deletedMillis\":0," +
-                                "--->--->--->\"department\":{\"id\":\"10\"}" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}");
+                                        "--->\"id\":\"10\"," +
+                                        "--->\"name\":\"Develop\"," +
+                                        "--->\"deletedMillis\":0," +
+                                        "--->\"employees\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"id\":\"100\"," +
+                                        "--->--->--->\"name\":\"Tim\"," +
+                                        "--->--->--->\"gender\":\"MALE\"," +
+                                        "--->--->--->\"deletedMillis\":0," +
+                                        "--->--->--->\"department\":{\"id\":\"10\"}" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}");
                     });
                 }
         );
@@ -1397,14 +1397,14 @@ public class CascadeSaveTest extends AbstractMutationTest {
     public void testUpdateOnlyChild() {
         executeAndExpectResult(
                 getSqlClient().getEntities().saveCommand(
-                        DepartmentDraft.$.produce(draft -> {
-                            draft.setId(1L);
-                            draft.addIntoEmployees(employee -> employee.setId(1).setName("Tim"));
-                        })
-                )
-                .setMode(SaveMode.UPDATE_ONLY)
-                .setAssociatedModeAll(AssociatedSaveMode.UPDATE)
-                .setTargetTransferModeAll(TargetTransferMode.ALLOWED),
+                                DepartmentDraft.$.produce(draft -> {
+                                    draft.setId(1L);
+                                    draft.addIntoEmployees(employee -> employee.setId(1).setName("Tim"));
+                                })
+                        )
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setAssociatedModeAll(AssociatedSaveMode.UPDATE)
+                        .setTargetTransferModeAll(TargetTransferMode.ALLOWED),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql("update EMPLOYEE set NAME = ?, DEPARTMENT_ID = ? where ID = ?");
@@ -1416,15 +1416,15 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         );
                         it.modified(
                                 "{" +
-                                "--->\"id\":\"1\"," +
-                                "--->\"employees\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"id\":\"1\"," +
-                                "--->--->--->\"name\":\"Tim\"," +
-                                "--->--->--->\"department\":{\"id\":\"1\"}" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}");
+                                        "--->\"id\":\"1\"," +
+                                        "--->\"employees\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"id\":\"1\"," +
+                                        "--->--->--->\"name\":\"Tim\"," +
+                                        "--->--->--->\"department\":{\"id\":\"1\"}" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}");
                     });
                 }
         );
@@ -1471,43 +1471,43 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.entity(it -> {
                         it.original(
                                 "{" +
-                                "--->\"name\":\"TURING\"," +
-                                "--->\"website\":\"https://www.turing.org\"," +
-                                "--->\"books\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"name\":\"SQL Optimization\"," +
-                                "--->--->--->\"edition\":1," +
-                                "--->--->--->\"price\":59.99" +
-                                "--->--->},{" +
-                                "--->--->--->\"name\":\"Jimmer, a new ORM\"," +
-                                "--->--->--->\"edition\":1," +
-                                "--->--->--->\"price\":59.99" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}"
+                                        "--->\"name\":\"TURING\"," +
+                                        "--->\"website\":\"https://www.turing.org\"," +
+                                        "--->\"books\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"name\":\"SQL Optimization\"," +
+                                        "--->--->--->\"edition\":1," +
+                                        "--->--->--->\"price\":59.99" +
+                                        "--->--->},{" +
+                                        "--->--->--->\"name\":\"Jimmer, a new ORM\"," +
+                                        "--->--->--->\"edition\":1," +
+                                        "--->--->--->\"price\":59.99" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}"
                         );
                         it.modified(
                                 "{" +
-                                "--->\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"," +
-                                "--->\"name\":\"TURING\"," +
-                                "--->\"website\":\"https://www.turing.org\"," +
-                                "--->\"version\":0," +
-                                "--->\"books\":[" +
-                                "--->--->{" +
-                                "--->--->--->\"id\":\"8b16a8cf-cb8a-4781-87b8-652dc7a1d04f\"," +
-                                "--->--->--->\"name\":\"SQL Optimization\"," +
-                                "--->--->--->\"edition\":1," +
-                                "--->--->--->\"price\":59.99," +
-                                "--->--->--->\"store\":{\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"}" +
-                                "--->--->},{" +
-                                "--->--->--->\"id\":\"003b0ef9-f63f-480f-b752-348a23c00997\"," +
-                                "--->--->--->\"name\":\"Jimmer, a new ORM\"," +
-                                "--->--->--->\"edition\":1," +
-                                "--->--->--->\"price\":59.99," +
-                                "--->--->--->\"store\":{\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"}" +
-                                "--->--->}" +
-                                "--->]" +
-                                "}"
+                                        "--->\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"," +
+                                        "--->\"name\":\"TURING\"," +
+                                        "--->\"website\":\"https://www.turing.org\"," +
+                                        "--->\"version\":0," +
+                                        "--->\"books\":[" +
+                                        "--->--->{" +
+                                        "--->--->--->\"id\":\"8b16a8cf-cb8a-4781-87b8-652dc7a1d04f\"," +
+                                        "--->--->--->\"name\":\"SQL Optimization\"," +
+                                        "--->--->--->\"edition\":1," +
+                                        "--->--->--->\"price\":59.99," +
+                                        "--->--->--->\"store\":{\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"}" +
+                                        "--->--->},{" +
+                                        "--->--->--->\"id\":\"003b0ef9-f63f-480f-b752-348a23c00997\"," +
+                                        "--->--->--->\"name\":\"Jimmer, a new ORM\"," +
+                                        "--->--->--->\"edition\":1," +
+                                        "--->--->--->\"price\":59.99," +
+                                        "--->--->--->\"store\":{\"id\":\"bdd0445b-c71f-46fd-80ed-b646d32b1351\"}" +
+                                        "--->--->}" +
+                                        "--->]" +
+                                        "}"
                         );
                     });
                 }
@@ -1611,7 +1611,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         it.batchVariables(1, "Task-2", 2L);
                         it.batchVariables(2, "Task-3", 2L);
                     });
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                     ctx.totalRowCount(4);
                     ctx.rowCount(AffectedTable.of(Task.class), 4);
                 }
@@ -1641,23 +1642,23 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "insert into ADMINISTRATOR(NAME, DELETED, CREATED_TIME, MODIFIED_TIME) " +
-                                "values(?, ?, ?, ?)"
+                                        "values(?, ?, ?, ?)"
                         );
                         it.variables("Daisy", false, UNKNOWN_VARIABLE, UNKNOWN_VARIABLE);
                     });
                     ctx.statement(it -> {
                         it.sql(
                                 "merge into ADMINISTRATOR_METADATA tb_1_ " +
-                                "using(values(?, ?, ?, ?, ?, ?, ?)) " +
-                                "tb_2_(NAME, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID, DELETED) " +
-                                "on tb_1_.NAME = tb_2_.NAME and tb_1_.DELETED = false " +
-                                "when matched then " +
-                                "--->update set CREATED_TIME = tb_2_.CREATED_TIME, MODIFIED_TIME = tb_2_.MODIFIED_TIME, " +
-                                "EMAIL = tb_2_.EMAIL, WEBSITE = tb_2_.WEBSITE, ADMINISTRATOR_ID = tb_2_.ADMINISTRATOR_ID " +
-                                "when not matched then " +
-                                "--->insert(NAME, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID, DELETED) " +
-                                "--->values(tb_2_.NAME, tb_2_.CREATED_TIME, tb_2_.MODIFIED_TIME, tb_2_.EMAIL, " +
-                                "tb_2_.WEBSITE, tb_2_.ADMINISTRATOR_ID, tb_2_.DELETED)"
+                                        "using(values(?, ?, ?, ?, ?, ?, ?)) " +
+                                        "tb_2_(NAME, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID, DELETED) " +
+                                        "on tb_1_.NAME = tb_2_.NAME and tb_1_.DELETED = false " +
+                                        "when matched then " +
+                                        "--->update set CREATED_TIME = tb_2_.CREATED_TIME, MODIFIED_TIME = tb_2_.MODIFIED_TIME, " +
+                                        "EMAIL = tb_2_.EMAIL, WEBSITE = tb_2_.WEBSITE, ADMINISTRATOR_ID = tb_2_.ADMINISTRATOR_ID " +
+                                        "when not matched then " +
+                                        "--->insert(NAME, CREATED_TIME, MODIFIED_TIME, EMAIL, WEBSITE, ADMINISTRATOR_ID, DELETED) " +
+                                        "--->values(tb_2_.NAME, tb_2_.CREATED_TIME, tb_2_.MODIFIED_TIME, tb_2_.EMAIL, " +
+                                        "tb_2_.WEBSITE, tb_2_.ADMINISTRATOR_ID, tb_2_.DELETED)"
                         );
                         it.variables(
                                 "Daisy-Metadata",
@@ -1669,7 +1670,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                                 false
                         );
                     });
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                 }
         );
     }
@@ -1688,11 +1690,12 @@ public class CascadeSaveTest extends AbstractMutationTest {
                     ctx.statement(it -> {
                         it.sql(
                                 "delete from ADMINISTRATOR_METADATA " +
-                                "where ADMINISTRATOR_ID = ?"
+                                        "where ADMINISTRATOR_ID = ?"
                         );
                         it.variables(1L);
                     });
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                 }
         );
     }
@@ -1716,7 +1719,8 @@ public class CascadeSaveTest extends AbstractMutationTest {
                         );
                         it.variables(true, 1L, true);
                     });
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                 }
         );
     }
@@ -1844,16 +1848,16 @@ public class CascadeSaveTest extends AbstractMutationTest {
 
                     ctx.entity(it -> {
                         it.modified("{" +
-                                    "\"id\":\"" + authorId + "\"," +
-                                    "\"books\":[{" +
-                                    "\"id\":\"" + bookId + "\"," +
-                                    "\"name\":\"Clean Code\"," +
-                                    "\"edition\":1," +
-                                    "\"price\":100," +
-                                    "\"store\":{" +
-                                    "\"id\":\"" + storeId + "\"}" +
-                                    "}]" +
-                                    "}");
+                                "\"id\":\"" + authorId + "\"," +
+                                "\"books\":[{" +
+                                "\"id\":\"" + bookId + "\"," +
+                                "\"name\":\"Clean Code\"," +
+                                "\"edition\":1," +
+                                "\"price\":100," +
+                                "\"store\":{" +
+                                "\"id\":\"" + storeId + "\"}" +
+                                "}]" +
+                                "}");
                     });
                 }
         );

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectEventsAndCacheTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectEventsAndCacheTest.java
@@ -1,0 +1,244 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.meta.ImmutableType;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.ComparableExpression;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.AssociationTable;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable1;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.cache.Cache;
+import org.babyfish.jimmer.sql.cache.CacheFactory;
+import org.babyfish.jimmer.sql.cache.CacheOperator;
+import org.babyfish.jimmer.sql.cache.UsedCache;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.common.CacheImpl;
+import org.babyfish.jimmer.sql.event.AssociationEvent;
+import org.babyfish.jimmer.sql.event.EntityEvent;
+import org.babyfish.jimmer.sql.event.TriggerType;
+import org.babyfish.jimmer.sql.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.babyfish.jimmer.sql.common.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InsertFromSelectEventsAndCacheTest extends AbstractMutationTest {
+
+    @Test
+    public void testInsertEventAndObjectCacheInvalidation() {
+        List<EntityEvent<?>> events = new ArrayList<>();
+        List<String> evictions = new ArrayList<>();
+        JSqlClient client = cachedClient(evictions, false);
+        client.getTriggers(true).addEntityListener(BookStore.class, events::add);
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000031");
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = source(client, id, "EVENT-INSERT");
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> assertEquals(
+                1,
+                client.createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .execute(con)
+        ));
+
+        assertEquals(1, events.size());
+        EntityEvent<?> event = events.get(0);
+        assertNull(event.getOldEntity());
+        assertEquals(id, event.getId());
+        assertEquals("EVENT-INSERT", ((BookStore) event.getNewEntity()).name());
+        assertEquals(singletonList("BookStore-" + id), evictions);
+    }
+
+    @Test
+    public void testUpdateEventAndObjectCacheInvalidation() {
+        List<EntityEvent<?>> events = new ArrayList<>();
+        List<String> evictions = new ArrayList<>();
+        JSqlClient client = cachedClient(evictions, false);
+        client.getTriggers(true).addEntityListener(BookStore.class, events::add);
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = source(
+                client,
+                oreillyId,
+                "O'REILLY-EVENT"
+        );
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> assertEquals(
+                1,
+                client.createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .execute(con)
+        ));
+
+        assertEquals(1, events.size());
+        EntityEvent<?> event = events.get(0);
+        assertEquals("O'REILLY", ((BookStore) event.getOldEntity()).name());
+        assertEquals("O'REILLY-EVENT", ((BookStore) event.getNewEntity()).name());
+        assertEquals(singletonList("BookStore-" + oreillyId), evictions);
+    }
+
+    @Test
+    public void testRejectedUpdateProducesNoEventOrInvalidation() {
+        List<EntityEvent<?>> events = new ArrayList<>();
+        List<String> evictions = new ArrayList<>();
+        JSqlClient client = cachedClient(evictions, false);
+        client.getTriggers(true).addEntityListener(BookStore.class, events::add);
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = source(
+                client,
+                oreillyId,
+                "REJECTED"
+        );
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> assertEquals(
+                0,
+                client.createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .updateWhere(source.get_2().eq("ACCEPTED"))
+                        .execute(con)
+        ));
+
+        assertTrue(events.isEmpty());
+        assertTrue(evictions.isEmpty());
+    }
+
+    @Test
+    public void testFakeUpdateEventAndObjectCacheInvalidation() {
+        List<EntityEvent<?>> events = new ArrayList<>();
+        List<String> evictions = new ArrayList<>();
+        JSqlClient client = cachedClient(evictions, false);
+        client.getTriggers(true).addEntityListener(BookStore.class, events::add);
+        BaseTable1<ComparableExpression<UUID>> source = client
+                .createBaseQuery()
+                .addSelect(Expression.value(oreillyId))
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> assertEquals(
+                1,
+                client.createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .execute(con)
+        ));
+
+        assertEquals(1, events.size());
+        assertNotNull(events.get(0).getOldEntity());
+        assertNotNull(events.get(0).getNewEntity());
+        assertEquals(singletonList("BookStore-" + oreillyId), evictions);
+    }
+
+    @Test
+    public void testAssociationEventAndBidirectionalCacheInvalidation() {
+        List<AssociationEvent> events = new ArrayList<>();
+        List<String> evictions = new ArrayList<>();
+        JSqlClient client = cachedClient(evictions, true);
+        client.getTriggers(true).addAssociationListener(events::add);
+        BaseTable2<ComparableExpression<UUID>, ComparableExpression<UUID>> source = client
+                .createBaseQuery()
+                .addSelect(Expression.value(effectiveTypeScriptId1))
+                .addSelect(Expression.value(alexId))
+                .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> association =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+
+        jdbc(con -> assertEquals(
+                1,
+                client.createInsert(association, source)
+                        .set(association.<UUID>sourceId(), source.get_1())
+                        .set(association.<UUID>targetId(), source.get_2())
+                        .execute(con)
+        ));
+
+        assertEquals(2, events.size());
+        assertTrue(events.stream().anyMatch(it ->
+                it.getSourceId().equals(effectiveTypeScriptId1) &&
+                        alexId.equals(it.getAttachedTargetId())
+        ));
+        assertTrue(events.stream().anyMatch(it ->
+                it.getSourceId().equals(alexId) &&
+                        effectiveTypeScriptId1.equals(it.getAttachedTargetId())
+        ));
+        assertEquals(
+                asList(
+                        "Book.authors-" + effectiveTypeScriptId1,
+                        "Author.books-" + alexId
+                ),
+                evictions
+        );
+    }
+
+    private JSqlClient cachedClient(List<String> evictions, boolean associationCaches) {
+        return getSqlClient(builder -> {
+            builder.setTriggerType(TriggerType.TRANSACTION_ONLY);
+            builder.setCaches(cfg -> cfg
+                    .setCacheFactory(new CacheFactory() {
+                        @Override
+                        public Cache<?, ?> createObjectCache(ImmutableType type) {
+                            Class<?> javaType = type.getJavaClass();
+                            return javaType == BookStore.class ||
+                                    associationCaches && (javaType == Book.class || javaType == Author.class) ?
+                                    new CacheImpl<>(type) :
+                                    null;
+                        }
+
+                        @Override
+                        public Cache<?, List<?>> createAssociatedIdListCache(ImmutableProp prop) {
+                            return associationCaches &&
+                                    (prop == BookProps.AUTHORS.unwrap() || prop == AuthorProps.BOOKS.unwrap()) ?
+                                    new CacheImpl<>(prop) :
+                                    null;
+                        }
+                    })
+                    .setCacheOperator(new CacheOperator() {
+                        @Override
+                        public void delete(UsedCache<Object, ?> cache, Object key, Object reason) {
+                            evictions.add(cacheName(cache) + '-' + key);
+                            CacheOperator.suspending(() -> cache.delete(key));
+                        }
+
+                        @Override
+                        public void deleteAll(
+                                UsedCache<Object, ?> cache,
+                                Collection<Object> keys,
+                                Object reason
+                        ) {
+                            for (Object key : keys) {
+                                evictions.add(cacheName(cache) + '-' + key);
+                            }
+                            CacheOperator.suspending(() -> cache.deleteAll(keys));
+                        }
+                    }));
+        });
+    }
+
+    private static BaseTable2<ComparableExpression<UUID>, StringExpression> source(
+            JSqlClient client,
+            UUID id,
+            String name
+    ) {
+        return client
+                .createBaseQuery()
+                .addSelect(Expression.value(id))
+                .addSelect(Expression.value(name))
+                .asBaseTable();
+    }
+
+    private static String cacheName(UsedCache<?, ?> cache) {
+        ImmutableProp prop = cache.prop();
+        if (prop == null) {
+            return cache.type().getJavaClass().getSimpleName();
+        }
+        return prop.getDeclaringType().getJavaClass().getSimpleName() + '.' + prop.getName();
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectInheritanceTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectInheritanceTest.java
@@ -1,0 +1,199 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.NumericExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable3;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.dialect.DefaultDialect;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.OrganizationTable;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InsertFromSelectInheritanceTest extends AbstractMutationTest {
+
+    @Test
+    public void testInsertAddsSingleTableDiscriminator() {
+        BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source =
+                source(399L, "New Organization", "NEW-399");
+        OrganizationTable table = OrganizationTable.$;
+        connectAndExpect(
+                con -> {
+                    int rowCount = getSqlClient()
+                            .createInsert(table, source)
+                            .set(table.id(), source.get_1())
+                            .set(table.name(), source.get_2())
+                            .set(table.taxCode(), source.get_3())
+                            .execute(con);
+                    return rowCount + "; " + clientRow(con, 399L);
+                },
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into CLIENT(ID, NAME, TAX_CODE, CLIENT_TYPE) " +
+                                        "select tb_1_.c1, tb_1_.c2, tb_1_.c3, ? from (" +
+                                        "select cast(? as bigint) as c1, " +
+                                        "cast(? as varchar) as c2, " +
+                                        "cast(? as varchar) as c3" +
+                                        ") tb_1_"
+                        );
+                        it.variables("ORG", 399L, "New Organization", "NEW-399");
+                    });
+                    ctx.value("1; [ORG, New Organization, NEW-399, null, null]");
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertUpdatesMatchingSingleTableSubtype() {
+        BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source =
+                source(100L, "Acme+", "ACME-002");
+        OrganizationTable table = OrganizationTable.$;
+        connectAndExpect(
+                con -> {
+                    int rowCount = getSqlClient()
+                            .createUpsert(table, source)
+                            .key(table.id(), source.get_1())
+                            .merge(table.name(), source.get_2())
+                            .merge(table.taxCode(), source.get_3())
+                            .execute(con);
+                    return rowCount + "; " + clientRow(con, 100L);
+                },
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(upsertSql());
+                        it.variables(100L, "Acme+", "ACME-002", "ORG", "ORG");
+                    });
+                    ctx.value("1; [ORG, Acme+, ACME-002, null, null]");
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertDoesNotUpdateRowWithDifferentDiscriminator() {
+        BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source =
+                source(101L, "Should not update", "SHOULD-NOT-WRITE");
+        OrganizationTable table = OrganizationTable.$;
+        connectAndExpect(
+                con -> {
+                    int rowCount = getSqlClient()
+                            .createUpsert(table, source)
+                            .key(table.id(), source.get_1())
+                            .merge(table.name(), source.get_2())
+                            .merge(table.taxCode(), source.get_3())
+                            .execute(con);
+                    return rowCount + "; " + clientRow(con, 101L);
+                },
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(upsertSql());
+                        it.variables(101L, "Should not update", "SHOULD-NOT-WRITE", "ORG", "ORG");
+                    });
+                    ctx.value("0; [Person, Bob, null, Bob, Brown]");
+                }
+        );
+    }
+
+    @Test
+    public void testMaterializedUpsertRejectsDifferentDiscriminator() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        OrganizationTable sourceTable = OrganizationTable.$;
+        BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source =
+                sqlClient
+                        .createBaseQuery(sourceTable)
+                        .where(sourceTable.id().eq(100L))
+                        .addSelect(sourceTable.id().plus(1L))
+                        .addSelect(sourceTable.name().concat(" should not update"))
+                        .addSelect(sourceTable.taxCode().concat("-SHOULD-NOT-WRITE"))
+                        .asBaseTable();
+        OrganizationTable table = OrganizationTable.$;
+        connectAndExpect(
+                con -> {
+                    List<Long> ids = sqlClient
+                            .createUpsert(table, source)
+                            .key(table.id(), source.get_1())
+                            .merge(
+                                    table.name(),
+                                    source.get_2(),
+                                    table.name().concat(source.get_2())
+                            )
+                            .merge(table.taxCode(), source.get_3())
+                            .updateWhere(source.get_2().ne(table.name()))
+                            .returning(table.id())
+                            .execute(con);
+                    return ids + "; " + clientRow(con, 101L);
+                },
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2, tb_1_.c3, ? from (" +
+                                    "select tb_1_.ID + ? c1, " +
+                                    "concat(tb_1_.NAME, ?) c2, " +
+                                    "concat(tb_1_.TAX_CODE, ?) c3 " +
+                                    "from CLIENT tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.CLIENT_TYPE = ?) tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID from CLIENT tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.CLIENT_TYPE = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.CLIENT_TYPE from CLIENT tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.value("[]; [Person, Bob, null, Bob, Brown]");
+                }
+        );
+    }
+
+    private BaseTable3<NumericExpression<Long>, StringExpression, StringExpression> source(
+            long id,
+            String name,
+            String taxCode
+    ) {
+        return getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(id))
+                .addSelect(Expression.value(name))
+                .addSelect(Expression.value(taxCode))
+                .asBaseTable();
+    }
+
+    private static String upsertSql() {
+        return "merge into CLIENT tb_2_ using (" +
+                "select cast(? as bigint) as c1, " +
+                "cast(? as varchar) as c2, " +
+                "cast(? as varchar) as c3" +
+                ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                "when matched and tb_2_.CLIENT_TYPE = ? " +
+                "then update set tb_2_.NAME = tb_1_.c2, tb_2_.TAX_CODE = tb_1_.c3 " +
+                "when not matched then insert(ID, NAME, TAX_CODE, CLIENT_TYPE) " +
+                "values(tb_1_.c1, tb_1_.c2, tb_1_.c3, ?)";
+    }
+
+    private static String clientRow(Connection con, long id) {
+        try (PreparedStatement stmt = con.prepareStatement(
+                "select CLIENT_TYPE, NAME, TAX_CODE, FIRST_NAME, LAST_NAME from CLIENT where ID = ?"
+        )) {
+            stmt.setLong(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                assertTrue(rs.next());
+                return "[" +
+                        rs.getString(1) + ", " +
+                        rs.getString(2) + ", " +
+                        rs.getString(3) + ", " +
+                        rs.getString(4) + ", " +
+                        rs.getString(5) +
+                        "]";
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectLogicalDeleteTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectLogicalDeleteTest.java
@@ -1,0 +1,60 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.ComparableExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
+import org.babyfish.jimmer.sql.model.Gender;
+import org.babyfish.jimmer.sql.model.hr.EmployeeTable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InsertFromSelectLogicalDeleteTest extends AbstractMutationTest {
+
+    @Test
+    public void testNonBooleanLogicalDeleteColumnBelongsToConflictKey() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setIdGenerator(IdentityIdGenerator.INSTANCE));
+        EmployeeTable sourceEmployee = EmployeeTable.$;
+        BaseTable2<StringExpression, ComparableExpression<Gender>> source = sqlClient
+                .createBaseQuery(sourceEmployee)
+                .where(sourceEmployee.id().eq(2L))
+                .addSelect(sourceEmployee.name())
+                .addSelect(sourceEmployee.gender())
+                .asBaseTable();
+        EmployeeTable table = EmployeeTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.name(), source.get_1())
+                        .merge(table.gender(), source.get_2())
+                        .returning(table.id(), table.gender(), table.deletedMillis())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select ID, GENDER, DELETED_MILLIS from final table (" +
+                                        "merge into EMPLOYEE tb_2_ using (" +
+                                        "select tb_1_.NAME c1, tb_1_.GENDER c2 from EMPLOYEE tb_1_ " +
+                                        "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?" +
+                                        ") tb_1_ on tb_2_.NAME = tb_1_.c1 " +
+                                        "and tb_2_.DELETED_MILLIS = ? " +
+                                        "when matched then update set tb_2_.GENDER = tb_1_.c2 " +
+                                        "when not matched then insert(NAME, GENDER, DELETED_MILLIS) " +
+                                        "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                        ")"
+                        );
+                        it.variables(2L, 0L, 0L, 0L);
+                    });
+                    ctx.value(rows -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(2L, rows.get(0).get_1());
+                        assertEquals(Gender.FEMALE, rows.get(0).get_2());
+                        assertEquals(0L, rows.get(0).get_3());
+                    });
+                }
+        );
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectTest.java
@@ -1,0 +1,1265 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.ComparableExpression;
+import org.babyfish.jimmer.sql.ast.Expression;
+import org.babyfish.jimmer.sql.ast.NumericExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.query.ConfigurableBaseQuery;
+import org.babyfish.jimmer.sql.ast.query.TypedBaseQuery;
+import org.babyfish.jimmer.sql.ast.table.AssociationTable;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable1;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable3;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable4;
+import org.babyfish.jimmer.sql.ast.tuple.Tuple2;
+import org.babyfish.jimmer.sql.ast.tuple.Tuple3;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.dialect.*;
+import org.babyfish.jimmer.sql.event.EntityEvent;
+import org.babyfish.jimmer.sql.event.TriggerType;
+import org.babyfish.jimmer.sql.exception.ExecutionException;
+import org.babyfish.jimmer.sql.meta.impl.IdentityIdGenerator;
+import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.model.embedded.ProductTable;
+import org.babyfish.jimmer.sql.model.hr.DepartmentTable;
+import org.babyfish.jimmer.sql.model.inheritance.RoleTable;
+import org.babyfish.jimmer.sql.runtime.DefaultExecutor;
+import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.Executor;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.babyfish.jimmer.sql.tuple.*;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.babyfish.jimmer.sql.common.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InsertFromSelectTest extends AbstractMutationTest {
+
+    @Test
+    public void testDialectRendererDelegation() {
+        AtomicBoolean supported = new AtomicBoolean();
+        AtomicBoolean rendered = new AtomicBoolean();
+        AtomicReference<InsertFromSelectMode> modeRef = new AtomicReference<>();
+        InsertFromSelectRenderer delegate = new H2Dialect().getInsertFromSelectRenderer();
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new H2Dialect() {
+            private final InsertFromSelectRenderer renderer = new InsertFromSelectRenderer() {
+                @Override
+                public boolean isSupported(InsertFromSelectContext ctx) {
+                    supported.set(true);
+                    modeRef.set(ctx.getMode());
+                    return delegate.isSupported(ctx);
+                }
+
+                @Override
+                public boolean isTransactionTriggerSupported(InsertFromSelectContext ctx) {
+                    return delegate.isTransactionTriggerSupported(ctx);
+                }
+
+                @Override
+                public void render(InsertFromSelectContext ctx) {
+                    rendered.set(true);
+                    delegate.render(ctx);
+                }
+            };
+
+            @Override
+            public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+                return renderer;
+            }
+        }));
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000021");
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = sqlClient
+                .createBaseQuery()
+                .addSelect(Expression.value(id))
+                .addSelect(Expression.value("RENDERER"))
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        executeAndExpectRowCount(
+                sqlClient
+                        .createInsert(store, source)
+                        .set(store.id(), source.get_1())
+                        .set(store.name(), source.get_2()),
+                ctx -> {
+                    ctx.statement(it -> {
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+        assertTrue(supported.get());
+        assertTrue(rendered.get());
+        assertEquals(InsertFromSelectMode.INSERT, modeRef.get());
+    }
+
+    @Test
+    public void testInsertFromNormalTypedBaseQuery() {
+        BookTable book = BookTable.$;
+        BookUpdateReturningTupleTable source = getSqlClient()
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(book.id())
+                                .name(book.name().concat("+"))
+                )
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(store, source)
+                        .set(store.id(), source.getId())
+                        .set(store.name(), source.getName()),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                                        "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                        "select tb_1_.ID c1, concat(tb_1_.NAME, ?) c2 " +
+                                        "from BOOK tb_1_ where tb_1_.ID = ?" +
+                                        ") tb_1_"
+                        );
+                        it.variables(0, "+", learningGraphQLId1);
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    @Test
+    public void testInsertFromRootlessTypedUnionAll() {
+        UUID id1 = UUID.fromString("a0000000-0000-0000-0000-000000000011");
+        UUID id2 = UUID.fromString("a0000000-0000-0000-0000-000000000012");
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> row1 = getSqlClient()
+                .createBaseQuery()
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(Expression.value(id1))
+                                .name(Expression.value("UNION-1"))
+                );
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> row2 = getSqlClient()
+                .createBaseQuery()
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(Expression.value(id2))
+                                .name(Expression.value("UNION-2"))
+                );
+        BookUpdateReturningTupleTable source = TypedBaseQuery.unionAll(row1, row2).asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(store, source)
+                        .set(store.id(), source.getId())
+                        .set(store.name(), source.getName()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                                    "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                    "select cast(? as char(36)) as c1, cast(? as varchar) as c2 " +
+                                    "union all " +
+                                    "select cast(? as char(36)) as c1, cast(? as varchar) as c2" +
+                                    ") tb_1_"
+                    ));
+                    ctx.rowCount(2);
+                }
+        );
+    }
+
+    @Test
+    public void testWideTypedTupleSourcePruning() {
+        RoleTable role = RoleTable.$;
+        WideTupleTable source = getSqlClient()
+                .createBaseQuery(role)
+                .where(role.id().eq(100L))
+                .select(
+                        WideTupleMapper
+                                .value1(Expression.constant(1L))
+                                .value2(Expression.constant(2L))
+                                .value3(Expression.constant(3L))
+                                .value4(Expression.constant(4L))
+                                .value5(Expression.constant(5L))
+                                .value6(Expression.constant(6L))
+                                .value7(Expression.constant(7L))
+                                .value8(Expression.constant(8L))
+                                .value9(Expression.constant(9L))
+                                .value10(role.id())
+                )
+                .asBaseTable();
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(role, source)
+                        .set(role.id(), source.getValue10())
+                        .onConflictDoNothing(role.id()),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "merge into ROLE tb_2_ using (" +
+                                        "select tb_1_.ID c1 from ROLE tb_1_ " +
+                                        "where tb_1_.ID = ? and tb_1_.DELETED <> ?" +
+                                        ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                                        "when not matched then insert(ID, DELETED) values(tb_1_.c1, ?)"
+                        );
+                        it.variables(100L, true, false);
+                    });
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testMaterializedReturningWithGeneratedId() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookTable book = BookTable.$;
+        BookUpdateReturningTupleTable source = sqlClient
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(book.id())
+                                .name(book.name().concat("-MATERIALIZED"))
+                )
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> {
+            java.util.List<UUID> ids = sqlClient
+                    .createInsert(store, source)
+                    .set(store.name(), source.getName())
+                    .returning(store.id())
+                    .execute(con);
+            assertEquals(1, ids.size());
+            assertNotNull(ids.get(0));
+        });
+    }
+
+    @Test
+    public void testMaterializedReturningWithDatabaseDefault() {
+        resetIdentity(null, "SYS_USER");
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(DefaultDialect.INSTANCE);
+            it.setIdGenerator(IdentityIdGenerator.INSTANCE);
+        });
+        SysUserTable sourceUser = SysUserTable.$;
+        BaseTable4<StringExpression, StringExpression, StringExpression, StringExpression> source = sqlClient
+                .createBaseQuery(sourceUser)
+                .where(sourceUser.id().eq(1L))
+                .addSelect(sourceUser.account().concat("_m"))
+                .addSelect(sourceUser.email().concat(".m"))
+                .addSelect(sourceUser.area().concat("m"))
+                .addSelect(sourceUser.nickName().concat("M"))
+                .asBaseTable();
+        SysUserTable table = SysUserTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createInsert(table, source)
+                        .set(table.account(), source.get_1())
+                        .set(table.email(), source.get_2())
+                        .set(table.area(), source.get_3())
+                        .set(table.nickName(), source.get_4())
+                        .returning(table.description())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select tb_1_.c1, tb_1_.c2, tb_1_.c3, tb_1_.c4 from (" +
+                                        "select concat(tb_1_.ACCOUNT, ?) c1, concat(tb_1_.EMAIL, ?) c2, " +
+                                        "concat(tb_1_.AREA, ?) c3, concat(tb_1_.NICK_NAME, ?) c4 " +
+                                        "from SYS_USER tb_1_ where tb_1_.ID = ?" +
+                                        ") tb_1_"
+                        );
+                        it.variables("_m", ".m", "m", "M", 1L);
+                    });
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into SYS_USER(ACCOUNT, EMAIL, AREA, NICK_NAME) " +
+                                        "values(?, ?, ?, ?)"
+                        );
+                        it.variables("sysusr_001_m", "tom.cook@gmail.com.m", "northm", "TomM");
+                    });
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select tb_1_.ID, tb_1_.ACCOUNT, tb_1_.EMAIL, tb_1_.AREA, " +
+                                        "tb_1_.NICK_NAME, tb_1_.DESCRIPTION " +
+                                        "from SYS_USER tb_1_ where tb_1_.ID = ?"
+                        );
+                        it.variables(100L);
+                    });
+                    ctx.value(rows -> assertEquals(singletonList("DEFAULT_DESCRIPTION"), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testMaterializedInsertWithEmbeddedIdParts() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        ProductTable product = ProductTable.$;
+        BaseTable3<StringExpression, StringExpression, StringExpression> source = sqlClient
+                .createBaseQuery(product)
+                .where(
+                        product.id().alpha().eq("00B"),
+                        product.id().beta().eq("00A")
+                )
+                .addSelect(product.id().alpha().concat("X"))
+                .addSelect(product.id().beta())
+                .addSelect(product.name().concat("+"))
+                .asBaseTable();
+        jdbc(con -> {
+            java.util.List<Tuple3<String, String, String>> rows =
+                    sqlClient
+                            .createInsert(product, source)
+                            .set(product.id().alpha(), source.get_1())
+                            .set(product.id().beta(), source.get_2())
+                            .set(product.name(), source.get_3())
+                            .returning(
+                                    product.id().alpha(),
+                                    product.id().beta(),
+                                    product.name()
+                            )
+                            .execute(con);
+            assertEquals(1, rows.size());
+            assertEquals("00BX", rows.get(0).get_1());
+            assertEquals("00A", rows.get(0).get_2());
+            assertEquals("Bike+", rows.get(0).get_3());
+        });
+    }
+
+    @Test
+    public void testMaterializedUpsertWithEmbeddedIdParts() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        ProductTable product = ProductTable.$;
+        BaseTable3<StringExpression, StringExpression, StringExpression> source = sqlClient
+                .createBaseQuery(product)
+                .where(
+                        product.id().alpha().eq("00A"),
+                        product.id().beta().eq("00A")
+                )
+                .addSelect(product.id().alpha())
+                .addSelect(product.id().beta())
+                .addSelect(product.name().concat("+"))
+                .asBaseTable();
+        jdbc(con -> {
+            java.util.List<Tuple3<String, String, String>> rows =
+                    sqlClient
+                            .createUpsert(product, source)
+                            .key(product.id().alpha(), source.get_1())
+                            .key(product.id().beta(), source.get_2())
+                            .merge(product.name(), source.get_3())
+                            .returning(
+                                    product.id().alpha(),
+                                    product.id().beta(),
+                                    product.name()
+                            )
+                            .execute(con);
+            assertEquals(1, rows.size());
+            assertEquals("00A", rows.get(0).get_1());
+            assertEquals("00A", rows.get(0).get_2());
+            assertEquals("Car+", rows.get(0).get_3());
+        });
+    }
+
+    @Test
+    public void testMaterializedUpsertRejectsDuplicateKeys() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookTable book = BookTable.$;
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> row1 = sqlClient
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .select(BookUpdateReturningTupleMapper.id(book.id()).name(book.name()));
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> row2 = sqlClient
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .select(BookUpdateReturningTupleMapper.id(book.id()).name(book.name()));
+        BookUpdateReturningTupleTable source = TypedBaseQuery.unionAll(row1, row2).asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> assertThrows(
+                IllegalArgumentException.class,
+                () -> sqlClient
+                        .createUpsert(store, source)
+                        .key(store.id(), source.getId())
+                        .merge(store.name(), source.getName())
+                        .execute(con)
+        ));
+    }
+
+    @Test
+    public void testMaterializedFakeUpsertReturning() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookStoreTable sourceStore = BookStoreTable.$;
+        BookUpdateReturningTupleTable source = sqlClient
+                .createBaseQuery(sourceStore)
+                .where(sourceStore.id().eq(oreillyId))
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(sourceStore.id())
+                                .name(sourceStore.name())
+                )
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> {
+            java.util.List<UUID> ids = sqlClient
+                    .createUpsert(store, source)
+                    .key(store.id(), source.getId())
+                    .returning(store.id())
+                    .execute(con);
+            assertEquals(singletonList(oreillyId), ids);
+        });
+    }
+
+    @Test
+    public void testTransactionTriggerUsesMaterializedPlan() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setTriggerType(TriggerType.TRANSACTION_ONLY));
+        AtomicReference<EntityEvent<?>> eventRef = new AtomicReference<>();
+        sqlClient.getTriggers(true).addEntityListener(
+                org.babyfish.jimmer.sql.model.BookStore.class,
+                eventRef::set
+        );
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = sqlClient
+                .createBaseQuery()
+                .addSelect(Expression.value(oreillyId))
+                .addSelect(Expression.value("O'REILLY-TRIGGER"))
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> sqlClient
+                .createUpsert(store, source)
+                .key(store.id(), source.get_1())
+                .merge(store.name(), source.get_2())
+                .execute(con));
+        EntityEvent<?> event = eventRef.get();
+        assertNotNull(event);
+        assertNotNull(event.getOldEntity());
+        assertNotNull(event.getNewEntity());
+    }
+
+    @Test
+    public void testInsertFromRootlessBaseQuery() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000001");
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                getSqlClient()
+                        .createBaseQuery()
+                        .addSelect(Expression.value(id))
+                        .addSelect(Expression.value("ROOTLESS"))
+                        .addSelect(Expression.value(0))
+                        .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .set(table.version(), source.get_3()),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                                        "select tb_1_.c1, tb_1_.c2, tb_1_.c3 " +
+                                        "from (select " +
+                                        "cast(? as char(36)) as c1, " +
+                                        "cast(? as varchar) as c2, " +
+                                        "cast(? as int) as c3" +
+                                        ") tb_1_"
+                        );
+                        it.variables(id, "ROOTLESS", 0);
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    @Test
+    public void testInsertReturningFromRootlessBaseQuery() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000002");
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                getSqlClient()
+                        .createBaseQuery()
+                        .addSelect(Expression.value(id))
+                        .addSelect(Expression.value("RETURNING"))
+                        .addSelect(Expression.value(0))
+                        .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .set(table.version(), source.get_3())
+                        .returning(table.id())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "insert into BOOK_STORE(ID, NAME, VERSION) " +
+                                    "select tb_1_.c1, tb_1_.c2, tb_1_.c3 " +
+                                    "from (select " +
+                                    "cast(? as char(36)) as c1, " +
+                                    "cast(? as varchar) as c2, " +
+                                    "cast(? as int) as c3" +
+                                    ") tb_1_" +
+                                    ")"
+                    ));
+                    ctx.value(rows -> assertEquals(singletonList(id), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertOnConflictDoNothing() {
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                source(oreillyId, "IGNORED", 0);
+        BookStoreTable table = BookStoreTable.$;
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .set(table.version(), source.get_3())
+                        .onConflictDoNothing(table.id()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "merge into BOOK_STORE tb_2_ using " + rootlessSql() + " tb_1_ " +
+                                    "on tb_2_.ID = tb_1_.c1 " +
+                                    "when not matched then insert(ID, NAME, VERSION) " +
+                                    "values(tb_1_.c1, tb_1_.c2, tb_1_.c3)"
+                    ));
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlMaterializedInsertIfAbsentPreservesIdConflictTarget() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000031");
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new MySqlDialect());
+            it.setConstraintViolationTranslatable(false);
+        });
+        BookStoreTable sourceStore = BookStoreTable.$;
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = sqlClient
+                .createBaseQuery(sourceStore)
+                .where(sourceStore.id().eq(oreillyId))
+                .addSelect(Expression.comparable().sql(UUID.class, "cast('" + id + "' as char(36))"))
+                .addSelect(sourceStore.name())
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        executeAndExpectRowCount(
+                sqlClient
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .onConflictDoNothing(table.id()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                    "select cast('" + id + "' as char(36)) c1, tb_1_.NAME c2 " +
+                                    "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                                    "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "insert into BOOK_STORE(ID, NAME, VERSION) values(?, ?, ?)"
+                    ));
+                    ctx.throwable(it -> it.type(ExecutionException.class));
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlMaterializedUpsertPreservesIdConflictTarget() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000032");
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new MySqlDialect());
+            it.setConstraintViolationTranslatable(false);
+        });
+        BookStoreTable sourceStore = BookStoreTable.$;
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = sqlClient
+                .createBaseQuery(sourceStore)
+                .where(sourceStore.id().eq(oreillyId))
+                .addSelect(Expression.comparable().sql(UUID.class, "cast('" + id + "' as char(36))"))
+                .addSelect(sourceStore.name())
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .returning(table.id())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2, ? from (" +
+                                    "select cast('" + id + "' as char(36)) c1, tb_1_.NAME c2 " +
+                                    "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                                    "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "insert into BOOK_STORE(ID, NAME, VERSION) values(?, ?, ?)"
+                    ));
+                    ctx.throwable(it -> it.type(ExecutionException.class));
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlNativeUpsertForGuaranteedSingleKeyConstraint() {
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new MySqlDialect());
+            it.setExecutor(new Executor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <R> R execute(Args<R> args) {
+                    getExecutions().add(Execution.simple(args.sql, args.purpose, args.variables));
+                    return (R) Integer.valueOf(1);
+                }
+
+                @Override
+                public BatchContext executeBatch(
+                        Connection con,
+                        String sql,
+                        ImmutableProp generatedIdProp,
+                        ExecutionPurpose purpose,
+                        JSqlClientImplementor sqlClient,
+                        boolean constraintViolationTranslatable
+                ) {
+                    throw new AssertionError("Batch execution is not expected");
+                }
+            });
+        });
+        DepartmentTable table = DepartmentTable.$;
+        BaseTable1<StringExpression> source = sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(1L))
+                .addSelect(table.name())
+                .asBaseTable();
+        executeAndExpectRowCount(
+                sqlClient
+                        .createUpsert(table, source)
+                        .key(table.name(), source.get_1()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "insert into DEPARTMENT(NAME, DELETED_MILLIS) " +
+                                    "select tb_1_.c1, ? from (" +
+                                    "select tb_1_.NAME c1 from DEPARTMENT tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?" +
+                                    ") tb_1_ " +
+                                    "on duplicate key update DELETED_MILLIS = DELETED_MILLIS"
+                    ));
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlInsertIfAbsentForGuaranteedSingleKeyUsesMaterializedPlan() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new MySqlDialect()));
+        DepartmentTable table = DepartmentTable.$;
+        BaseTable1<StringExpression> source = sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(1L))
+                .addSelect(table.name())
+                .asBaseTable();
+        executeAndExpectRowCount(
+                sqlClient
+                        .createInsert(table, source)
+                        .set(table.name(), source.get_1())
+                        .onConflictDoNothing(table.name()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, ? from (" +
+                                    "select tb_1_.NAME c1 from DEPARTMENT tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME " +
+                                    "from DEPARTMENT tb_1_ " +
+                                    "where tb_1_.NAME = ? and tb_1_.DELETED_MILLIS = ?"
+                    ));
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlMaterializedUpsertDoesNotPreselectGuaranteedSingleKeyConstraint() {
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new MySqlDialect());
+            it.setExecutor(new Executor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <R> R execute(Args<R> args) {
+                    getExecutions().add(Execution.simple(args.sql, args.purpose, args.variables));
+                    if (args.sql.startsWith("insert into DEPARTMENT")) {
+                        return (R) Integer.valueOf(0);
+                    }
+                    return DefaultExecutor.INSTANCE.execute(args);
+                }
+
+                @Override
+                public BatchContext executeBatch(
+                        Connection con,
+                        String sql,
+                        ImmutableProp generatedIdProp,
+                        ExecutionPurpose purpose,
+                        JSqlClientImplementor sqlClient,
+                        boolean constraintViolationTranslatable
+                ) {
+                    throw new AssertionError("Batch execution is not expected");
+                }
+            });
+        });
+        DepartmentTable table = DepartmentTable.$;
+        BaseTable1<StringExpression> source = sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(1L))
+                .addSelect(table.name())
+                .asBaseTable();
+        connectAndExpect(
+                con -> sqlClient
+                        .createUpsert(table, source)
+                        .key(table.name(), source.get_1())
+                        .returning(table.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, ? from (" +
+                                    "select tb_1_.NAME c1 from DEPARTMENT tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.DELETED_MILLIS = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "insert into DEPARTMENT(NAME, DELETED_MILLIS) values(?, ?) " +
+                                    "on duplicate key update " +
+                                    "/* fake update to return all ids */ ID = last_insert_id(ID)"
+                    ));
+                    ctx.value(rows -> assertEquals(singletonList("Market"), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertOnConflictDoNothingReturningOnlyInsertedRows() {
+        UUID insertedId = UUID.fromString("a0000000-0000-0000-0000-000000000013");
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> conflictingRow = getSqlClient()
+                .createBaseQuery()
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(Expression.value(oreillyId))
+                                .name(Expression.value("CONFLICTING"))
+                );
+        ConfigurableBaseQuery<BookUpdateReturningTupleTable> insertedRow = getSqlClient()
+                .createBaseQuery()
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(Expression.value(insertedId))
+                                .name(Expression.value("INSERTED"))
+                );
+        BookUpdateReturningTupleTable source = TypedBaseQuery.unionAll(conflictingRow, insertedRow).asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.getId())
+                        .set(table.name(), source.getName())
+                        .onConflictDoNothing(table.id())
+                        .returning(table.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select NAME from final table (" +
+                                        "merge into BOOK_STORE tb_2_ using (" +
+                                        "select cast(? as char(36)) as c1, cast(? as varchar) as c2 " +
+                                        "union all " +
+                                        "select cast(? as char(36)) as c1, cast(? as varchar) as c2" +
+                                        ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                                        "when not matched then insert(ID, NAME, VERSION) " +
+                                        "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                        ")"
+                        );
+                        it.variables(oreillyId, "CONFLICTING", insertedId, "INSERTED", 0);
+                    });
+                    ctx.value(rows -> assertEquals(singletonList("INSERTED"), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertReturning() {
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                source(oreillyId, "O'REILLY+", 0);
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .insert(table.version(), source.get_3())
+                        .returning(table.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select NAME from final table (" +
+                                    "merge into BOOK_STORE tb_2_ using " + rootlessSql() + " tb_1_ " +
+                                    "on tb_2_.ID = tb_1_.c1 " +
+                                    "when matched then update set tb_2_.NAME = tb_1_.c2 " +
+                                    "when not matched then insert(ID, NAME, VERSION) " +
+                                    "values(tb_1_.c1, tb_1_.c2, tb_1_.c3)" +
+                                    ")"
+                    ));
+                    ctx.value(rows -> assertEquals(singletonList("O'REILLY+"), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertReturningTypedTuple() {
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                source(oreillyId, "O'REILLY-TUPLE", 0);
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .insert(table.version(), source.get_3())
+                        .returning(
+                                BookUpdateReturningTupleMapper
+                                        .id(table.id())
+                                        .name(table.name())
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID, NAME from final table (" +
+                                    "merge into BOOK_STORE tb_2_ using " + rootlessSql() + " tb_1_ " +
+                                    "on tb_2_.ID = tb_1_.c1 " +
+                                    "when matched then update set tb_2_.NAME = tb_1_.c2 " +
+                                    "when not matched then insert(ID, NAME, VERSION) " +
+                                    "values(tb_1_.c1, tb_1_.c2, tb_1_.c3)" +
+                                    ")"
+                    ));
+                    ctx.value((java.util.List<BookUpdateReturningTuple> rows) -> {
+                        assertEquals(1, rows.size());
+                        assertEquals(oreillyId, rows.get(0).getId());
+                        assertEquals("O'REILLY-TUPLE", rows.get(0).getName());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertWithCustomMergeExpressionAndUpdateWhere() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(oreillyId))
+                .addSelect(Expression.value("+"))
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(
+                                table.name(),
+                                source.get_2(),
+                                table.name().concat(source.get_2())
+                        )
+                        .updateWhere(source.get_2().ne(table.name()))
+                        .returning(table.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select NAME from final table (" +
+                                    "merge into BOOK_STORE tb_2_ using (" +
+                                    "select cast(? as char(36)) as c1, cast(? as varchar) as c2" +
+                                    ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                                    "when matched and tb_1_.c2 <> tb_2_.NAME " +
+                                    "then update set tb_2_.NAME = concat(tb_2_.NAME, tb_1_.c2) " +
+                                    "when not matched then insert(ID, NAME, VERSION) " +
+                                    "values(tb_1_.c1, tb_1_.c2, ?)" +
+                                    ")"
+                    ));
+                    ctx.value(rows -> assertEquals(singletonList("O'REILLY+"), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testNativeUpdateWhereRejectionReturning() {
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                source(oreillyId, "REJECTED", 0);
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .merge(table.name(), source.get_2())
+                        .insert(table.version(), source.get_3())
+                        .updateWhere(source.get_2().eq(table.name()))
+                        .returning(table.name())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select NAME from final table (" +
+                                        "merge into BOOK_STORE tb_2_ using " + rootlessSql() + " tb_1_ " +
+                                        "on tb_2_.ID = tb_1_.c1 " +
+                                        "when matched and tb_1_.c2 = tb_2_.NAME " +
+                                        "then update set tb_2_.NAME = tb_1_.c2 " +
+                                        "when not matched then insert(ID, NAME, VERSION) " +
+                                        "values(tb_1_.c1, tb_1_.c2, tb_1_.c3)" +
+                                        ")"
+                        );
+                        it.variables(oreillyId, "REJECTED", 0);
+                    });
+                    ctx.value(rows -> assertEquals(emptyList(), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testMaterializedUpsertWithCustomMergeExpressionAndUpdateWhere() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookStoreTable sourceStore = BookStoreTable.$;
+        BookUpdateReturningTupleTable source = sqlClient
+                .createBaseQuery(sourceStore)
+                .where(sourceStore.id().eq(oreillyId))
+                .select(
+                        BookUpdateReturningTupleMapper
+                                .id(sourceStore.id())
+                                .name(sourceStore.name().concat("+"))
+                )
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        jdbc(con -> {
+            java.util.List<String> rows = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.getId())
+                    .merge(
+                            table.name(),
+                            source.getName(),
+                            table.name().concat(source.getName())
+                    )
+                    .updateWhere(source.getName().ne(table.name()))
+                    .returning(table.name())
+                    .execute(con);
+            assertEquals(singletonList("O'REILLYO'REILLY+"), rows);
+        });
+    }
+
+    @Test
+    public void testValidation() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(oreillyId))
+                .addSelect(Expression.value("VALUE"))
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        assertThrows(
+                IllegalStateException.class,
+                () -> getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.id(), source.get_1())
+        );
+        jdbc(con -> {
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> getSqlClient()
+                            .createUpsert(table, source)
+                            .insert(table.id(), source.get_1())
+                            .execute(con)
+            );
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .createInsert(table, source)
+                            .set(table.id(), source.get_1())
+                            .onConflictDoNothing(table.name())
+                            .execute(con)
+            );
+        });
+    }
+
+    @Test
+    public void testFakeUpsertReturning() {
+        BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source =
+                source(oreillyId, "UNUSED", 0);
+        BookStoreTable table = BookStoreTable.$;
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createUpsert(table, source)
+                        .key(table.id(), source.get_1())
+                        .returning(table.id())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into BOOK_STORE tb_2_ using " + rootlessIdSql() + " tb_1_ " +
+                                    "on tb_2_.ID = tb_1_.c1 " +
+                                    "when matched then update set tb_2_.VERSION = tb_2_.VERSION " +
+                                    "when not matched then insert(ID, VERSION) values(tb_1_.c1, ?)" +
+                                    ")"
+                    ));
+                    ctx.value(rows -> assertEquals(singletonList(oreillyId), rows));
+                }
+        );
+    }
+
+    @Test
+    public void testAssociationInsertAndReturning() {
+        BaseTable2<ComparableExpression<UUID>, ComparableExpression<UUID>> source =
+                getSqlClient()
+                        .createBaseQuery()
+                        .addSelect(Expression.value(effectiveTypeScriptId1))
+                        .addSelect(Expression.value(alexId))
+                        .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> association =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        connectAndExpect(
+                con -> getSqlClient()
+                        .createInsert(association, source)
+                        .set(association.sourceId(), source.get_1())
+                        .set(association.targetId(), source.get_2())
+                        .returning(association.sourceId(), association.targetId())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select BOOK_ID, AUTHOR_ID from final table (" +
+                                    "insert into BOOK_AUTHOR_MAPPING(BOOK_ID, AUTHOR_ID) " +
+                                    "select tb_1_.c1, tb_1_.c2 from (" +
+                                    "select cast(? as char(36)) as c1, cast(? as char(36)) as c2" +
+                                    ") tb_1_" +
+                                    ")"
+                    ));
+                    ctx.value(rows -> assertEquals(1, rows.size()));
+                }
+        );
+    }
+
+    @Test
+    public void testMaterializedAssociationReturning() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BaseTable2<ComparableExpression<UUID>, ComparableExpression<UUID>> source = sqlClient
+                .createBaseQuery()
+                .addSelect(Expression.comparable().sql(
+                        UUID.class,
+                        "cast('" + effectiveTypeScriptId1 + "' as char(36))"
+                ))
+                .addSelect(Expression.comparable().sql(
+                        UUID.class,
+                        "cast('" + alexId + "' as char(36))"
+                ))
+                .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> association =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        connectAndExpect(
+                con -> sqlClient
+                        .createInsert(association, source)
+                        .set(association.sourceId(), source.get_1())
+                        .set(association.targetId(), source.get_2())
+                        .returning(association.sourceId(), association.targetId())
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2 from (" +
+                                    "select cast('" + effectiveTypeScriptId1 + "' as char(36)) as c1, " +
+                                    "cast('" + alexId + "' as char(36)) as c2" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> {
+                        it.sql("insert into BOOK_AUTHOR_MAPPING(BOOK_ID, AUTHOR_ID) values(?, ?)");
+                        it.variables(effectiveTypeScriptId1, alexId);
+                    });
+                    ctx.value(rows -> assertEquals(
+                            singletonList(new Tuple2<>(effectiveTypeScriptId1, alexId)),
+                            rows
+                    ));
+                }
+        );
+    }
+
+    @Test
+    public void testAssociationBaseQueryAndInsertOverloads() {
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> sourceAssociation =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        BaseTable2<Expression<UUID>, Expression<UUID>> source =
+                getSqlClient()
+                        .createBaseQuery(sourceAssociation)
+                        .where(
+                                sourceAssociation.<UUID>sourceId().eq(learningGraphQLId1),
+                                sourceAssociation.<UUID>targetId().eq(alexId)
+                        )
+                        .addSelect(sourceAssociation.<UUID>sourceId())
+                        .addSelect(sourceAssociation.<UUID>targetId())
+                        .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> targetAssociation =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(targetAssociation, source)
+                        .set(targetAssociation.sourceId(), source.get_1())
+                        .set(targetAssociation.targetId(), source.get_2())
+                        .onConflictDoNothing(),
+                ctx -> {
+                    ctx.statement(it -> {
+                    });
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testAssociationInsertIfAbsent() {
+        BaseTable2<ComparableExpression<UUID>, ComparableExpression<UUID>> source =
+                getSqlClient()
+                        .createBaseQuery()
+                        .addSelect(Expression.value(learningGraphQLId1))
+                        .addSelect(Expression.value(alexId))
+                        .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> association =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        executeAndExpectRowCount(
+                getSqlClient()
+                        .createInsert(association, source)
+                        .set(association.sourceId(), source.get_1())
+                        .set(association.targetId(), source.get_2())
+                        .onConflictDoNothing(),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "merge into BOOK_AUTHOR_MAPPING tb_2_ using (" +
+                                    "select cast(? as char(36)) as c1, cast(? as char(36)) as c2" +
+                                    ") tb_1_ on tb_2_.BOOK_ID = tb_1_.c1 and tb_2_.AUTHOR_ID = tb_1_.c2 " +
+                                    "when not matched then insert(BOOK_ID, AUTHOR_ID) values(tb_1_.c1, tb_1_.c2)"
+                    ));
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlAssociationInsertIfAbsentUsesMaterializedPlan() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new MySqlDialect()));
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> sourceAssociation =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        BaseTable2<Expression<UUID>, Expression<UUID>> source = sqlClient
+                .createBaseQuery(sourceAssociation)
+                .where(
+                        sourceAssociation.<UUID>sourceId().eq(learningGraphQLId1),
+                        sourceAssociation.<UUID>targetId().eq(alexId)
+                )
+                .addSelect(sourceAssociation.<UUID>sourceId())
+                .addSelect(sourceAssociation.<UUID>targetId())
+                .asBaseTable();
+        AssociationTable<Book, BookTableEx, Author, AuthorTableEx> targetAssociation =
+                AssociationTable.of(BookTableEx.class, BookTableEx::authors);
+        executeAndExpectRowCount(
+                sqlClient
+                        .createInsert(targetAssociation, source)
+                        .set(targetAssociation.sourceId(), source.get_1())
+                        .set(targetAssociation.targetId(), source.get_2())
+                        .onConflictDoNothing(),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2 from (" +
+                                    "select tb_2_.BOOK_ID c1, tb_2_.AUTHOR_ID c2 " +
+                                    "from BOOK_AUTHOR_MAPPING tb_2_ " +
+                                    "where tb_2_.BOOK_ID = ? and tb_2_.AUTHOR_ID = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select AUTHOR_ID from BOOK_AUTHOR_MAPPING " +
+                                    "where (BOOK_ID, AUTHOR_ID) = (?, ?)"
+                    ));
+                    ctx.rowCount(0);
+                }
+        );
+    }
+
+    @Test
+    public void testH2NullableKeyUpsertUsesMaterializedPlan() {
+        testNullableTreeNodeKeyUpsert(getSqlClient(it -> it.setDialect(new H2Dialect())));
+    }
+
+    @Test
+    public void testMySqlNullableKeyUpsertUsesMaterializedPlan() {
+        testNullableTreeNodeKeyUpsert(
+                getSqlClient(it -> it
+                        .setDialect(new MySqlDialect())
+                        .setIdGenerator(TreeNode.class, IdentityIdGenerator.INSTANCE))
+        );
+    }
+
+    private void testNullableTreeNodeKeyUpsert(JSqlClient sqlClient) {
+        TreeNodeTable table = TreeNodeTable.$;
+        BaseTable2<StringExpression, NumericExpression<Long>> source = sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(1L))
+                .addSelect(table.name())
+                .addSelect(table.parentId())
+                .asBaseTable();
+        executeAndExpectRowCount(
+                sqlClient
+                        .createUpsert(table, source)
+                        .key(table.name(), source.get_1())
+                        .key(table.parentId(), source.get_2()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.c1, tb_1_.c2 from (" +
+                                    "select tb_1_.NAME c1, tb_1_.PARENT_ID c2 " +
+                                    "from TREE_NODE tb_1_ where tb_1_.NODE_ID = ?" +
+                                    ") tb_1_"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.NODE_ID, tb_1_.NAME, tb_1_.PARENT_ID " +
+                                    "from TREE_NODE tb_1_ " +
+                                    "where tb_1_.PARENT_ID is null and tb_1_.NAME = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update TREE_NODE set " +
+                                    "/* fake update to return all ids */ PARENT_ID = PARENT_ID " +
+                                    "where NODE_ID = ?"
+                    ));
+                    ctx.rowCount(1);
+                }
+        );
+    }
+
+    private BaseTable3<ComparableExpression<UUID>, StringExpression, NumericExpression<Integer>> source(
+            UUID id,
+            String name,
+            int version
+    ) {
+        return getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(id))
+                .addSelect(Expression.value(name))
+                .addSelect(Expression.value(version))
+                .asBaseTable();
+    }
+
+    private static String rootlessSql() {
+        return "(select " +
+                "cast(? as char(36)) as c1, " +
+                "cast(? as varchar) as c2, " +
+                "cast(? as int) as c3" +
+                ")";
+    }
+
+    private static String rootlessIdSql() {
+        return "(select cast(? as char(36)) as c1)";
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectValidationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectValidationTest.java
@@ -1,0 +1,215 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.ast.*;
+import org.babyfish.jimmer.sql.ast.mutation.MutableInsert;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable1;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.babyfish.jimmer.sql.common.Constants.oreillyId;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InsertFromSelectValidationTest extends AbstractMutationTest {
+
+    @Test
+    public void testStrictInsertDoesNotSuppressConflict() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "CONFLICT");
+        BookStoreTable table = BookStoreTable.$;
+        jdbc(con -> assertThrows(
+                RuntimeException.class,
+                () -> getSqlClient()
+                        .createInsert(table, source)
+                        .set(table.id(), source.get_1())
+                        .set(table.name(), source.get_2())
+                        .execute(con)
+        ));
+    }
+
+    @Test
+    public void testAssignmentMustBelongToTarget() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "VALUE");
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient()
+                        .createInsert(BookStoreTable.$, source)
+                        .set(BookTable.$.id(), source.get_1())
+        );
+        assertTrue(ex.getMessage().contains("does not belong to the mutation target"));
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testAssignmentTypesMustMatch() {
+        BaseTable1<NumericExpression<Integer>> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(1))
+                .asBaseTable();
+        MutableInsert raw = getSqlClient().createInsert(BookStoreTable.$, source);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> raw.set(
+                        BookStoreTable.$.name(),
+                        source.get_1()
+                )
+        );
+        assertTrue(ex.getMessage().contains("is incompatible with target expression type"));
+    }
+
+    @Test
+    public void testExplicitConflictTargetValidation() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "VALUE");
+        BookStoreTable store = BookStoreTable.$;
+
+        IllegalArgumentException wrongTable = assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient()
+                        .createInsert(store, source)
+                        .set(store.id(), source.get_1())
+                        .onConflictDoNothing(BookTable.$.id())
+        );
+        assertTrue(wrongTable.getMessage().contains("does not belong to the mutation target"));
+
+        jdbc(con -> {
+            IllegalArgumentException duplicate = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .createInsert(store, source)
+                            .set(store.id(), source.get_1())
+                            .set(store.name(), source.get_2())
+                            .onConflictDoNothing(store.id(), store.id())
+                            .execute(con)
+            );
+            assertTrue(duplicate.getMessage().contains("Duplicate conflict target property"));
+
+            IllegalArgumentException unassigned = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .createInsert(store, source)
+                            .set(store.id(), source.get_1())
+                            .onConflictDoNothing(store.name())
+                            .execute(con)
+            );
+            assertTrue(unassigned.getMessage().contains("has no insert assignment"));
+        });
+    }
+
+    @Test
+    public void testExplicitlyEmptyConflictTargetIsRejected() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "VALUE");
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient()
+                        .createInsert(BookStoreTable.$, source)
+                        .onConflictDoNothing(new PropExpression<?>[0])
+        );
+        assertEquals(
+                "Explicit conflict properties cannot be empty; use onConflictDoNothing() for inference",
+                ex.getMessage()
+        );
+    }
+
+    @Test
+    public void testConflictTargetMustBeUnique() {
+        BaseTable1<NumericExpression<BigDecimal>> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(new BigDecimal("12.34")))
+                .asBaseTable();
+        BookTable table = BookTable.$;
+        jdbc(con -> {
+            IllegalArgumentException ex = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .createInsert(table, source)
+                            .set(table.price(), source.get_1())
+                            .onConflictDoNothing(table.price())
+                            .execute(con)
+            );
+            assertTrue(ex.getMessage().contains("do not uniquely identify a target row"));
+        });
+    }
+
+    @Test
+    public void testConflictTargetInferenceCanFail() {
+        BaseTable1<NumericExpression<Integer>> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(7))
+                .asBaseTable();
+        BookStoreTable table = BookStoreTable.$;
+        jdbc(con -> {
+            IllegalStateException ex = assertThrows(
+                    IllegalStateException.class,
+                    () -> getSqlClient()
+                            .createInsert(table, source)
+                            .set(table.version(), source.get_1())
+                            .onConflictDoNothing()
+                            .execute(con)
+            );
+            assertTrue(ex.getMessage().contains("Cannot infer an eligible conflict key"));
+        });
+    }
+
+    @Test
+    public void testUpsertRequiresUniqueAssignedKey() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "VALUE");
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> {
+            IllegalStateException noKey = assertThrows(
+                    IllegalStateException.class,
+                    () -> getSqlClient()
+                            .createUpsert(store, source)
+                            .insert(store.id(), source.get_1())
+                            .merge(store.name(), source.get_2())
+                            .execute(con)
+            );
+            assertTrue(noKey.getMessage().contains("At least one key assignment is required"));
+        });
+    }
+
+    @Test
+    public void testReturningSelectionMustBelongToTarget() {
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = uuidAndString(oreillyId, "VALUE");
+        BookStoreTable store = BookStoreTable.$;
+        jdbc(con -> {
+            IllegalArgumentException ex = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .createInsert(store, source)
+                            .set(store.id(), source.get_1())
+                            .set(store.name(), source.get_2())
+                            .returning(BookTable.$.id())
+                            .execute(con)
+            );
+            assertTrue(ex.getMessage().contains("does not belong to the mutation target"));
+        });
+    }
+
+    @Test
+    public void testJoinedTableInheritanceTargetIsRejected() {
+        BaseTable1<NumericExpression<Long>> source = getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(1L))
+                .asBaseTable();
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> getSqlClient().createInsert(
+                        org.babyfish.jimmer.sql.model.inheritance.joinedtable.OrganizationTable.$,
+                        source
+                )
+        );
+        assertTrue(ex.getMessage().contains("does not support joined-inheritance target type"));
+    }
+
+    private BaseTable2<ComparableExpression<UUID>, StringExpression> uuidAndString(UUID id, String value) {
+        return getSqlClient()
+                .createBaseQuery()
+                .addSelect(Expression.value(id))
+                .addSelect(Expression.value(value))
+                .asBaseTable();
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectVersionTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/InsertFromSelectVersionTest.java
@@ -1,0 +1,432 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.meta.ImmutableProp;
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.ComparableExpression;
+import org.babyfish.jimmer.sql.ast.NumericExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable1;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.dialect.*;
+import org.babyfish.jimmer.sql.event.EntityEvent;
+import org.babyfish.jimmer.sql.event.TriggerType;
+import org.babyfish.jimmer.sql.model.BookStore;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.babyfish.jimmer.sql.runtime.DefaultExecutor;
+import org.babyfish.jimmer.sql.runtime.ExecutionPurpose;
+import org.babyfish.jimmer.sql.runtime.Executor;
+import org.babyfish.jimmer.sql.runtime.JSqlClientImplementor;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.babyfish.jimmer.sql.common.Constants.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class InsertFromSelectVersionTest extends AbstractMutationTest {
+
+    @Test
+    public void testImplicitVersionIsEquivalentForNativeAndMaterializedPlans() {
+        JSqlClient nativeClient = getSqlClient();
+        JSqlClient materializedClient = materializedH2Client();
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            setStoreVersion(con, oreillyId, 5);
+            setStoreVersion(con, manningId, 5);
+            clearExecutions();
+
+            BaseTable2<ComparableExpression<UUID>, StringExpression> nativeSource = nameSource(
+                    nativeClient,
+                    oreillyId,
+                    "-NATIVE"
+            );
+            BaseTable2<ComparableExpression<UUID>, StringExpression> materializedSource = nameSource(
+                    materializedClient,
+                    manningId,
+                    "-MATERIALIZED"
+            );
+            List<Integer> nativeVersions = nativeClient
+                    .createUpsert(table, nativeSource)
+                    .key(table.id(), nativeSource.get_1())
+                    .merge(table.name(), nativeSource.get_2())
+                    .returning(table.version())
+                    .execute(con);
+            List<Integer> materializedVersions = materializedClient
+                    .createUpsert(table, materializedSource)
+                    .key(table.id(), materializedSource.get_1())
+                    .merge(table.name(), materializedSource.get_2())
+                    .returning(table.version())
+                    .execute(con);
+
+            assertEquals(singletonList(5), nativeVersions);
+            assertEquals(nativeVersions, materializedVersions);
+            assertEquals(asList("O'REILLY-NATIVE", 5), storeNameAndVersion(con, oreillyId));
+            assertEquals(asList("MANNING-MATERIALIZED", 5), storeNameAndVersion(con, manningId));
+            assertExecutedSql(
+                    "select VERSION from final table (" +
+                            "merge into BOOK_STORE tb_2_ using (" +
+                            "select tb_1_.ID c1, concat(tb_1_.NAME, ?) c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_ on tb_2_.ID = tb_1_.c1 " +
+                            "when matched then update set tb_2_.NAME = tb_1_.c2 " +
+                            "when not matched then insert(ID, NAME, VERSION) " +
+                            "values(tb_1_.c1, tb_1_.c2, ?))",
+                    "select tb_1_.c1, tb_1_.c2, ? from (" +
+                            "select tb_1_.ID c1, concat(tb_1_.NAME, ?) c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "merge into BOOK_STORE tb_1_ " +
+                            "using(values(?, ?, ?)) tb_2_(ID, NAME, VERSION) " +
+                            "on tb_1_.ID = tb_2_.ID " +
+                            "when matched then update set NAME = tb_2_.NAME " +
+                            "when not matched then insert(ID, NAME, VERSION) " +
+                            "values(tb_2_.ID, tb_2_.NAME, tb_2_.VERSION)",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMaterializedInsertOnlyVersionDoesNotChangeMatchedRow() {
+        JSqlClient sqlClient = materializedH2Client();
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            setStoreVersion(con, oreillyId, 5);
+            clearExecutions();
+
+            BaseTable2<ComparableExpression<UUID>, NumericExpression<Integer>> source = versionSource(
+                    sqlClient,
+                    oreillyId,
+                    4
+            );
+            List<Integer> versions = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .insert(table.version(), source.get_2())
+                    .returning(table.version())
+                    .execute(con);
+
+            assertEquals(singletonList(5), versions);
+            assertEquals(asList("O'REILLY", 5), storeNameAndVersion(con, oreillyId));
+            assertExecutedSql(
+                    "select tb_1_.c1, tb_1_.c2 from (" +
+                            "select tb_1_.ID c1, tb_1_.VERSION + ? c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "merge into BOOK_STORE tb_1_ " +
+                            "using(values(?, ?)) tb_2_(ID, VERSION) " +
+                            "on tb_1_.ID = tb_2_.ID " +
+                            "when matched then update set " +
+                            "/* fake update to return all ids */ VERSION = tb_1_.VERSION " +
+                            "when not matched then insert(ID, VERSION) " +
+                            "values(tb_2_.ID, tb_2_.VERSION)",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMaterializedMergeVersionWritesSourceValue() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            setStoreVersion(con, oreillyId, 5);
+            clearExecutions();
+
+            BaseTable2<ComparableExpression<UUID>, NumericExpression<Integer>> source = versionSource(
+                    sqlClient,
+                    oreillyId,
+                    4
+            );
+            List<Integer> versions = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .merge(table.version(), source.get_2())
+                    .returning(table.version())
+                    .execute(con);
+
+            assertEquals(singletonList(9), versions);
+            assertEquals(asList("O'REILLY", 9), storeNameAndVersion(con, oreillyId));
+            assertExecutedSql(
+                    "select tb_1_.c1, tb_1_.c2 from (" +
+                            "select tb_1_.ID c1, tb_1_.VERSION + ? c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?",
+                    "update BOOK_STORE set VERSION = ? where ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMaterializedFakeUpsertEventKeepsDatabaseVersion() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setTriggerType(TriggerType.TRANSACTION_ONLY));
+        AtomicReference<EntityEvent<?>> eventRef = new AtomicReference<>();
+        sqlClient.getTriggers(true).addEntityListener(BookStore.class, eventRef::set);
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            setStoreVersion(con, oreillyId, 5);
+            clearExecutions();
+
+            BaseTable2<ComparableExpression<UUID>, NumericExpression<Integer>> source = versionSource(
+                    sqlClient,
+                    oreillyId,
+                    4
+            );
+            int affectedRowCount = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .insert(table.version(), source.get_2())
+                    .execute(con);
+
+            assertEquals(1, affectedRowCount);
+            EntityEvent<?> event = eventRef.get();
+            assertNotNull(event);
+            assertEquals(5, ((BookStore) event.getOldEntity()).version());
+            assertEquals(5, ((BookStore) event.getNewEntity()).version());
+            assertEquals(asList("O'REILLY", 5), storeNameAndVersion(con, oreillyId));
+            assertExecutedSql(
+                    "select tb_1_.c1, tb_1_.c2 from (" +
+                            "select tb_1_.ID c1, tb_1_.VERSION + ? c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?",
+                    "update BOOK_STORE set " +
+                            "/* fake update to return all ids */ VERSION = VERSION " +
+                            "where ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMySqlMaterializedFakeUpsertReturningDoesNotDependOnChangedRowCount() {
+        JSqlClient sqlClient = getSqlClient(it -> {
+            it.setDialect(new MySqlDialect());
+            it.setExecutor(new Executor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <R> R execute(Args<R> args) {
+                    getExecutions().add(Execution.simple(args.sql, args.purpose, args.variables));
+                    R result = DefaultExecutor.INSTANCE.execute(args);
+                    if (args.sql.startsWith("update BOOK_STORE set /* fake update to return all ids */")) {
+                        return (R) Integer.valueOf(0);
+                    }
+                    return result;
+                }
+
+                @Override
+                public BatchContext executeBatch(
+                        Connection con,
+                        String sql,
+                        ImmutableProp generatedIdProp,
+                        ExecutionPurpose purpose,
+                        JSqlClientImplementor sqlClient,
+                        boolean constraintViolationTranslatable
+                ) {
+                    throw new AssertionError("Batch execution is not expected");
+                }
+            });
+        });
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            clearExecutions();
+            BaseTable1<ComparableExpression<UUID>> source = sqlClient
+                    .createBaseQuery(table)
+                    .where(table.id().eq(oreillyId))
+                    .addSelect(table.id())
+                    .asBaseTable();
+            List<UUID> ids = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .returning(table.id())
+                    .execute(con);
+
+            assertEquals(singletonList(oreillyId), ids);
+            assertExecutedSql(
+                    "select tb_1_.c1, ? from (" +
+                            "select tb_1_.ID c1 from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?",
+                    "update BOOK_STORE set " +
+                            "/* fake update to return all ids */ VERSION = VERSION " +
+                            "where ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMaterializedCustomMergeCanCheckAndIncreaseVersion() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        BookStoreTable table = BookStoreTable.$;
+
+        jdbc(con -> {
+            setStoreVersion(con, oreillyId, 5);
+            clearExecutions();
+
+            BaseTable2<ComparableExpression<UUID>, NumericExpression<Integer>> source = versionSource(
+                    sqlClient,
+                    oreillyId,
+                    0
+            );
+            List<Integer> versions = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .merge(
+                            table.version(),
+                            source.get_2(),
+                            table.version().plus(1)
+                    )
+                    .updateWhere(source.get_2().eq(table.version()))
+                    .returning(table.version())
+                    .execute(con);
+
+            assertEquals(singletonList(6), versions);
+            assertEquals(asList("O'REILLY", 6), storeNameAndVersion(con, oreillyId));
+            assertExecutedSql(
+                    "select tb_1_.c1, tb_1_.c2 from (" +
+                            "select tb_1_.ID c1, tb_1_.VERSION c2 " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?",
+                    "select tb_1_.ID from BOOK_STORE tb_1_ " +
+                            "where tb_1_.ID = ? and ? = tb_1_.VERSION",
+                    "update BOOK_STORE set VERSION = VERSION + ? " +
+                            "where ID = ? and ? = VERSION",
+                    "select tb_1_.ID, tb_1_.NAME, tb_1_.WEBSITE, tb_1_.VERSION " +
+                            "from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+            );
+        });
+    }
+
+    @Test
+    public void testMaterializedFakeUpsertWithoutVersionIsAccepted() {
+        JSqlClient sqlClient = materializedH2Client();
+        BookTable table = BookTable.$;
+
+        jdbc(con -> {
+            clearExecutions();
+            BaseTable1<ComparableExpression<UUID>> source = sqlClient
+                    .createBaseQuery(table)
+                    .where(table.id().eq(effectiveTypeScriptId1))
+                    .addSelect(table.id())
+                    .asBaseTable();
+            List<UUID> ids = sqlClient
+                    .createUpsert(table, source)
+                    .key(table.id(), source.get_1())
+                    .returning(table.id())
+                    .execute(con);
+
+            assertEquals(singletonList(effectiveTypeScriptId1), ids);
+            assertExecutedSql(
+                    "select tb_1_.c1 from (" +
+                            "select tb_1_.ID c1 from BOOK tb_1_ where tb_1_.ID = ?" +
+                            ") tb_1_",
+                    "merge into BOOK tb_1_ using(values(?)) tb_2_(ID) " +
+                            "on tb_1_.ID = tb_2_.ID " +
+                            "when matched then update set " +
+                            "/* fake update to return all ids */ PRICE = tb_1_.PRICE " +
+                            "when not matched then insert(ID) values(tb_2_.ID)"
+            );
+        });
+    }
+
+    private static BaseTable2<ComparableExpression<UUID>, StringExpression> nameSource(
+            JSqlClient sqlClient,
+            UUID id,
+            String name
+    ) {
+        BookStoreTable table = BookStoreTable.$;
+        return sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(id))
+                .addSelect(table.id())
+                .addSelect(table.name().concat(name))
+                .asBaseTable();
+    }
+
+    private JSqlClient materializedH2Client() {
+        return getSqlClient(it -> it.setDialect(new H2Dialect() {
+            private final InsertFromSelectRenderer renderer = new InsertFromSelectRenderer() {
+                @Override
+                public boolean isSupported(InsertFromSelectContext ctx) {
+                    return false;
+                }
+
+                @Override
+                public void render(InsertFromSelectContext ctx) {
+                    throw new AssertionError("The unsupported renderer must not be invoked");
+                }
+            };
+
+            @Override
+            public InsertFromSelectRenderer getInsertFromSelectRenderer() {
+                return renderer;
+            }
+        }));
+    }
+
+    private static BaseTable2<ComparableExpression<UUID>, NumericExpression<Integer>> versionSource(
+            JSqlClient sqlClient,
+            UUID id,
+            int increment
+    ) {
+        BookStoreTable table = BookStoreTable.$;
+        return sqlClient
+                .createBaseQuery(table)
+                .where(table.id().eq(id))
+                .addSelect(table.id())
+                .addSelect(increment != 0 ? table.version().plus(increment) : table.version())
+                .asBaseTable();
+    }
+
+    private static void setStoreVersion(Connection con, UUID id, int version) throws SQLException {
+        try (PreparedStatement stmt = con.prepareStatement(
+                "update BOOK_STORE set VERSION = ? where ID = ?"
+        )) {
+            stmt.setInt(1, version);
+            stmt.setObject(2, id);
+            assertEquals(1, stmt.executeUpdate());
+        }
+    }
+
+    private static List<Object> storeNameAndVersion(Connection con, UUID id) throws SQLException {
+        try (PreparedStatement stmt = con.prepareStatement(
+                "select NAME, VERSION from BOOK_STORE where ID = ?"
+        )) {
+            stmt.setObject(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                return asList(rs.getString(1), rs.getInt(2));
+            }
+        }
+    }
+
+    private void assertExecutedSql(String... expectedSql) {
+        List<String> actualSql = new ArrayList<>();
+        getExecutions().forEach(it -> actualSql.add(it.getSql()));
+        assertEquals(asList(expectedSql), actualSql);
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/ModifiedFetcherTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/ModifiedFetcherTest.java
@@ -505,7 +505,7 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testSaveReturningByUserOptimisticLock() {
+    public void testSaveReturningByOptimisticLockCondition() {
         connectAndExpect(
                 con -> getSqlClient(it -> it.setDialect(new H2Dialect()))
                         .saveCommand(Immutables.createBook(draft -> {
@@ -629,7 +629,7 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testSaveReturningByUserOptimisticLockFailed() {
+    public void testSaveReturningByOptimisticLockConditionFailed() {
         connectAndExpect(
                 con -> getSqlClient(it -> it.setDialect(new H2Dialect()))
                         .saveCommand(Immutables.createBook(draft -> {
@@ -1465,7 +1465,7 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUpsertReturnDraftByUserOptimisticLockByPostgres() {
+    public void testUpsertReturnDraftByOptimisticLockConditionByPostgres() {
         NativeDatabases.assumeNativeDatabase();
 
         connectAndExpect(
@@ -1513,7 +1513,7 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUpsertByUserOptimisticLockWithoutReturningByPostgres() {
+    public void testUpsertByOptimisticLockConditionWithoutReturningByPostgres() {
         NativeDatabases.assumeNativeDatabase();
 
         connectAndExpect(
@@ -1801,17 +1801,9 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
                                         "--->insert(NAME, DELETED_MILLIS) values(tb_2_.NAME, tb_2_.DELETED_MILLIS)"
                         );
                     });
-                    ctx.statement(it -> {
-                        it.queryReason(QueryReason.FETCHER);
-                        it.sql(
-                                "select tb_1_.ID, tb_1_.NAME " +
-                                        "from DEPARTMENT tb_1_ " +
-                                        "where tb_1_.NAME = ? and tb_1_.DELETED_MILLIS = ?"
-                        );
-                    });
                     ctx.value(
                             "{" +
-                                    "--->\"id\":\"1\",\"name\":\"Market\"" +
+                                    "--->\"name\":\"Market\"" +
                                     "}");
                 }
         );
@@ -1852,17 +1844,9 @@ public class ModifiedFetcherTest extends AbstractMutationTest {
                                         "--->insert(NAME, DELETED_MILLIS) values(tb_2_.NAME, tb_2_.DELETED_MILLIS)"
                         );
                     });
-                    ctx.statement(it -> {
-                        it.queryReason(QueryReason.FETCHER);
-                        it.sql(
-                                "select tb_1_.ID, tb_1_.NAME " +
-                                        "from DEPARTMENT tb_1_ " +
-                                        "where tb_1_.NAME = ? and tb_1_.DELETED_MILLIS = ?"
-                        );
-                    });
                     ctx.value(
                             "[" +
-                                    "--->{\"id\":\"1\",\"name\":\"Market\"}, " +
+                                    "--->{\"name\":\"Market\"}, " +
                                     "--->{\"id\":\"100\",\"name\":\"Sales\"}" +
                                     "]");
                 }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveUpdateWhereTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveUpdateWhereTest.java
@@ -1,0 +1,709 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.mutation.*;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.dialect.DefaultDialect;
+import org.babyfish.jimmer.sql.dialect.H2Dialect;
+import org.babyfish.jimmer.sql.exception.SaveException;
+import org.babyfish.jimmer.sql.model.*;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.Organization;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.OrganizationDraft;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.OrganizationProps;
+import org.babyfish.jimmer.sql.model.inheritance.singletable.OrganizationTable;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.babyfish.jimmer.sql.common.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SaveUpdateWhereTest extends AbstractMutationTest {
+
+    @Test
+    public void testSharedUpdateConditionApiShape() {
+        UpdateCondition<Book, BookTable> condition =
+                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE));
+        SimpleEntitySaveCommand<Book> command = getSqlClient().saveCommand(book(BigDecimal.valueOf(100)));
+        assertNotNull(command.setUpdateWhere(BookTable.class, condition));
+        assertNotNull(command.setOptimisticLock(BookTable.class, condition));
+    }
+
+    @Test
+    public void testNativeUpsertAcceptsAndRejectsUpdateArm() {
+        connectAndExpect(
+                con -> {
+                    SimpleSaveResult<Book> accepted = getSqlClient()
+                            .saveCommand(book(BigDecimal.valueOf(100)))
+                            .setMode(SaveMode.UPSERT)
+                            .setUpdateWhere(
+                                    BookTable.class,
+                                    (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                            )
+                            .execute(con, BookFetcher.$.price());
+                    SimpleSaveResult<Book> rejected = getSqlClient()
+                            .saveCommand(book(BigDecimal.valueOf(70)))
+                            .setMode(SaveMode.UPSERT)
+                            .setUpdateWhere(
+                                    BookTable.class,
+                                    (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                            )
+                            .execute(con, BookFetcher.$.price());
+                    return asList(accepted, rejected);
+                },
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into BOOK tb_1_ using(values(?, ?)) tb_2_(ID, PRICE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.PRICE < tb_2_.PRICE " +
+                                    "then update set PRICE = tb_2_.PRICE " +
+                                    "when not matched then insert(ID, PRICE) values(tb_2_.ID, tb_2_.PRICE))"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into BOOK tb_1_ using(values(?, ?)) tb_2_(ID, PRICE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.PRICE < tb_2_.PRICE " +
+                                    "then update set PRICE = tb_2_.PRICE " +
+                                    "when not matched then insert(ID, PRICE) values(tb_2_.ID, tb_2_.PRICE))"
+                    ));
+                    ctx.value(results -> {
+                        SimpleSaveResult<Book> accepted = results.get(0);
+                        SimpleSaveResult<Book> rejected = results.get(1);
+                        assertTrue(accepted.isAccepted());
+                        assertEquals(1, accepted.getTotalAffectedRowCount());
+                        assertEquals(BigDecimal.valueOf(100), accepted.getModifiedEntity().price());
+                        assertFalse(rejected.isAccepted());
+                        assertEquals(0, rejected.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testNativeUpdateOnlyUsesWhere() {
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book(BigDecimal.valueOf(70)))
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con, BookFetcher.$.price()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ? where ID = ? and PRICE < ?"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.isAccepted());
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testCustomAssignmentAndUpdateWhereRemainIndependent() {
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book(BigDecimal.valueOf(100)))
+                        .setMode(SaveMode.UPSERT)
+                        .set(
+                                BookTable.class,
+                                BookProps.PRICE,
+                                (target, values) -> target.price().plus(values.newNumber(BookProps.PRICE))
+                        )
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con, BookFetcher.$.price()),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID, PRICE from final table (" +
+                                    "merge into BOOK tb_1_ using(values(?, ?)) tb_2_(ID, PRICE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.PRICE < tb_2_.PRICE " +
+                                    "then update set PRICE = tb_1_.PRICE + tb_2_.PRICE " +
+                                    "when not matched then insert(ID, PRICE) values(tb_2_.ID, tb_2_.PRICE))"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(new BigDecimal("180.00"), result.getModifiedEntity().price());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpdateWhereDoesNotSuppressOptimisticLockFailure() {
+        jdbc(con -> assertThrows(
+                SaveException.class,
+                () -> getSqlClient()
+                        .saveCommand(book(BigDecimal.valueOf(100)))
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .setOptimisticLock(
+                                BookTable.class,
+                                (table, values) -> table.price().gt(BigDecimal.valueOf(1000))
+                        )
+                        .execute(con)
+        ));
+    }
+
+    @Test
+    public void testAcceptanceContractForFakeUpdateAndInsertIfAbsentConflict() {
+        jdbc(con -> {
+            Book idOnlyBook = BookDraft.$.produce(draft -> draft.setId(graphQLInActionId3));
+            SimpleSaveResult<Book> fakeUpdate = getSqlClient()
+                    .saveCommand(idOnlyBook)
+                    .setMode(SaveMode.UPSERT)
+                    .execute(con);
+            SimpleSaveResult<Book> insertIfAbsentConflict = getSqlClient()
+                    .saveCommand(idOnlyBook)
+                    .setMode(SaveMode.INSERT_IF_ABSENT)
+                    .execute(con);
+
+            assertTrue(fakeUpdate.isAccepted());
+            assertFalse(insertIfAbsentConflict.isAccepted());
+        });
+    }
+
+    @Test
+    public void testBatchContainsAcceptedAndRejectedItems() {
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveEntitiesCommand(
+                                asList(
+                                        book(graphQLInActionId3, BigDecimal.valueOf(100)),
+                                        book(graphQLInActionId2, BigDecimal.valueOf(70))
+                                )
+                        )
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into BOOK tb_1_ using(values(?, ?), (?, ?)) tb_2_(ID, PRICE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.PRICE < tb_2_.PRICE " +
+                                    "then update set PRICE = tb_2_.PRICE " +
+                                    "when not matched then insert(ID, PRICE) values(tb_2_.ID, tb_2_.PRICE))"
+                    ));
+                    ctx.value(result -> {
+                        assertEquals(2, result.getItems().size());
+                        assertTrue(result.getItems().get(0).isAccepted());
+                        assertFalse(result.getItems().get(1).isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testMixedNativeAndPreselectedBatchUsesPredicatePerItem() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new H2Dialect() {
+            @Override
+            public boolean isNoIdUpsertSupported() {
+                return false;
+            }
+        }));
+        Book keyBasedBook = BookDraft.$.produce(draft -> {
+            draft.setName("GraphQL in Action");
+            draft.setEdition(2);
+            draft.setPrice(BigDecimal.valueOf(100));
+        });
+        connectAndExpect(
+                con -> sqlClient
+                        .saveEntitiesCommand(asList(book(BigDecimal.valueOf(70)), keyBasedBook))
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                                    "from BOOK tb_1_ " +
+                                    "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID from BOOK tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.PRICE < ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ? where ID = ? and PRICE < ?"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.getItems().get(0).isAccepted());
+                        assertTrue(result.getItems().get(1).isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testFallbackRejectsBeforeMutation() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        connectAndExpect(
+                con -> sqlClient
+                        .saveCommand(book(BigDecimal.valueOf(70)))
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                                    "from BOOK tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID from BOOK tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.PRICE < ?"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.isAccepted());
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testFallbackUsesPessimisticLockOnlyWhenExplicitlyRequested() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(DefaultDialect.INSTANCE));
+        connectAndExpect(
+                con -> sqlClient
+                        .saveCommand(book(BigDecimal.valueOf(70)))
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .setPessimisticLock(Book.class)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION " +
+                                    "from BOOK tb_1_ where tb_1_.ID = ? for update"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID from BOOK tb_1_ " +
+                                    "where tb_1_.ID = ? and tb_1_.PRICE < ? for update"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.isAccepted());
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testIdOnlyPreAssociationIsAllowed() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true).setId(manningId);
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ?, STORE_ID = ? where ID = ? and PRICE < ?"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testMutablePreAssociationIsRejectedBeforeSqlForWholeBatch() {
+        Book idOnlyAssociationBook = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true).setId(manningId);
+        });
+        Book mutableAssociationBook = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId2);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true).setId(manningId).setName("Changed");
+        });
+        executeAndExpectResult(
+                getSqlClient()
+                        .saveEntitiesCommand(asList(idOnlyAssociationBook, mutableAssociationBook))
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        ),
+                ctx -> ctx.throwable(it -> {
+                    it.type(IllegalArgumentException.class);
+                    it.message(
+                            "Cannot save the owning-side reference property " +
+                                    "\"org.babyfish.jimmer.sql.model.Book.store\" because update-where is " +
+                                    "configured for its owner type and the reference is neither null nor id-only; " +
+                                    "saving it before the owner may execute DML even if the owner is rejected"
+                    );
+                })
+        );
+    }
+
+    @Test
+    public void testAssociationPipelineOrderIsUnchangedWithoutUpdateWhere() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true)
+                    .setId(manningId)
+                    .setName("MANNING+")
+                    .setVersion(0);
+            draft.addIntoAuthors(author -> author.setId(alexId));
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setAssociatedMode(BookProps.AUTHORS, AssociatedSaveMode.APPEND)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set NAME = ?, VERSION = VERSION + 1 where ID = ? and VERSION = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ?, STORE_ID = ? where ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "insert into BOOK_AUTHOR_MAPPING(BOOK_ID, AUTHOR_ID) values(?, ?)"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(3, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testRejectedOwnerSkipsDependentAssociations() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(70));
+            draft.addIntoAuthors(author -> author.setId(alexId));
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                BookTable.class,
+                                (table, values) -> table.price().lt(values.newNumber(BookProps.PRICE))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into BOOK tb_1_ using(values(?, ?)) tb_2_(ID, PRICE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.PRICE < tb_2_.PRICE " +
+                                    "then update set PRICE = tb_2_.PRICE " +
+                                    "when not matched then insert(ID, PRICE) values(tb_2_.ID, tb_2_.PRICE))"
+                    ));
+                    ctx.value(result -> assertFalse(result.isAccepted()));
+                }
+        );
+    }
+
+    @Test
+    public void testInsertArmDoesNotEvaluateUpdateWhere() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000091");
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(id);
+            draft.setName("New selective upsert");
+            draft.setEdition(1);
+            draft.setPrice(BigDecimal.valueOf(90));
+            draft.setStoreId(manningId);
+        });
+        jdbc(con -> {
+            SimpleSaveResult<Book> result = getSqlClient()
+                    .saveCommand(book)
+                    .setMode(SaveMode.UPSERT)
+                    .setUpdateWhere(
+                            BookTable.class,
+                            (table, values) -> table.price().gt(BigDecimal.valueOf(1000))
+                    )
+                    .execute(con);
+
+            assertTrue(result.isAccepted());
+            assertEquals(1, result.getTotalAffectedRowCount());
+        });
+    }
+
+    @Test
+    public void testNullUpdateWhereResultIsAllowedWithInsertOnly() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000092");
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(id);
+            draft.setName("No update restriction");
+            draft.setEdition(1);
+            draft.setPrice(BigDecimal.valueOf(90));
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setUpdateWhere(BookTable.class, (table, values) -> null)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into BOOK(ID, NAME, EDITION, PRICE) values(?, ?, ?, ?)");
+                        it.variables(id, "No update restriction", 1, BigDecimal.valueOf(90));
+                    });
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testNullUpdateWhereResultAllowsMutablePreAssociation() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true)
+                    .setId(manningId)
+                    .setName("MANNING+")
+                    .setVersion(0);
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setUpdateWhere(BookTable.class, (table, values) -> null)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set NAME = ?, VERSION = VERSION + 1 where ID = ? and VERSION = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ?, STORE_ID = ? where ID = ?"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(2, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testRejectedInsertIfAbsentTargetRemainsAvailableForAssociation() {
+        UUID authorId = UUID.fromString("a0000000-0000-0000-0000-000000000093");
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new H2Dialect()));
+        Author author = AuthorDraft.$.produce(draft -> {
+            draft.setId(authorId);
+            draft.setFirstName("Michael");
+            draft.setLastName("Simpson");
+            draft.setGender(Gender.MALE);
+            draft.addIntoBooks(book -> {
+                book.setName("Learning GraphQL");
+                book.setEdition(1);
+                book.setPrice(BigDecimal.ONE);
+            });
+        });
+        connectAndExpect(
+                con -> sqlClient
+                        .getEntities()
+                        .forConnection(con)
+                        .saveCommand(author)
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setAssociatedMode(AuthorProps.BOOKS, AssociatedSaveMode.APPEND_IF_ABSENT)
+                        .execute(),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql("insert into AUTHOR(ID, FIRST_NAME, LAST_NAME, GENDER) values(?, ?, ?, ?)");
+                        it.variables(authorId, "Michael", "Simpson", "M");
+                    });
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select tb_1_.ID, tb_1_.NAME, tb_1_.EDITION from BOOK tb_1_ " +
+                                        "where (tb_1_.NAME, tb_1_.EDITION) = (?, ?)"
+                        );
+                        it.variables("Learning GraphQL", 1);
+                    });
+                    ctx.statement(it -> {
+                        it.sql("insert into BOOK_AUTHOR_MAPPING(AUTHOR_ID, BOOK_ID) values(?, ?)");
+                        it.variables(authorId, learningGraphQLId1);
+                    });
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(2, result.getTotalAffectedRowCount());
+                        assertEquals(learningGraphQLId1, result.getModifiedEntity().books().get(0).id());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testValidation() {
+        assertThrows(
+                NullPointerException.class,
+                () -> getSqlClient()
+                        .saveCommand(book(BigDecimal.valueOf(90)))
+                        .setUpdateWhere(BookTable.class, null)
+        );
+        jdbc(con -> {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .saveCommand(book(BigDecimal.valueOf(90)))
+                            .setMode(SaveMode.INSERT_ONLY)
+                            .setUpdateWhere(BookTable.class, (table, values) -> table.price().isNotNull())
+                            .execute(con)
+            );
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .saveCommand(BookDraft.$.produce(draft -> draft.setId(graphQLInActionId3)))
+                            .setMode(SaveMode.UPSERT)
+                            .setUpdateWhere(
+                                    BookTable.class,
+                                    (table, values) -> values.newNumber(BookProps.PRICE).gt(table.price())
+                            )
+                            .execute(con)
+            );
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> getSqlClient()
+                            .saveCommand(book(BigDecimal.valueOf(90)))
+                            .setMode(SaveMode.UPSERT)
+                            .setUpdateWhere(
+                                    OrganizationTable.class,
+                                    (table, values) -> table.name().isNotNull()
+                            )
+                            .execute(con)
+            );
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> getSqlClient()
+                            .saveCommand(book(BigDecimal.valueOf(90)))
+                            .setMode(SaveMode.UPSERT)
+                            .setUpdateWhere(
+                                    BookTable.class,
+                                    (table, values) -> table.store().name().isNotNull()
+                            )
+                            .execute(con)
+            );
+        });
+    }
+
+    @Test
+    public void testDifferentSingleTableDiscriminatorIsRejected() {
+        Organization organization = OrganizationDraft.$.produce(draft -> {
+            draft.setId(101L);
+            draft.setName("Should not update");
+            draft.setTaxCode("SHOULD-NOT-WRITE");
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(organization)
+                        .setMode(SaveMode.UPSERT)
+                        .setUpdateWhere(
+                                OrganizationTable.class,
+                                (table, values) -> table.name().ne(values.newString(OrganizationProps.NAME))
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select ID from final table (" +
+                                    "merge into CLIENT tb_1_ " +
+                                    "using(values(?, ?, ?, ?)) tb_2_(ID, NAME, TAX_CODE, CLIENT_TYPE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.NAME <> tb_2_.NAME " +
+                                    "and tb_1_.CLIENT_TYPE = tb_2_.CLIENT_TYPE " +
+                                    "then update set NAME = tb_2_.NAME, TAX_CODE = tb_2_.TAX_CODE " +
+                                    "when not matched then insert(ID, NAME, TAX_CODE, CLIENT_TYPE) " +
+                                    "values(tb_2_.ID, tb_2_.NAME, tb_2_.TAX_CODE, tb_2_.CLIENT_TYPE))"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.isAccepted());
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testDifferentSingleTableDiscriminatorIsRejectedWithoutUserPredicate() {
+        Organization organization = OrganizationDraft.$.produce(draft -> {
+            draft.setId(101L);
+            draft.setName("Should not update");
+            draft.setTaxCode("SHOULD-NOT-WRITE");
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(organization)
+                        .setMode(SaveMode.UPSERT)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "merge into CLIENT tb_1_ " +
+                                    "using(values(?, ?, ?, ?)) tb_2_(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when matched and tb_1_.CLIENT_TYPE = tb_2_.CLIENT_TYPE " +
+                                    "then update set NAME = tb_2_.NAME, TAX_CODE = tb_2_.TAX_CODE " +
+                                    "when not matched then insert(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
+                                    "values(tb_2_.ID, tb_2_.CLIENT_TYPE, tb_2_.NAME, tb_2_.TAX_CODE)"
+                    ));
+                    ctx.value(result -> {
+                        assertFalse(result.isAccepted());
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    private static Book book(BigDecimal price) {
+        return book(graphQLInActionId3, price);
+    }
+
+    private static Book book(UUID id, BigDecimal price) {
+        return BookDraft.$.produce(draft -> {
+            draft.setId(id);
+            draft.setPrice(price);
+        });
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveVersionModeTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/SaveVersionModeTest.java
@@ -1,0 +1,231 @@
+package org.babyfish.jimmer.sql.mutation;
+
+import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
+import org.babyfish.jimmer.sql.ast.mutation.UpsertMask;
+import org.babyfish.jimmer.sql.ast.mutation.VersionMode;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.exception.SaveException;
+import org.babyfish.jimmer.sql.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.babyfish.jimmer.sql.common.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SaveVersionModeTest extends AbstractMutationTest {
+
+    @Test
+    public void testUnloadedVersionUsesInitialValueOnInsert() {
+        UUID id = UUID.fromString("a0000000-0000-0000-0000-000000000092");
+        BookStore store = BookStoreDraft.$.produce(draft -> {
+            draft.setId(id);
+            draft.setName("VERSION MODE");
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(store)
+                        .setMode(SaveMode.INSERT_ONLY)
+                        .setVersionMode(VersionMode.ASSIGNMENT)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "insert into BOOK_STORE(ID, NAME, VERSION) values(?, ?, ?)"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                        assertEquals(0, result.getModifiedEntity().version());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testLoadedVersionIsOrdinaryUpdateAssignment() {
+        BookStore store = store(oreillyId, 7);
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(store)
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setVersionMode(VersionMode.ASSIGNMENT)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set VERSION = ? where ID = ?"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(1, result.getTotalAffectedRowCount());
+                        assertEquals(7, result.getModifiedEntity().version());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testCustomVersionAssignmentIsIndependentOfFluentOrder() {
+        connectAndExpect(
+                con -> asList(
+                        getSqlClient()
+                                .saveCommand(store(oreillyId, 0))
+                                .setMode(SaveMode.UPDATE_ONLY)
+                                .set(
+                                        BookStoreTable.class,
+                                        BookStoreProps.VERSION,
+                                        (target, values) -> target.version().plus(1)
+                                )
+                                .setVersionMode(VersionMode.ASSIGNMENT)
+                                .setUpdateWhere(
+                                        BookStoreTable.class,
+                                        (table, values) -> table.version().eq(values.newNumber(BookStoreProps.VERSION))
+                                )
+                                .execute(con),
+                        getSqlClient()
+                                .saveCommand(store(manningId, 0))
+                                .setMode(SaveMode.UPDATE_ONLY)
+                                .setVersionMode(VersionMode.ASSIGNMENT)
+                                .set(
+                                        BookStoreTable.class,
+                                        BookStoreProps.VERSION,
+                                        (target, values) -> target.version().plus(1)
+                                )
+                                .setUpdateWhere(
+                                        BookStoreTable.class,
+                                        (table, values) -> table.version().eq(values.newNumber(BookStoreProps.VERSION))
+                                )
+                                .execute(con)
+                ),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set VERSION = VERSION + ? where ID = ? and VERSION = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set VERSION = VERSION + ? where ID = ? and VERSION = ?"
+                    ));
+                    ctx.value(results -> {
+                        assertTrue(results.get(0).isAccepted());
+                        assertTrue(results.get(1).isAccepted());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testUpsertMaskCanMakeVersionInsertOnly() {
+        BookStore store = store(oreillyId, 7);
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(store)
+                        .setMode(SaveMode.UPSERT)
+                        .setVersionMode(VersionMode.ASSIGNMENT)
+                        .setUpsertMask(
+                                UpsertMask
+                                        .of(BookStore.class)
+                                        .addInsertableProp(BookStoreProps.VERSION)
+                                        .forbidUpdate()
+                        )
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "merge into BOOK_STORE tb_1_ " +
+                                    "using(values(?, ?)) tb_2_(ID, VERSION) " +
+                                    "on tb_1_.ID = tb_2_.ID " +
+                                    "when not matched then insert(ID, VERSION) values(tb_2_.ID, tb_2_.VERSION)"
+                    ));
+                    ctx.value(result -> {
+                        assertEquals(0, result.getTotalAffectedRowCount());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testExplicitOptimisticLockStillWorksInAssignmentMode() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .saveCommand(store(oreillyId, 7))
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setVersionMode(VersionMode.ASSIGNMENT)
+                        .setOptimisticLock(
+                                BookStoreTable.class,
+                                (table, values) -> table.version().eq(values.newNumber(BookStoreProps.VERSION))
+                        ),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set VERSION = ? where ID = ? and VERSION = ?"
+                    ));
+                    ctx.throwable(it -> it.type(SaveException.OptimisticLockError.class));
+                }
+        );
+    }
+
+    @Test
+    public void testVersionModeDoesNotPropagateToAssociatedEntities() {
+        Book book = BookDraft.$.produce(draft -> {
+            draft.setId(graphQLInActionId3);
+            draft.setPrice(BigDecimal.valueOf(100));
+            draft.store(true)
+                    .setId(manningId)
+                    .setName("MANNING+")
+                    .setVersion(0);
+        });
+        connectAndExpect(
+                con -> getSqlClient()
+                        .saveCommand(book)
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .setVersionMode(VersionMode.ASSIGNMENT)
+                        .execute(con),
+                ctx -> {
+                    ctx.statement(it -> it.sql(
+                            "select tb_1_.ID, tb_1_.NAME from BOOK_STORE tb_1_ where tb_1_.ID = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK_STORE set NAME = ?, VERSION = VERSION + 1 where ID = ? and VERSION = ?"
+                    ));
+                    ctx.statement(it -> it.sql(
+                            "update BOOK set PRICE = ?, STORE_ID = ? where ID = ?"
+                    ));
+                    ctx.value(result -> {
+                        assertTrue(result.isAccepted());
+                        assertEquals(2, result.getTotalAffectedRowCount());
+                        assertEquals(1, result.getModifiedEntity().store().version());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testVersionAssignmentRequiresAssignmentMode() {
+        executeAndExpectResult(
+                getSqlClient()
+                        .saveCommand(store(oreillyId, 0))
+                        .setMode(SaveMode.UPDATE_ONLY)
+                        .set(
+                                BookStoreTable.class,
+                                BookStoreProps.VERSION,
+                                (target, values) -> target.version().plus(1)
+                        ),
+                ctx -> ctx.throwable(it -> {
+                    it.type(IllegalArgumentException.class);
+                    it.message(
+                            "The version property \"org.babyfish.jimmer.sql.model.BookStore.version\" " +
+                                    "can only be a save assignment target in ASSIGNMENT version mode"
+                    );
+                })
+        );
+        assertThrows(
+                NullPointerException.class,
+                () -> getSqlClient().saveCommand(store(oreillyId, 0)).setVersionMode(null)
+        );
+    }
+
+    private static BookStore store(UUID id, int version) {
+        return BookStoreDraft.$.produce(draft -> {
+            draft.setId(id);
+            draft.setVersion(version);
+        });
+    }
+}

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/UpsertMaskTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/UpsertMaskTest.java
@@ -1,6 +1,7 @@
 package org.babyfish.jimmer.sql.mutation;
 
 import org.babyfish.jimmer.ImmutableObjects;
+import org.babyfish.jimmer.meta.ImmutableProp;
 import org.babyfish.jimmer.sql.ast.mutation.QueryReason;
 import org.babyfish.jimmer.sql.ast.mutation.SaveMode;
 import org.babyfish.jimmer.sql.ast.mutation.SimpleSaveResult;
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.UUID;
+
+import static java.util.Collections.singletonList;
 
 public class UpsertMaskTest extends AbstractMutationTest {
 
@@ -223,7 +226,37 @@ public class UpsertMaskTest extends AbstractMutationTest {
                                     draft.setEdition(3);
                                 })
                         )
-                        .setUpsertMask(UpsertMask.of(Book.class).forbidUpdate()),
+                        .forbidUpdate(),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "merge into BOOK tb_1_ " +
+                                        "using(values(?, ?, ?)) tb_2_(ID, NAME, EDITION) " +
+                                        "on tb_1_.ID = tb_2_.ID " +
+                                        "when not matched then insert(ID, NAME, EDITION) " +
+                                        "values(tb_2_.ID, tb_2_.NAME, tb_2_.EDITION)"
+                        );
+                    });
+                    ctx.entity(it -> {
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testExplicitEmptyUpdateMaskArrayByBatch() {
+        executeAndExpectResult(
+                getSqlClient(it -> it.setDialect(new H2Dialect()))
+                        .saveEntitiesCommand(
+                                singletonList(
+                                        Immutables.createBook(draft -> {
+                                            draft.setId(Constants.graphQLInActionId3);
+                                            draft.setName("GraphQL in Action");
+                                            draft.setEdition(3);
+                                        })
+                                )
+                        )
+                        .setUpsertMask(new ImmutableProp[0]),
                 ctx -> {
                     ctx.statement(it -> {
                         it.sql(

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceMutationTest.java
@@ -1154,7 +1154,7 @@ public class JoinedInheritanceMutationTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUpdateAbstractRootWithUserOptimisticLock() {
+    public void testUpdateAbstractRootWithOptimisticLockCondition() {
         connectAndExpect(
                 con -> {
                     getSqlClient()

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceOptimisticLockTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/joinedtable/JoinedInheritanceOptimisticLockTest.java
@@ -18,7 +18,7 @@ import java.sql.SQLException;
 public class JoinedInheritanceOptimisticLockTest extends AbstractMutationTest {
 
     @Test
-    public void testUserOptimisticLockUsesFakeRootGate() {
+    public void testOptimisticLockConditionUsesFakeRootGate() {
         connectAndExpect(
                 con -> {
                     getSqlClient()
@@ -62,7 +62,7 @@ public class JoinedInheritanceOptimisticLockTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUserOptimisticLockFailureSkipsJoinedChildUpdate() {
+    public void testOptimisticLockConditionFailureSkipsJoinedChildUpdate() {
         executeAndExpectResult(
                 getSqlClient()
                         .getEntities()
@@ -98,7 +98,7 @@ public class JoinedInheritanceOptimisticLockTest extends AbstractMutationTest {
     }
 
     @Test
-    public void testUserOptimisticLockRejectsDerivedTypeProp() {
+    public void testOptimisticLockConditionRejectsDerivedTypeProp() {
         executeAndExpectResult(
                 getSqlClient()
                         .getEntities()

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/singletable/SingleTableInheritanceMutationTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/mutation/inheritance/singletable/SingleTableInheritanceMutationTest.java
@@ -1,9 +1,11 @@
 package org.babyfish.jimmer.sql.mutation.inheritance.singletable;
 
 import org.babyfish.jimmer.sql.DissociateAction;
+import org.babyfish.jimmer.sql.JSqlClient;
 import org.babyfish.jimmer.sql.ast.TypeMatchMode;
 import org.babyfish.jimmer.sql.ast.mutation.*;
 import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.dialect.MySqlDialect;
 import org.babyfish.jimmer.sql.exception.ExecutionException;
 import org.babyfish.jimmer.sql.model.inheritance.enumdiscriminator.EnumOrganization;
 import org.babyfish.jimmer.sql.model.inheritance.enumdiscriminator.EnumOrganizationDraft;
@@ -555,16 +557,16 @@ public class SingleTableInheritanceMutationTest extends AbstractMutationTest {
                                 })
                         ),
                 ctx -> {
-	                    ctx.statement(it -> {
-	                        it.sql(
-	                                "merge into CLIENT tb_1_ " +
-	                                        "using(values(?, ?, ?, ?)) tb_2_(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
-	                                        "on tb_1_.ID = tb_2_.ID " +
-	                                        "when matched and tb_1_.CLIENT_TYPE = tb_2_.CLIENT_TYPE " +
-	                                        "then update set NAME = tb_2_.NAME, TAX_CODE = tb_2_.TAX_CODE " +
-	                                        "when not matched then insert(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
-	                                        "values(tb_2_.ID, tb_2_.CLIENT_TYPE, tb_2_.NAME, tb_2_.TAX_CODE)"
-	                        );
+                    ctx.statement(it -> {
+                        it.sql(
+                                "merge into CLIENT tb_1_ " +
+                                        "using(values(?, ?, ?, ?)) tb_2_(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
+                                        "on tb_1_.ID = tb_2_.ID " +
+                                        "when matched and tb_1_.CLIENT_TYPE = tb_2_.CLIENT_TYPE " +
+                                        "then update set NAME = tb_2_.NAME, TAX_CODE = tb_2_.TAX_CODE " +
+                                        "when not matched then insert(ID, CLIENT_TYPE, NAME, TAX_CODE) " +
+                                        "values(tb_2_.ID, tb_2_.CLIENT_TYPE, tb_2_.NAME, tb_2_.TAX_CODE)"
+                        );
                         it.variables(300L, "ORG", "New Org", "NEW-001");
                     });
                     ctx.rowCount(AffectedTable.of(Organization.class), 1);
@@ -668,6 +670,38 @@ public class SingleTableInheritanceMutationTest extends AbstractMutationTest {
                         it.variables(101L, "ORG", "Should not update", "SHOULD-NOT-WRITE");
                     });
                     ctx.value("[Person, Bob, null, Bob, Brown]");
+                }
+        );
+    }
+
+    @Test
+    public void testMySqlUpsertDerivedTypeWithMismatchedDiscriminatorDoesNotExecuteUpdate() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new MySqlDialect()));
+        connectAndExpect(
+                con -> sqlClient
+                        .getEntities()
+                        .saveCommand(
+                                OrganizationDraft.$.produce(organization -> {
+                                    organization.setId(101L);
+                                    organization.setName("Should not update");
+                                    organization.setTaxCode("SHOULD-NOT-WRITE");
+                                })
+                        )
+                        .execute(con)
+                        .isAccepted() + "; " + clientRow(con, 101L),
+                ctx -> {
+                    ctx.statement(it -> {
+                        it.sql(
+                                "select tb_1_.ID from CLIENT tb_1_ " +
+                                        "where tb_1_.ID = ? and tb_1_.CLIENT_TYPE = ?"
+                        );
+                        it.variables(101L, "ORG");
+                    });
+                    ctx.statement(it -> {
+                        it.sql("select tb_1_.ID, tb_1_.CLIENT_TYPE from CLIENT tb_1_ where tb_1_.ID = ?");
+                        it.variables(101L);
+                    });
+                    ctx.value("false; [Person, Bob, null, Bob, Brown]");
                 }
         );
     }
@@ -1063,7 +1097,8 @@ public class SingleTableInheritanceMutationTest extends AbstractMutationTest {
                         it.variables("Single root project+", 101L, 1000L);
                     });
                     ctx.rowCount(AffectedTable.of(ClientProject.class), 1);
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                 }
         );
     }
@@ -1188,7 +1223,8 @@ public class SingleTableInheritanceMutationTest extends AbstractMutationTest {
                         it.variables("Single organization project+", 102L, 1001L);
                     });
                     ctx.rowCount(AffectedTable.of(OrganizationProject.class), 1);
-                    ctx.entity(it -> {});
+                    ctx.entity(it -> {
+                    });
                 }
         );
     }

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/FluentAssociationQueryTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/query/FluentAssociationQueryTest.java
@@ -21,7 +21,7 @@ public class FluentAssociationQueryTest extends AbstractQueryTest {
         AssociationTable<Book, BookTableEx, Author, AuthorTableEx> association =
                 AssociationTable.of(BookTableEx.class, BookTableEx::authors);
         executeAndExpect(
-                getSqlClient().createAssociationQuery(association)
+                getSqlClient().createQuery(association)
                         .where(association.source().name().eq("Learning GraphQL"))
                         .where(association.target().firstName().eq("Alex"))
                         .select(association),

--- a/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlite/SQLiteInsertFromSelectTest.java
+++ b/project/jimmer-sql/src/test/java/org/babyfish/jimmer/sql/sqlite/SQLiteInsertFromSelectTest.java
@@ -1,0 +1,54 @@
+package org.babyfish.jimmer.sql.sqlite;
+
+import org.babyfish.jimmer.sql.JSqlClient;
+import org.babyfish.jimmer.sql.ast.ComparableExpression;
+import org.babyfish.jimmer.sql.ast.StringExpression;
+import org.babyfish.jimmer.sql.ast.table.base.BaseTable2;
+import org.babyfish.jimmer.sql.common.AbstractMutationTest;
+import org.babyfish.jimmer.sql.common.NativeDatabases;
+import org.babyfish.jimmer.sql.dialect.SQLiteDialect;
+import org.babyfish.jimmer.sql.model.BookStoreTable;
+import org.babyfish.jimmer.sql.model.BookTable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.babyfish.jimmer.sql.common.Constants.learningGraphQLId1;
+
+public class SQLiteInsertFromSelectTest extends AbstractMutationTest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        jdbc(
+                NativeDatabases.SQLITE_DATA_SOURCE,
+                false,
+                con -> initDatabase(con, "database-sqlite.sql")
+        );
+    }
+
+    @Test
+    public void testConflictClauseAfterWrappedSourceSelect() {
+        JSqlClient sqlClient = getSqlClient(it -> it.setDialect(new SQLiteDialect()));
+        BookTable book = BookTable.$;
+        BaseTable2<ComparableExpression<UUID>, StringExpression> source = sqlClient
+                .createBaseQuery(book)
+                .where(book.id().eq(learningGraphQLId1))
+                .addSelect(book.storeId())
+                .addSelect(book.name())
+                .asBaseTable();
+        BookStoreTable store = BookStoreTable.$;
+        executeAndExpectRowCount(
+                NativeDatabases.SQLITE_DATA_SOURCE,
+                sqlClient
+                        .createUpsert(store, source)
+                        .key(store.id(), source.get_1())
+                        .merge(store.name(), source.get_2()),
+                ctx -> {
+                    ctx.statement(it -> {
+                    });
+                    ctx.rowCount(1);
+                }
+        );
+    }
+}


### PR DESCRIPTION

## Summary

This PR adds bulk insert and upsert commands whose input is any typed Jimmer
base query. The same source abstraction now works for entity tables,
association tables, derived-table queries, and CTEs in both Java and Kotlin.

The implementation keeps one logical contract across dialects. It uses native
`INSERT ... SELECT`, `ON CONFLICT`, `ON DUPLICATE KEY UPDATE`, or `MERGE` when
the dialect can preserve the requested semantics, and falls back to the
existing save engine when returning or transaction-trigger requirements need
more information than the native statement can provide.

The save command has also gained selective update conditions, explicit result
acceptance, assignment-style `@Version` handling, and clearer upsert masks.
These capabilities are public and useful independently of insert-from-select;
they also let the materialized plan reuse the normal save pipeline instead of
maintaining a second entity mutation engine.

## Universal typed base-query sources

Mutation sources are ordinary `BaseTable` instances in Java and
`KBaseTableSymbol` instances in Kotlin. A source can come from:

- an entity or association query;
- a generated `@TypedTuple` projection;
- a rootless query containing literals, parameters, native expressions, or
  scalar subqueries;
- a union or union-all;
- a derived table, CTE, or recursive CTE;
- joins and aggregate queries.

The single-physical-table restriction applies only to the mutation target. A
source can read any query model supported by Jimmer. Global filters are applied
to every unfrozen branch of a merged source, and source rendering prunes fields
of a wide typed tuple when the mutation does not use them.

The new rootless factory makes typed static rows possible without introducing
a separate values DSL:

```java
ConfigurableBaseQuery<BookInputTable> row1 = sqlClient
        .createBaseQuery()
        .select(
                BookInputMapper
                        .id(Expression.value(id1))
                        .name(Expression.value("GraphQL"))
                        .price(Expression.value(price1))
        );

ConfigurableBaseQuery<BookInputTable> row2 = sqlClient
        .createBaseQuery()
        .select(
                BookInputMapper
                        .id(Expression.value(id2))
                        .name(Expression.value("SQL"))
                        .price(Expression.value(price2))
        );

BookInputTable source = TypedBaseQuery
        .unionAll(row1, row2)
        .asBaseTable();
```

A rootless base table is not mutation-only. Both `createQuery(baseTable)` and
`createBaseQuery(baseTable)` accept it, so it can be queried directly, nested
as another derived table, or registered as a CTE in the same way as any other
base query.

## Java mutation API

A normal typed query can be converted into a mutation source and mapped to the
target explicitly:

```java
BookTable book = BookTable.$;

BookInputTable source = sqlClient
        .createBaseQuery(book)
        .where(book.edition().gt(1))
        .select(
                BookInputMapper
                        .id(book.id())
                        .name(book.name().concat("+"))
                        .price(book.price())
        )
        .asBaseTable();

int affectedRowCount = sqlClient
        .createInsert(book, source)
        .set(book.id(), source.getId())
        .set(book.name(), source.getName())
        .set(book.price(), source.getPrice())
        .execute();
```

`createInsert` is strict by default. Conflict suppression is explicit and can
either infer the highest-priority eligible id/key group or name the physical
key:

```java
sqlClient
        .createInsert(book, source)
        .set(book.id(), source.getId())
        .set(book.name(), source.getName())
        .onConflictDoNothing(book.id())
        .execute();
```

The no-argument `onConflictDoNothing()` performs metadata-based inference. An
explicitly supplied empty property array is invalid; callers must use the
no-argument overload when they want inference.

Upsert has separate assignment roles:

- `key(target, source)` inserts a value and uses it to locate a conflict;
- `insert(target, source)` writes only in the insert branch;
- `merge(target, source)` writes the source value in both branches;
- three-argument `merge` uses one expression for insertion and another for
  update. The update expression can reference both target and source;
- `updateWhere` restricts only the matched update branch.

```java
List<BookResult> changedBooks = sqlClient
        .createUpsert(book, source)
        .key(book.id(), source.getId())
        .insert(book.name(), source.getName())
        .merge(
                book.price(),
                source.getPrice(),
                book.price().plus(source.getPrice())
        )
        .updateWhere(source.getPrice().ne(book.price()))
        .returning(
                BookResultMapper
                        .id(book.id())
                        .name(book.name())
                        .price(book.price())
        )
        .execute();
```

Target/source mapping is deliberately explicit. This supports differently
named fields, computed source values, embedded values, and composite ids or
keys without relying on positional or string-based column APIs.

## Kotlin mutation API

Kotlin exposes the same behavior through receiver DSLs. `table` is the target
table and `sourceTable` is the typed query source:

```kotlin
val changedBooks = sqlClient.executeUpsertReturning<Book, _, BookResult>(source) {
    key(table.id, sourceTable.id)
    insert(table.name, sourceTable.name)
    merge(
        table.price,
        sourceTable.price,
        table.price + sourceTable.price
    )
    updateWhere(sourceTable.price ne table.price)

    returning(
        BookResultMapper
            .id(table.id)
            .name(table.name)
            .price(table.price)
    )
}
```

There are non-returning and returning factories, reified extensions, and
immediate execution helpers for insert and upsert. The receiver types prevent
invalid combinations: insert exposes `set` and `onConflictDoNothing`, while
upsert exposes `key`, `insert`, `merge`, and `updateWhere`.

## Association tables

Association tables participate in the same query and insert model. Java now
supports the following uniform factory shape:

```java
AssociationTable<Book, BookTableEx, Author, AuthorTableEx> associationTable =
        AssociationTable.of(BookTableEx.class, BookTableEx::authors);

sqlClient.createBaseQuery(associationTable);
sqlClient.createQuery(associationTable);

sqlClient
        .createInsert(associationTable, source)
        .set(associationTable.sourceId(), source.getBookId())
        .set(associationTable.targetId(), source.getAuthorId())
        .onConflictDoNothing()
        .execute();
```

`createQuery(associationTable)` is now the preferred top-level association
query API. The old `createAssociationQuery(associationTable)` remains as a
deprecated delegating alias.

Kotlin provides association-property overloads for base queries, insert, and
insert-returning:

```kotlin
sqlClient.createBaseQuery(Book::authors) {
    select(AssociationPairMapper.bookId(table.sourceId).authorId(table.targetId))
}

sqlClient.createInsert(Book::authors, source) {
    set(table.sourceId, sourceTable.bookId)
    set(table.targetId, sourceTable.authorId)
    onConflictDoNothing()
}
```

Association insertion is strict by default. `onConflictDoNothing()` selects
insert-if-absent behavior using the association metadata. Returning can select
`sourceId`, `targetId`, or a typed tuple and includes only newly inserted
pairs. Association upsert is intentionally not introduced: creating a middle
table row is an insert operation.

Association behavior in the save pipeline is also made more precise. The
acceptance of a nested entity's own mutation is distinct from its usability as
an association target. In particular, an existing entity found by
`APPEND_IF_ABSENT` is rejected for that insert attempt but keeps its resolved
id, so the parent link is still created. Rejection by an update condition or a
single-table discriminator makes the target unavailable instead.

## Mutation semantics

The public commands have intentionally distinct conflict behavior:

| Command | No conflict | Conflict |
| --- | --- | --- |
| `createInsert` | Insert | Throw |
| `createInsert` + `onConflictDoNothing` | Insert | Skip |
| `createUpsert` with merge assignments | Insert | Update |
| `createUpsert` without merge assignments | Insert | Fake update |

An upsert with no effective merge assignment remains an upsert. It uses the
same safe self-assignment hook as the save command instead of silently turning
into conflict-do-nothing. This difference is observable through returning,
affected row counts, locking, database triggers, transaction events, and
database-generated values.

`updateWhere` remains active for a fake update. A matched row that fails the
predicate takes no update branch and is excluded from returning.

Upsert sources must be unique by their declared key. A materialized plan can
diagnose duplicate source keys before mutation; a direct native plan leaves
behavior for a violated precondition to the database. Insert-do-nothing can
accept duplicate source keys because later conflicting rows are simply
skipped.

Omitted target columns retain normal Jimmer/database behavior. Generated ids,
sequence values, database defaults, discriminator values, logical-delete
values, and initial versions are supplied when applicable.

### Logical delete and inheritance

Native key matching reuses the ordinary save command's logical-delete
metadata:

- a non-boolean logical-delete property is included in the physical conflict
  columns;
- a boolean logical-delete property contributes the active-row predicate;
- PostgreSQL and SQLite can place that predicate after the conflict column
  list to match a conditional unique index;
- merge-style dialects place the equivalent condition in `MERGE ... ON`;
- id-based conflicts are unchanged.

Therefore, a key owned only by a logically deleted row inserts a new active
row, while a key owned by an active row takes the requested conflict branch.

Single-table inheritance uses the physical id/key for conflict detection and
the subtype discriminator as an implicit update condition. If an upsert for
one subtype encounters the same id or key on another subtype, the physical
conflict is real, but the update branch is rejected. Jimmer neither changes
the discriminator nor attempts a second insert.

Entity mutation targets currently need to map to one physical table, including
single-table-inheritance subtypes. Joined-table-inheritance targets remain out
of scope; source queries are not subject to this restriction.

Statically detectable command errors fail before DML. This includes a missing
upsert key, duplicate target assignments, incompatible source/target types,
non-physical target properties, an invalid or unavailable conflict key, an
unsupported returning selection, and a joined-table-inheritance target.

## Returning and affected-row semantics

Insert and upsert support the existing returning forms for physical target
properties: a scalar, a tuple, or a generated `@TypedTuple` mapper. Returning
contains rows that actually took a mutation branch:

- strict insert returns inserted rows;
- insert-do-nothing excludes conflicts;
- upsert returns inserted and accepted updated rows;
- an accepted fake update is returned;
- an `updateWhere` or discriminator rejection is not returned.

Native returning is used when the dialect can preserve this contract. The
materialized path obtains generated ids and values produced by database
defaults through the save/returning infrastructure and, when necessary, a
cache-disabled reload of an accepted row. Association returning follows the
same contract through its dedicated association-save path.

`execute()` continues to report physical DML counts as exposed by the database
and JDBC driver. Those counts are intentionally not normalized across
dialects. Returning size is the portable count of rows that took an insert or
update branch.

## Save-command API changes

### Selective update conditions

`UserOptimisticLock` is replaced by the more general `UpdateCondition`.
`setUpdateWhere` and `setOptimisticLock` both accept this interface. The old
`UserOptimisticLock` type remains temporarily as a deprecated empty subtype of
`UpdateCondition`.

```java
sqlClient
        .saveCommand(bookDraft)
        .setMode(SaveMode.UPSERT)
        .setUpdateWhere(
                BookTable.class,
                (table, values) ->
                        values
                                .newNumber(BookProps.EDITION)
                                .gt(table.edition())
        )
        .execute();
```

The Kotlin save DSL exposes the same condition and version configuration:

```kotlin
sqlClient.save(bookDraft) {
    setMode(SaveMode.UPSERT)
    setVersionMode(VersionMode.ASSIGNMENT)
    setUpdateWhere(Book::class) {
        newNonNull(Book::edition) gt table.edition
    }
}
```

`setUpdateWhere` controls update-arm eligibility for `UPDATE_ONLY`, `UPSERT`,
and `NON_IDEMPOTENT_UPSERT`:

- no physical conflict still inserts in an upsert;
- a conflict with a true predicate updates;
- a conflict with a false predicate is rejected without an exception or DML.

This is deliberately different from optimistic locking: a false optimistic
lock still throws the existing save error. When both are configured, update
eligibility is evaluated first and optimistic locking applies only to an
accepted update. A callback returning `null` removes the update restriction
for that entity type.

Native `UPDATE_ONLY` remains a normal `UPDATE ... WHERE ...`; it is never
rewritten into `MERGE`. Native upsert renderers attach the condition only to
the matched update branch, so capable dialects do not need a preselect.

Owning-side references are saved before their owner in the existing pipeline.
When an effective `setUpdateWhere` is present, a mutable owning-side reference
would perform DML before owner acceptance is known and is therefore rejected
before any SQL. `null` and id-only references remain valid. Post-associations
remain after the owner and run only for accepted owners. This preserves the
existing lock acquisition order without allowing dependent mutations for a
rejected owner.

### Explicit acceptance

Save result items now expose `isAccepted`. The flag is separate from both
object modification and affected row count:

- inserted, updated, and accepted fake-updated rows are accepted;
- insert-if-absent conflicts, false update conditions, and incompatible
  discriminators are rejected;
- a zero physical affected-row count does not by itself mean rejection.

`SimpleSaveResult`, batch items, view results, and Kotlin wrappers preserve the
same acceptance state. This state drives returning, post-associations,
transaction events, and cache invalidation instead of inferring a logical
decision from a dialect-specific row count.

### Upsert masks

Save commands expose `forbidUpdate()` as the explicit form of an upsert mask
with no entity-property update assignments. Passing an empty property array to
the convenience `setUpsertMask(...)` overloads has the same meaning. A fake
update can still be rendered when matched-branch semantics, id fetching, or
returning requires it.

`UpsertMask.forbidInsert()` is the symmetric mask-building operation, but it
does not disable the insert branch. It starts with no user entity properties
selected for insertion; conflict columns and framework-required columns are
still emitted, and callers can add insertable properties explicitly. If an
omitted database column is mandatory and has no default, the database insert
fails normally.

```java
UpsertMask<Book> mask = UpsertMask
        .of(Book.class)
        .forbidInsert()
        .addInsertableProp(BookProps.NAME)
        .forbidUpdate();
```

### `@Version` as an assignment

Save commands now expose two root-entity version modes:

- `VersionMode.OPTIMISTIC_LOCK` is the default. A loaded version adds the
  implicit version condition and a successful update increments it;
- `VersionMode.ASSIGNMENT` treats version as a normal value controlled by the
  entity shape, `UpsertMask`, custom save assignments, and explicit update
  conditions. It adds neither an implicit predicate nor an automatic
  increment.

```java
sqlClient
        .saveCommand(bookDraft)
        .setMode(SaveMode.UPSERT)
        .setVersionMode(VersionMode.ASSIGNMENT)
        .execute();
```

An unloaded version still receives its framework-defined initial value on
insert. In assignment mode an insert-only version is ignored for a matched
row, a merge version is assigned, and a custom expression can implement an
explicit compare-and-increase policy together with `setUpdateWhere`. The mode
applies only to the root entity and does not propagate to associated entities.

The materialized insert/upsert-from-select adapter uses assignment mode so a
source version does not accidentally activate optimistic locking. It also
forces the matched branch for an empty merge set, allowing the standard save
fake-update hook to preserve native upsert semantics for entities with or
without `@Version`.

## Native execution and dialect abstraction

Dialect-specific SQL is owned by `InsertFromSelectRenderer`. The common
mutation planner passes an `InsertFromSelectContext` containing semantic
information such as mutation mode, assignments, conflict metadata,
logical-delete predicate, update condition, fake-update requirement, and
returning needs.

Each dialect renderer decides whether it can preserve that context and emits
its own syntax. The shared mutation code does not switch on dialect strategies
and does not contain H2, PostgreSQL, SQLite, or MySQL grammar. This keeps
capability checks and native rendering together and allows dialect extensions
without changing the mutation engine.

The planner prefers a direct native statement whenever it is semantically
sufficient. In particular, an update condition is evaluated atomically in a
native update/upsert branch and does not force a preliminary select on capable
dialects.

Native conflict handling is used only when the dialect can preserve the exact
conflict target. MySQL insert-if-absent therefore uses the materialized path
instead of the broader `INSERT IGNORE`. A nullable conflict key remains native
only when `isNullNotDistinct` metadata and the dialect both guarantee matching
`NULL` values; otherwise the fallback performs normal null-aware save matching.

## Materialized fallback

The fallback materializes only the required source fields and delegates each
entity row to the ordinary save command with the corresponding save mode, key
properties, `UpsertMask`, custom assignments, `UpdateCondition`, version mode,
and returning configuration. Association rows delegate to the association
save command. There is no parallel advanced entity plan based on manual
existence queries, `UPDATE_ONLY`/`INSERT_ONLY` branch orchestration, or subtype
queries.

Materialization is selected when a dialect cannot express the requested
conflict form or returning contract, or when transaction triggers require old
and new row information that the native statement cannot capture exactly. It
preserves save-command behavior for generated/default values, inheritance,
logical delete, accepted/rejected rows, dependent associations, events, and
cache invalidation.

The fallback intentionally does not add hidden pessimistic locking. It uses
the normal preselect-and-DML save flow, and existing pessimistic-lock options
remain the only way Jimmer adds `FOR UPDATE`. Its concurrency contract is
best-effort: exact branch selection, returning, dependent association
decisions, and old-row images are guaranteed when the relevant rows do not
change between the fallback's reads and writes. Applications that need the
same guarantee under concurrent changes must choose an appropriate isolation
level or explicitly lock the required scope.

## Triggers and cache invalidation

For `BINLOG_ONLY`, a supported count-only mutation can remain a direct native
statement, and native returning is added when requested and available.

For `TRANSACTION_ONLY` and `BOTH`, the planner uses a native optimization only
when the dialect can identify the accepted rows and obtain the exact old/new
information required by transaction triggers. Otherwise it selects the
materialized save path. Insertions emit insert events, real and fake updates
are compared as updates, and rejected update conditions or skipped conflicts
emit nothing. Fake updates are not assumed to be no-ops because database
triggers can change version, timestamp, or audit columns.

Association insertion emits the corresponding association event only for a
new pair. Skipped pairs emit nothing. Entity and association cache
invalidation reuse the existing event pipeline and target the exact changed
rows or pairs; the implementation does not substitute broad cache clearing for
missing native change information.

All fallback reads used for returning, events, or invalidation bypass object
and query caches and use the mutation connection. The concurrency qualification
described above also applies to transaction-trigger pre-images unless the
caller supplies isolation or locking that keeps them stable.

## Compatibility and current limits

- `UserOptimisticLock` is replaced by `UpdateCondition`.
- `UserOptimisticLock` remains deprecated and source-compatible as an empty
  subtype of `UpdateCondition`; command methods now accept `UpdateCondition`.
- `createAssociationQuery(associationTable)` is deprecated in favor of
  `createQuery(associationTable)` and delegates to it.
- Entity targets must map to one physical table. Joined-table-inheritance
  targets are not supported by this version.
- Association insert is supported; association upsert is not introduced.
- Returning is limited to physical target properties, tuples, and generated
  typed-tuple mappings. Joined/computed selections, fetcher graphs, a portable
  inserted-versus-updated marker, and a cross-dialect return-order guarantee
  are outside the current contract.
- `execute()` keeps database/JDBC affected-row semantics rather than forcing a
  normalized logical count.
